### PR TITLE
Add functional specs for 5 features

### DIFF
--- a/.specs/cases/README.md
+++ b/.specs/cases/README.md
@@ -1,0 +1,43 @@
+# Cases — Functional Specification
+
+## Purpose and Scope
+
+Define the `cases` Jekyll collection for case studies and testimonials. Cases appear in two contexts:
+
+1. **Inline on product pages** — filtered by `product_tags` to show relevant social proof
+2. **Dedicated section on the front page** — rendered via `_includes/cases.html`
+
+## Requirements
+
+### Front-page section
+
+- Renders in `_includes/cases.html` within `<main>` (already included in `default.html`)
+- Horizontal/flex layout (existing CSS `.cases` uses flexbox)
+- Shows `title`, `description`, and optional `result` + `customer`
+
+### Product-page filtering
+
+- Product pages reference cases via a shared tag system (`product_tags` in case matches `tags` in product frontmatter)
+- Only matching cases render in the "Kundesitater / cases" section of a product page
+
+## Data Structures
+
+### Case frontmatter (`_cases/*.md`)
+
+```yaml
+---
+title: "Effektivisering av logistikkflyten"   # required
+description: "Kort beskrivelse av caset"       # required
+image: "assets/images/case-bilde.png"          # optional
+result: "30% reduksjon i sykefravær"           # optional
+customer: "Kundenavn AS"                       # optional
+product_tags: "#ledelse"                       # optional — tag matching product.tags
+---
+```
+
+## Dependencies
+
+- **Collection**: Already declared in `_config.yml` (`cases: output: true`)
+- **Template**: `_includes/cases.html` exists with basic loop
+- **CSS**: `assets/css/cases.css` exists with basic styling
+- **Integration**: Product page needs tag-based filtering logic

--- a/.specs/ledelse-60-2/README.md
+++ b/.specs/ledelse-60-2/README.md
@@ -1,0 +1,95 @@
+# Ledelse 60:2 — Functional Specification
+
+## Purpose and Scope
+
+Redesign the Ledelse 60:2 product presence to drive both sales and brand authority among SMB leaders (5–50 employees). The product appears in two contexts:
+
+1. **Inline section on the front page** — attractive, compact preview with quick CTA.
+2. **Standalone landing page** at `/ledelse-60-2/` — full design guiding visitors through different tracks toward a tailored CTA.
+
+## Requirements
+
+### Sections (landing page)
+
+1. **Hero** — Headline, hero illustration, primary CTA (book meeting)
+2. **Fordeler (benefit grid)** — 2×2 grid of concrete benefits
+3. **Prosess / Hvordan** — 3-step walkthrough of the method
+4. **Kundesitater / cases** — Social proof from `_cases` collection, filtered by `product_tags`
+5. **Vitenskapelig grunnlag** — Prominent link to `/vitenskapelig-grunnlag/`
+6. **Avsluttende CTA** — Final booking call-to-action
+
+### Inline front-page section
+
+- Condensed version of the landing page (hero excerpt + benefits grid + CTA)
+- Must not duplicate full content already visible on the page
+- Links through to the full landing page
+
+## Data Structures
+
+### Product frontmatter (`_products/ledelse-60-2.md`)
+
+```yaml
+---
+name: "Ledelse 60:2"
+short_description: "En tidseffektiv modenhetsanalyse for ledergruppen"
+benefits:
+  - title: "Få kontroll uten byråkrati"
+    description: "Styrk den tillitsbaserte ledelsen fremfor rutiner og skjema"
+    icon: "assets/images/icons/benefit-control.png"
+  - title: "Oppnå målbare gevinster med KI"
+    description: "KI vil ikke gjøre ansatte overflødige, men de må ledes annerledes"
+    icon: "assets/images/icons/benefit-ai.png"
+  - title: "Bli forberedt på en usikker fremtid"
+    description: "Styr unna uønskede hendelser og fang mulighetene"
+    icon: "assets/images/icons/benefit-future.png"
+  - title: "Forankre initiativer i ledergruppen"
+    description: "Gi ledelsen innsikt i egen virksomhet for å prioritere initiativer"
+    icon: "assets/images/icons/benefit-anchoring.png"
+process_steps:
+  - title: "1. Uforpliktende samtale"
+    description: "Vi konkretiserer hva dere vil oppnå med modenhetsanalysen"
+    icon: "assets/images/icons/step-talk.png"
+  - title: "2. To timers strukturert intervju"
+    description: "60 diagnostiske spørsmål med inntil fem ledere"
+    icon: "assets/images/icons/step-interview.png"
+  - title: "3. Rapport og anbefalinger"
+    description: "Sammenlikning med best practice og konkrete tiltak"
+    icon: "assets/images/icons/step-report.png"
+story: "Hvorfor har vi laget metoden? «Ledelse 60:2» er vår tilnærming…"
+booking_url: "https://outlook.office.com/bookwithme/user/…"
+image: "assets/images/hero-illustration.png"
+tags: "#ledelse #modenhet #analyse"
+---
+```
+
+### Collection: Cases (`_cases/*.md`)
+
+```yaml
+---
+title: "Case title"              # required
+description: "Short description" # required
+image: "assets/images/case.png"  # optional
+result: "30% forbedring"         # optional — measurable outcome
+customer: "Kundenavn AS"         # optional
+product_tags: "#ledelse"         # optional — for filtering on product pages
+---
+```
+
+### Collection: Partners (`_partners/*.md`)
+
+```yaml
+---
+name: "Partner Name"            # required
+url: "https://partner.no"       # required
+image: "assets/images/partner-logo.png"  # required
+tags: "#samarbeid"              # optional
+---
+```
+
+## Dependencies
+
+- **Graphics**: 8 assets required (1 hero illustration + 7 icons) via GPT Image 2
+- **Template**: `_includes/products.html` rewrite for both inline and landing page
+- **CSS**: `assets/css/products.css` rewrite with hero layout, 2×2 grid, step flow
+- **Navigation**: `.specs/navigation/README.md`
+- **Content**: `_products/ledelse-60-2.md` frontmatter rewrite

