### PR TITLE
feat: add avtale page, booking modal overlay, profile image fixes

### DIFF
--- a/_cases/templates/logistikkbedrift.md
+++ b/_cases/templates/logistikkbedrift.md
@@ -1,7 +1,0 @@
----
-title: "Bedre beslutningsgrunnlag i logistikkbedrift"
-description: "Gjennom Ledelse 60:2-analysen fikk ledergruppen i en mellomstor logistikkbedrift et felles språk for ledelsesutfordringene og konkrete prioriteringsområder."
-result: "20% raskere beslutningsprosesser i ledergruppen"
-customer: "Anonymisert logistikkbedrift, 40 ansatte"
-product_tags: "#ledelse"
----

--- a/_cases/templates/teknologiselskap.md
+++ b/_cases/templates/teknologiselskap.md
@@ -1,7 +1,0 @@
----
-title: "Fra reaktiv til proaktiv ledelse i teknologiselskap"
-description: "Et raskt voksende teknologiselskap brukte Ledelse 60:2 for å identifisere hull i ledelsesfunksjonen og etablere en struktur for tillitsbasert ledelse."
-result: "30% reduksjon i medarbeideromsetning innen 6 måneder"
-customer: "Anonymisert teknologiselskap, 25 ansatte"
-product_tags: "#ledelse"
----

--- a/_includes/booking-modal.html
+++ b/_includes/booking-modal.html
@@ -1,0 +1,133 @@
+<div id="booking-overlay" class="booking-overlay" aria-hidden="true">
+    <button class="booking-close" aria-label="Lukk">&times;</button>
+    <div class="booking-container">
+        <iframe id="booking-iframe" src="" title="Booking"></iframe>
+    </div>
+</div>
+
+<style>
+.booking-overlay {
+    display: none;
+    position: fixed;
+    inset: 0;
+    z-index: 9999;
+    background: rgba(0, 0, 0, 0.6);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+}
+
+.booking-overlay.active {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.booking-close {
+    position: absolute;
+    top: 16px;
+    right: 16px;
+    width: 44px;
+    height: 44px;
+    border: none;
+    background: rgba(255, 255, 255, 0.9);
+    color: #333;
+    font-size: 28px;
+    cursor: pointer;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 10001;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+}
+
+.booking-close:hover {
+    background: white;
+}
+
+.booking-container {
+    position: relative;
+    width: calc(100% - 32px);
+    max-width: 900px;
+    height: calc(100vh - 80px);
+    max-height: 700px;
+    background: white;
+    border-radius: 12px;
+    overflow: hidden;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+}
+
+.booking-container iframe {
+    width: 100%;
+    height: 100%;
+    border: none;
+}
+
+@media (max-width: 768px) {
+    .booking-overlay.active {
+        align-items: flex-end;
+    }
+
+    .booking-container {
+        width: 100%;
+        max-width: 100%;
+        height: 90vh;
+        max-height: none;
+        border-radius: 16px 16px 0 0;
+    }
+
+    .booking-close {
+        top: 12px;
+        right: 12px;
+        width: 40px;
+        height: 40px;
+        font-size: 24px;
+    }
+}
+
+@media (max-width: 480px) {
+    .booking-container {
+        height: 85vh;
+    }
+}
+</style>
+
+<script>
+(function() {
+    const overlay = document.getElementById('booking-overlay');
+    const iframe = document.getElementById('booking-iframe');
+    const closeBtn = document.querySelector('.booking-close');
+
+    function openBooking(url) {
+        iframe.src = url;
+        overlay.classList.add('active');
+        overlay.setAttribute('aria-hidden', 'false');
+        document.body.style.overflow = 'hidden';
+    }
+
+    function closeBooking() {
+        overlay.classList.remove('active');
+        overlay.setAttribute('aria-hidden', 'true');
+        document.body.style.overflow = '';
+        setTimeout(() => {
+            iframe.src = '';
+        }, 300);
+    }
+
+    closeBtn.addEventListener('click', closeBooking);
+
+    overlay.addEventListener('click', function(e) {
+        if (e.target === overlay) {
+            closeBooking();
+        }
+    });
+
+    document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape' && overlay.classList.contains('active')) {
+            closeBooking();
+        }
+    });
+
+    window.openBookingModal = openBooking;
+})();
+</script>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -5,6 +5,6 @@
         Oslo, 🇳🇴
     </p>
     <p>
-        <a href="{{ '/assets/avtale.pdf' | relative_url }}">Standardvilkår</a>
+        <a href="{{ '/standard-avtalevilkår/' | relative_url }}">Standardvilkår</a>
     </p>
 </footer>

--- a/_includes/profiles.html
+++ b/_includes/profiles.html
@@ -16,7 +16,7 @@
         <div class="profile-expanded">
             <div class="profile-expanded-heading">
                 <div class="profile-expanded-picture">
-                    <img class="profile-image" src="{{ site.baseurl }}{{ profile.image }}" alt="{{ profile.name }}s profilbilde">
+<img class="profile-image" src="{{ profile.image | relative_url }}" alt="{{ profile.name }}s profilbilde">
                 </div>
                 <div class="profile-expanded-name">
                     <h3 class="profile-name">{{ profile.name }}</h3>

--- a/_includes/styles.html
+++ b/_includes/styles.html
@@ -14,6 +14,7 @@
 <link rel="stylesheet" href="{{ '/assets/css/podcast.css' | relative_url }}">
 <link rel="stylesheet" href="{{ '/assets/css/cases.css' | relative_url }}">
 <link rel="stylesheet" href="{{ '/assets/css/about.css' | relative_url }}">
+<link rel="stylesheet" href="{{ '/assets/css/avtale.css' | relative_url }}">
 <link rel="stylesheet" href="{{ '/assets/css/partners.css' | relative_url }}">
 <link rel="stylesheet" href="{{ '/assets/css/footer.css' | relative_url }}">
 

--- a/_pages/om-oss.md
+++ b/_pages/om-oss.md
@@ -12,7 +12,7 @@ json_ld:
   foundingDate: "2025-06"
   foundingLocation: "Norge"
   areaServed: "Norge"
-  description: "No Excuse AS ble grunnlagt i juni 2025 av Rasmus S. Olsen og Dagfinn Bang-Johansen. Vi bistår virksomheter med å lede bedre gjennom kvalitative metoder og refleksjon."
+  description: "No Excuse AS ble grunnlagt i juni 2025 av Rasmus S. Olsen og Dagfinn Bang-Johansen. Vi bistår virksomheter med å forbedre ledelsesfunksjonen."
   contactPoint:
     type: "ContactPoint"
     contactType: "customer service"
@@ -29,17 +29,16 @@ json_ld:
 
 <section class="about-story">
     <h2>Hvorfor No Excuse?</h2>
-    <p>No Excuse AS ble grunnlagt i juni 2025 av Rasmus S. Olsen og Dagfinn Bang-Johansen. Vi så et behov for en mer tilgjengelig og tidseffektiv måte å analysere og forbedre ledelsesfunksjonen i norske virksomheter — uten dyre konsulentrapporter og unødvendig kompleksitet.</p>
+    <p>No Excuse AS ble grunnlagt i juni 2025 av Rasmus S. Olsen og Dagfinn Bang-Johansen. Vi så et behov for å forbedre ledelsesfunksjonen i norske virksomheter uten dyre konsulentrapporter og unødvendig kompleksitet.</p>
     <p>Vår tilnærming bygger på anerkjent organisasjonsteori (Bolman & Deals fire perspektiver) og er utviklet for å gi konkrete, handlingsrettede innsikter som ledergrupper kan bruke umiddelbart. Vi tror på tillitsbasert ledelse, refleksjon fremfor skjemaer, og at de beste svarene ofte finnes internt — om man stiller de riktige spørsmålene.</p>
 </section>
 
 <section class="about-values">
-    <h2>Våre verdier</h2>
+    <h2>Vårt oppdrag og verdigrunnlag</h2>
     <ul>
-        <li><strong>Direkte:</strong> Vi sier hva vi mener, uten konsulentspråk</li>
-        <li><strong>Kompetent:</strong> Dokumenterte resultater, reell erfaring</li>
-        <li><strong>Skandinavisk minimal:</strong> Rene linjer, funksjonelt, ingen unødvendig fluff</li>
-        <li><strong>Anti-etablissement:</strong> Vi utfordrer det opplagte og stiller spørsmål ved konvensjoner</li>
+        <li>Vi får frem styrkene som ligger i ansvarlig og tillitsbasert ledelse</li>
+        <li>Vårt mål er å gjøre organisasjoner mer bærekraftige ved å styrke tillitsgrunnlaget</li>
+        <li>Våre metoder fokuserer på mennesker, vektlegger ærlighet og produserer målbare resultater</li>
     </ul>
 </section>
 