--- a/.specs/navigation/README.md
+++ b/.specs/navigation/README.md
@@ -1,0 +1,23 @@
+# Navigation — Functional Specification
+
+## Purpose and Scope
+
+Replace the currently empty navbar with a minimal, functional navigation for the site. The navbar sits inside `<header>` (via `_includes/navbar.html`).
+
+## Requirements
+
+- Two links in the navbar:
+  - **"Ledelse 60:2"** → `/ledelse-60-2/` (new landing page)
+  - **"Om oss"** → `/om-oss/` (new about page)
+- Clean, minimal styling (Scandinavian minimal)
+- Visible on all pages
+
+## Data Structures
+
+No new collections or frontmatter — navigation links are hardcoded in `_includes/navbar.html`.
+
+## Dependencies
+
+- **Landing page**: `/ledelse-60-2/` — see `.specs/ledelse-60-2/README.md`
+- **About page**: `/om-oss/` — see `.specs/om-oss/README.md`
+- **CSS**: `assets/css/navbar.css` may need updates

--- a/.specs/om-oss/README.md
+++ b/.specs/om-oss/README.md
@@ -1,0 +1,35 @@
+# Om oss — Functional Specification
+
+## Purpose and Scope
+
+Create a separate "Om oss" (About us) page that introduces the company, its people, and its mission. The page is linked from the navbar.
+
+## Requirements
+
+- Separate page at `/om-oss/`
+- Includes company story/mission
+- Renders team profiles (from `_profiles` collection) in a dedicated profile section
+- Minimal, clean layout consistent with brand
+
+## Data Structures
+
+### Frontmatter (`om-oss.md`)
+
+```yaml
+---
+layout: default
+title: "Om No Excuse"
+permalink: /om-oss/
+---
+```
+
+### Content
+
+- **Company story**: Short paragraph about founding (Rasmus S. Olsen and Dagfinn Bang-Johansen, June 2025), mission, and values
+- **Profiles section**: Renders `{% include profiles.html %}` to display team members
+- **CTA**: "Book et møte" link or Microsoft Bookings embed
+
+## Dependencies
+
+- **Profiles**: Already implemented — `_profiles/dagfinn.md`, `_includes/profiles.html`, `assets/css/profiles.css`
+- **Navbar**: Navigation link — see `.specs/navigation/README.md`