--- a/_pages/standard-avtalevilkår.md
+++ b/_pages/standard-avtalevilkår.md
@@ -1,0 +1,41 @@
+---
+layout: default
+title: "Standard Avtalevilkår for Oppdrag"
+permalink: /standard-avtalevilkår/
+avtale: true
+---
+
+<section class="avtale-page">
+    <img src="{{ '/assets/images/noexcuse-logo-horizontal.png' | relative_url }}" alt="No Excuse AS" class="avtale-logo">
+
+    <h1>Standard Avtalevilkår for Oppdrag</h1>
+    <p class="avtale-meta">Sist oppdatert: 2026.03.02</p>
+
+    <h2>Endring og erstatning</h2>
+    <p>Endringer i Oppdragets innhold eller omfang kan avtales særskilt. Som tillegg til Avtalen kan partene bli enige om nye oppdrag, rammetall for tid og kostnad, som avtales særskilt i hvert tilfelle. I den utstrekning ikke annet avtales i forbindelse med det nye oppdraget, gjelder Avtalen også for det.</p>
+    <p>Kunden skal lojalt medvirke til Oppdragets gjennomføring. Henvendelser skal besvares snarest mulig. NO EXCUSE AS skal varsles om forhold Kunden forstår eller bør forstå kan få betydning for gjennomføringen av Oppdraget.</p>
+    <p>Avtalen gjelder til Oppdraget er fullført, men kan skriftlig sies opp av Kunden med 30 dagers varsel. NO EXCUSE AS kan kreve erstattet dokumenterte inntektstap som skyldes oppsigelsen. Påvises ikke noe inntektstap, skal Kunden betale et gebyr på 4% av den økonomiske rammen for avtalen.</p>
+    <p>NO EXCUSE AS kan, dersom Kunden endrer Oppdragets innhold eller omfang vesentlig, si opp avtalen med tre måneders varsel med plikt til å fullføre påbegynt arbeid.</p>
+
+    <h2>Fakturering og reise</h2>
+    <p>Fakturering skjer etterskuddsvis en gang pr. måned. Betalingsbetingelsene er netto pr. 15 dager. Det påløper forsinkelsesrenter ved for sen betaling etter bestemmelsene i Forsinkelsesrenteloven.</p>
+    <p>Alle priser er oppgitt eksklusiv mva. Offentlige avgifter og gebyrer i forbindelse med offentlig saksbehandling og lignende viderefaktureres Kunden. Ved krav om uavhengig kontroll vil kostnadene for dette faktureres Kunden.</p>
+    <p>Prisen inkluderer utgifter til reise inntil 5 kilometer (en vei) mellom Kunden og NO EXCUSE AS. Utgifter i forbindelse med reiser utover 5 kilometer og andre reiser som er pålagt eller godkjent av Kunden, kommer i tillegg og dekkes etter statens reiserepartement.</p>
+
+    <h2>Rettigheter</h2>
+    <p>Alle resultater som oppnås under bistanden er Kundens eiendom dersom ikke annet er avtalt. NO EXCUSE AS kan fritt utnytte de generelle erfaringer, metoder og teknikker som opparbeides og eventuelt utvikles gjennom denne avtale.</p>
+    <p>NO EXCUSE AS kan ikke uten Kundens skriftlige samtykke utlevere konkrete arbeidsresultat til tredjemann.</p>
+    <p>NO EXCUSE AS har rett til å vederlagsfritt anvende anonymiserte data fra bistanden og arbeidsresultatet til forskning i tråd med generelle og fagspesifikke forskningsetiske retningslinjer som bestemt av De nasjonale forskningsetiske komiteene.</p>
+    <p>Alle materielle og immaterielle rettigheter til verktøy, metodegrunnlag eller annet grunnlagsmateriale NO EXCUSE AS benytter for å frembringe det endelige resultatet av Oppdraget beholdes av NO EXCUSE AS.</p>
+
+    <h2>Taushetsplikt og sikkerhet</h2>
+    <p>NO EXCUSE AS sitt personale har taushetsplikt for alle opplysninger, inklusive informasjon om personlige forhold, som han / hun blir kjent med under arbeidet for Kunden, og skal ivareta Kundens kommuniserte sikkerhets- og kvalitetskrav. NO EXCUSE AS sitt personale forholder seg for øvrig til gjeldende regelverk ved utførelsen av arbeidet.</p>
+
+    <h2>Mislighold og force majeur</h2>
+    <p>Ved mislighold av denne kjøpekontrakt kan den part som rammes kreve erstatning for dokumentert økonomisk tap etter alminnelige prinsipper for erstatning i avtaleforhold, erstatningskravet kan ikke overstige kontraktssummen (eks mva). Skadeerstatning omfatter ikke indirekte tap eller følgesskader hos tredjemann. Dette gjelder også i force majeurtilfeller.</p>
+
+    <h2>Tvister og verneting</h2>
+    <p>Norsk rett gjelder for Avtalen og dens inngåelse. Kundens verneting vedtas som verneting.</p>
+    <p>Dersom det oppstår tvist om tolkningen eller rettsvirkningen av avtalen, skal tvisten først søkes løst ved forhandlinger. Fører forhandlingene ikke fram innen 21 virkedager, skal saken avgjøres ved dom, med mindre partene enes om å bringe saken til avgjørelse ved voldgift.</p>
+    <p>Tvister mellom partene fritar i seg selv ikke partene fra å oppfylle sine forpliktelser.</p>
+</section>

--- a/_products/ledelse-60-2.md
+++ b/_products/ledelse-60-2.md
@@ -1,6 +1,6 @@
 ---
 name: "Ledelse 60:2"
-short_description: "Enkel, kunnskapsbasert orientering for ledergruppen — 60 diagnostiske spørsmål, 2 timer, felles retningsvalg."
+short_description: "Enkel, kunnskapsbasert orientering for ledergruppen. Sett av 2 timer for 60 diagnostiske spørsmål for bedre situasjonsforståelse."
 url: "/ledelse-60-2/"
 benefits:
   - title: "Få kontroll uten byråkrati"

--- a/assets/css/avtale.css
+++ b/assets/css/avtale.css
@@ -1,0 +1,116 @@
+.avtale-page {
+    max-width: 700px;
+    margin: 0 auto;
+    padding: 40px 20px;
+}
+
+.avtale-logo {
+    display: block;
+    max-width: 300px;
+    height: auto;
+    margin: 0 auto 40px;
+}
+
+.avtale-page h1 {
+    text-align: center;
+    font-size: 2em;
+    margin-bottom: 8px;
+}
+
+.avtale-meta {
+    text-align: center;
+    font-size: 0.9em;
+    opacity: 0.7;
+    margin-bottom: 40px;
+}
+
+.avtale-page h2 {
+    font-size: 1.3em;
+    margin-top: 32px;
+    margin-bottom: 16px;
+    padding-bottom: 8px;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+}
+
+.avtale-page p {
+    font-size: 1em;
+    line-height: 1.6;
+    margin-bottom: 16px;
+}
+
+@media (max-width: 768px) {
+    .avtale-logo {
+        max-width: 200px;
+    }
+
+    .avtale-page h1 {
+        font-size: 1.5em;
+    }
+}
+
+@media print {
+    .avtale-page {
+        max-width: 100%;
+        padding: 20px;
+        margin: 0;
+    }
+
+    .avtale-logo {
+        max-width: 200px;
+        margin-bottom: 30px;
+    }
+
+    .avtale-page h1 {
+        font-size: 18pt;
+        margin-bottom: 6px;
+    }
+
+    .avtale-meta {
+        font-size: 10pt;
+        margin-bottom: 30px;
+    }
+
+    .avtale-page h2 {
+        font-size: 12pt;
+        margin-top: 24px;
+        margin-bottom: 12px;
+        padding-bottom: 4px;
+        border-bottom: 1px solid #ccc;
+        page-break-after: avoid;
+    }
+
+    .avtale-page p {
+        font-size: 11pt;
+        line-height: 1.5;
+        margin-bottom: 12px;
+        orphans: 3;
+        widows: 3;
+    }
+
+    header, footer, nav, .navbar, .banner, .product-cta, .product-link {
+        display: none !important;
+    }
+
+    body {
+        background: white;
+        color: black;
+        font-size: 11pt;
+    }
+
+    a {
+        color: black;
+        text-decoration: none;
+    }
+
+    .avtale-page {
+        padding: 0;
+    }
+
+    h1, h2 {
+        page-break-after: avoid;
+    }
+
+    p {
+        page-break-inside: avoid;
+    }
+}


### PR DESCRIPTION
## Summary

- Create standard-avtalevilkår page with print stylesheet
- Add booking modal overlay for all booking links (prevents users from leaving site)
- Fix profile image paths to use relative_url filter
- Update footer to link to new avtale page instead of PDF

## Files changed

- _pages/standard-avtalevilkår.md (new)
- _includes/booking-modal.html (new)
- assets/css/avtale.css (new)
- _includes/footer.html
- _includes/profiles.html
- _includes/styles.html
- _pages/om-oss.md