--- a/.specs/partners/README.md
+++ b/.specs/partners/README.md
@@ -1,0 +1,30 @@
+# Partners — Functional Specification
+
+## Purpose and Scope
+
+Define the `partners` Jekyll collection for partner organizations. Collection is declared but currently has no content files or rendering template.
+
+## Requirements
+
+- Simple listing of partner logos/names with links
+- Tags for categorization (future filtering)
+
+## Data Structures
+
+### Partner frontmatter (`_partners/*.md`)
+
+```yaml
+---
+name: "Partner Name"               # required
+url: "https://partner.no"          # required
+image: "assets/images/partner-logo.png"  # required
+tags: "#samarbeid #teknologi"      # optional
+---
+```
+
+## Dependencies
+
+- **Collection**: Already declared in `_config.yml` (`partners: output: true`)
+- **Template**: Needs `_includes/partners.html` creation
+- **CSS**: Needs `partners.css` creation (or inclusion in `products.css`)
+- **Include**: Needs to be added to `_layouts/default.html` `<main>`

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -4,12 +4,40 @@ All tasks and work-in-progress are tracked here.
 
 ## To Do
 
-- [ ] Ledelse 60:2 — Generate 8 graphics via GPT Image 2 (1 hero illustration + 7 line-art icons in azure)
-- [ ] Ledelse 60:2 — Rewrite product frontmatter with structured fields (benefits[], process_steps[], story, short_description)
-- [ ] Ledelse 60:2 — Rewrite `_includes/products.html` template with hero + benefit grid + step flow + story + CTA
-- [ ] Ledelse 60:2 — Rewrite `assets/css/products.css` with hero layout, 2×2 benefit grid, 3-step process, inline booking link
+### Ledelse 60:2 — Graphics
+- [ ] Generate 1 hero illustration via GPT Image 2 (azure theme, Scandinavian minimal)
+- [ ] Generate 4 benefit icons + 3 process-step icons via GPT Image 2 (line-art, azure)
+
+### Ledelse 60:2 — Product frontmatter
+- [ ] Rewrite `_products/modenhetsvurdering.md` → `_products/ledelse-60-2.md` with structured fields (short_description, benefits[], process_steps[], story, tags)
+
+### Ledelse 60:2 — Inline front-page section
+- [ ] Rewrite `_includes/products.html` with compact hero excerpt + benefit grid + CTA linking to landing page
+- [ ] Rewrite `assets/css/products.css` with inline section layout
+
+### Ledelse 60:2 — Landing page
+- [ ] Create `_pages/ledelse-60-2.md` with `permalink: /ledelse-60-2/`
+- [ ] Build landing page template (hero + full benefit grid + step flow + cases + vitenskapelig grunnlag + final CTA)
+- [ ] Add landing page CSS
+
+### Navigation
+- [ ] Update `_includes/navbar.html` with links: "Ledelse 60:2" and "Om oss"
+- [ ] Update `assets/css/navbar.css` for visible minimal nav
+
+### Om oss
+- [ ] Create `om-oss.md` with company story and `{% include profiles.html %}`
+- [ ] Ensure `/om-oss/` renders correctly with profile cards
+
+### Cases collection
+- [ ] Update `_includes/cases.html` with filtering by `product_tags`
+- [ ] Create 1–2 case content files in `_cases/`
+- [ ] Wire case display into Ledelse 60:2 landing page section
+
+### Partners collection
+- [ ] Create `_includes/partners.html` template
+- [ ] Create `assets/css/partners.css`
+- [ ] Add partners include to `_layouts/default.html`
 
 ## In Progress
 
 ## Blocked
-


### PR DESCRIPTION
Adds functional specification documents under .specs/:
- **Ledelse 60:2** — Product redesign (inline + landing page), frontmatter schema, 8 graphics
- **Cases** — Case study collection schema (description, image, result, customer, product_tags)
- **Partners** — Partner organization schema (name, url, image, tags)
- **Navigation** — Minimal navbar with Ledelse 60:2 + Om oss links
- **Om oss** — About page spec with profiles integration

BACKLOG.md updated with all tasks uncovered during spec analysis.