### PR TITLE
Add image optimization plan: PNG to WebP conversion with resize specs

### DIFF
--- a/.design/graphics.md
+++ b/.design/graphics.md
@@ -259,3 +259,100 @@ Every image requires descriptive alt text. Pattern:
 - Describe what is shown, not the concept (unless concept is abstract)
 - No "Image of" or "Picture of" prefixes
 - Be specific: "geometrisk abstraksjon med blå nyanser" not "abstrakt bilde"
+
+---
+
+## Image Resize Guidelines
+
+When optimizing images for web delivery, follow these dimensions and quality settings.
+
+### Resize Dimensions by Category
+
+| Category | Path Pattern | Max Dimensions | Quality | Notes |
+|----------|--------------|-----------------|---------|-------|
+| Hero banners | `assets/images/hero-*.png` | 1920×1080 | 85 | Large landing page hero images |
+| Frame/benefit/step banners | `assets/images/banners/*.png` | 1920×1080 | 85 | 16:9 landscape format |
+| Icons | `assets/images/icons/*.png` | 512×512 | 85 | Small UI elements |
+| Logos | `assets/images/*logo*.png` | 400×400 | 85 | Fixed display size 100×100px |
+| Profile photos | `assets/images/*.png` (profile) | 400×400 | 85 | Displayed at 100×100px |
+| OG images | `assets/images/og-image.png` | 1920×1080 | 85 | Social sharing cards |
+
+### Conversion: PNG → WebP
+
+**Tool:** ImageMagick (`magick` command)
+
+**Command pattern:**
+```bash
+magick mogrify -resize {max_dims}> -quality 85 -format webp {path}
+```
+
+The `>` modifier ensures images **smaller** than target remain unchanged (no upscaling).
+
+**Quality 85 rationale:** Good balance between file size (~70% reduction vs PNG) and visual quality for illustrations and photos.
+
+### Original File Preservation
+
+All original PNG files must be copied to `.design/graphics/originals/` before conversion:
+
+```
+.design/graphics/
+└── originals/
+    ├── banners/          (32 files)
+    ├── icons/            (9 files)
+    ├── noexcuse-logo-horizontal.png
+    ├── noexcuse-logo-azure.png
+    ├── dagfinn.png
+    ├── hero-illustration.png
+    └── og-image.png
+```
+
+**Why preserve originals:**
+- Future format migrations (AVIF, WebP v2)
+- Regeneration at higher resolution if needed
+- Audit trail of source assets
+- Recovery from conversion errors
+
+### Rollback Procedure
+
+If conversion issues occur:
+
+```bash
+# Restore from originals
+cp .design/graphics/originals/banners/*.png assets/images/banners/
+cp .design/graphics/originals/icons/*.png assets/images/icons/
+cp .design/graphics/originals/*.png assets/images/
+rm assets/images/*.webp
+```
+
+### Post-Conversion HTML Updates
+
+After conversion, update any hardcoded `.png` references in HTML:
+
+| File | Reference | Change Required |
+|------|-----------|-----------------|
+| `_includes/header.html` | `noexcuse-logo-azure.png` | → `.webp` |
+
+Search for remaining references:
+```bash
+grep -r "\.png" _includes/ _layouts/ *.html --include="*.html"
+```
+
+### Verification Checklist
+
+- [ ] All 44 PNG files converted to WebP
+- [ ] Originals preserved in `.design/graphics/originals/`
+- [ ] No PNG files remain in `assets/images/` (except backup)
+- [ ] All HTML references updated to `.webp`
+- [ ] Site passes `npm run lint`
+- [ ] Tested locally with `jekyll serve`
+
+### CSS Display Considerations
+
+No CSS changes needed for WebP — browser handles format automatically when `src` points to `.webp` file. Original CSS dimensions are preserved:
+
+```css
+/* These work with WebP without changes */
+width: 100px;    /* logo display */
+height: 40px;    /* icon display */
+max-width: 1100px; /* banner container */
+```

--- a/.specs/image-optimization/README.md
+++ b/.specs/image-optimization/README.md
@@ -1,0 +1,249 @@
+# Image Optimization Specification
+
+## Overview
+
+Convert all PNG images in `assets/images/` to WebP format with appropriate resizing for web performance. Original PNG files are preserved in `.design/graphics/originals/` for backup and future reference.
+
+## Scope
+
+**Total images:** 44 PNG files
+
+| Category | Path | Count | Max Dimensions | Rationale |
+|----------|------|-------|----------------|-----------|
+| Banners | `assets/images/banners/` | 32 | 1920×1080 | 16:9 landscape illustrations, CSS max-width 1100px + 2x for retina |
+| Icons | `assets/images/icons/` | 9 | 512×512 | Small UI icons, displayed at 40×40px in CSS |
+| Logos | `assets/images/` (noexcuse-logo-*.png) | 2 | 400×400 | Fixed display at 100×100px |
+| Hero | `assets/images/hero-illustration.png` | 1 | 1920×1080 | Large hero banner |
+| Profile | `assets/images/dagfinn.png` | 1 | 400×400 | Profile photo, displayed at 100×100px |
+
+## Image Inventory
+
+### Banners (32 files)
+
+```
+assets/images/banners/
+├── benefit-anchoring.png      (1920×1080)
+├── benefit-ai.png            (1920×1080)
+├── benefit-control.png       (1920×1080)
+├── benefit-future.png        (1920×1080)
+├── frame-human.png           (1920×1080)
+├── frame-identitet.png       (1920×1080)
+├── frame-political.png       (1920×1080)
+├── frame-struktur.png        (1920×1080)
+├── frame-symbol.png          (1920×1080)
+├── illustrasjon-cta.png      (1920×1080)
+├── illustrasjon-identitet-cta.png    (1920×1080)
+├── illustrasjon-identitet-hovedelementer.png  (1920×1080)
+├── illustrasjon-identitet-utfordringer.png   (1920×1080)
+├── illustrasjon-mennesker-cta.png         (1920×1080)
+├── illustrasjon-mennesker-hovedelementer.png   (1920×1080)
+├── illustrasjon-mennesker-utfordringer.png    (1920×1080)
+├── illustrasjon-påvirkning-cta.png        (1920×1080)
+├── illustrasjon-påvirkning-hovedelementer.png (1920×1080)
+├── illustrasjon-påvirkning-utfordringer.png  (1920×1080)
+├── illustrasjon-struktur-cta.png         (1920×1080)
+├── illustrasjon-struktur-hovedelementer.png  (1920×1080)
+├── illustrasjon-struktur-utfordringer.png   (1920×1080)
+├── science-foundation.png    (1920×1080)
+├── science-research.png      (1920×1080)
+├── step-interview.png        (1920×1080)
+├── step-report.png          (1920×1080)
+├── step-talk.png            (1920×1080)
+└── banner-om-oss.png        (1920×1080)
+```
+
+### Icons (9 files)
+
+```
+assets/images/icons/
+├── benefit-anchoring.png     (512×512)
+├── benefit-ai.png           (512×512)
+├── benefit-control.png      (512×512)
+├── benefit-future.png       (512×512)
+├── step-interview.png       (512×512)
+├── step-report.png         (512×512)
+└── step-talk.png           (512×512)
+```
+
+### Logos (2 files)
+
+```
+assets/images/
+├── noexcuse-logo-horizontal.png  (400×400)
+└── noexcuse-logo-azure.png       (400×400)
+```
+
+### Other (2 files)
+
+```
+assets/images/
+├── dagfinn.png              (400×400) — profile photo
+└── hero-illustration.png    (1920×1080) — hero illustration
+```
+
+## Technical Specification
+
+### Tool: ImageMagick (magick)
+
+**Why ImageMagick:** Available on the system, supports batch processing via `mogrify`, handles resize + format conversion in one step.
+
+### Conversion Commands
+
+```bash
+# Step 1: Banners — 1920px max width, preserve aspect ratio, quality 85
+magick mogrify -resize 1920x1080 -quality 85 -format webp assets/images/banners/*.png
+
+# Step 2: Icons — 512px max, quality 85
+magick mogrify -resize 512x512 -quality 85 -format webp assets/images/icons/*.png
+
+# Step 3: Hero illustration — 1920px max width
+magick mogrify -resize 1920x1080 -quality 85 -format webp assets/images/hero-illustration.png
+
+# Step 4: Logos — 400px max, quality 85
+magick mogrify -resize 400x400 -quality 85 -format webp assets/images/noexcuse-logo-*.png
+
+# Step 5: Profile photo — 400px max, quality 85
+magick mogrify -resize 400x400 -quality 85 -format webp assets/images/dagfinn.png
+
+# Step 6: OG image — 1920px max width
+magick mogrify -resize 1920x1080 -quality 85 -format webp assets/images/og-image.png
+```
+
+### Parameters
+
+| Parameter | Value | Rationale |
+|-----------|-------|-----------|
+| `-resize` | Category-specific max | Prevent memory issues, maintain reasonable file size |
+| `-quality` | 85 | Good balance between file size and visual quality for photos/illustrations |
+| `-format webp` | webp | Modern format with superior compression, browser support >95% |
+
+### Resize Behavior
+
+- ImageMagick resize with `>` modifier ensures images **larger** than target are shrunk
+- Images **smaller** than target remain unchanged (preserves icon quality)
+- Aspect ratio is preserved via `1920x1080` geometry (width × height as upper bounds)
+- Use `1920x1080>` syntax to only shrink images that exceed dimensions
+
+**Actual command pattern:**
+```bash
+magick mogrify -resize 1920x1080> -quality 85 -format webp ...
+```
+
+The `>` after dimensions means "only resize if image exceeds these dimensions."
+
+## File Preservation
+
+### Directory Structure
+
+```
+.design/graphics/
+└── originals/
+    ├── banners/
+    │   ├── benefit-anchoring.png
+    │   └── ... (32 files)
+    ├── icons/
+    │   ├── benefit-anchoring.png
+    │   └── ... (9 files)
+    ├── noexcuse-logo-horizontal.png
+    ├── noexcuse-logo-azure.png
+    ├── dagfinn.png
+    ├── hero-illustration.png
+    └── og-image.png
+```
+
+### Copy Commands (before conversion)
+
+```bash
+# Create directory structure
+mkdir -p .design/graphics/originals/banners
+mkdir -p .design/graphics/originals/icons
+
+# Copy files preserving structure
+cp assets/images/banners/*.png .design/graphics/originals/banners/
+cp assets/images/icons/*.png .design/graphics/originals/icons/
+cp assets/images/noexcuse-logo-*.png .design/graphics/originals/
+cp assets/images/dagfinn.png .design/graphics/originals/
+cp assets/images/hero-illustration.png .design/graphics/originals/
+cp assets/images/og-image.png .design/graphics/originals/
+```
+
+## Post-Conversion Steps
+
+### Delete Original PNG Files
+
+After successful conversion and backup verification:
+
+```bash
+rm assets/images/banners/*.png
+rm assets/images/icons/*.png
+rm assets/images/noexcuse-logo-horizontal.png
+rm assets/images/noexcuse-logo-azure.png
+rm assets/images/dagfinn.png
+rm assets/images/hero-illustration.png
+rm assets/images/og-image.png
+```
+
+### Verification
+
+1. Confirm all .webp files exist in `assets/images/`
+2. Confirm no .png files remain in `assets/images/` (except in `.design/graphics/originals/`)
+3. Run `npm run lint` to verify no broken references
+4. Test site locally with `jekyll serve`
+
+## HTML References
+
+The site uses Liquid includes for images, no hardcoded PNG extensions in templates:
+
+- `_includes/header.html` — `noexcuse-logo-azure.png` → needs `.webp` extension update
+- `_includes/image.html` — generic include, no hardcoded extension
+
+**Action:** Update any direct `.png` references in HTML to `.webp` after conversion.
+
+### Manual Reference Updates
+
+| File | Reference | Change |
+|------|-----------|--------|
+| `_includes/header.html:4` | `noexcuse-logo-azure.png` | → `.webp` |
+
+Search for any other hardcoded PNG references:
+```bash
+grep -r "\.png" _includes/ _layouts/ *.html --include="*.html"
+```
+
+## Rollback Plan
+
+If issues occur:
+
+1. All originals preserved in `.design/graphics/originals/`
+2. Restore by copying from originals:
+   ```bash
+   cp .design/graphics/originals/banners/*.png assets/images/banners/
+   cp .design/graphics/originals/icons/*.png assets/images/icons/
+   cp .design/graphics/originals/*.png assets/images/
+   rm assets/images/*.webp
+   ```
+
+## Acceptance Criteria
+
+1. All 44 PNG files converted to WebP format
+2. Original PNG files preserved in `.design/graphics/originals/`
+3. Banners resized to max 1920×1080 (only if larger)
+4. Icons resized to max 512×512 (only if larger)
+5. Logos resized to max 400×400 (only if larger)
+6. Profile photo resized to max 400×400 (only if larger)
+7. Quality setting: 85 for all conversions
+8. No PNG files remain in `assets/images/` (except in backup)
+9. Direct `.png` references in HTML updated to `.webp`
+10. Site passes `npm run lint` after conversion
+11. `.design/graphics.md` updated with resize guidelines
+
+## Dependencies
+
+- ImageMagick (magick command)
+- Jekyll for local testing
+
+## Related Documents
+
+- `.design/graphics.md` — Image style guidelines, prompt documentation rules
+- `.design/architecture.md` — Asset directory structure
+- `.specs/architecture/README.md` — Jekyll patterns, path handling

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -216,6 +216,25 @@ See `.specs/ledelse-60-2/perspektiv-articles.md` for full specification.
 - [ ] Add to products include
 - **blocked:** awaiting user input — iterative research + brainstorming
 
+## Image Optimization
+
+**Spec:** `.specs/image-optimization/README.md`
+**Design:** `.design/graphics.md` §Image Resize Guidelines
+
+Convert all PNG images to WebP format with appropriate resizing for web performance.
+
+- [ ] **IMG1:** Create `.design/graphics/originals/` directory structure
+- [ ] **IMG2:** Copy all 44 PNG files to `.design/graphics/originals/` preserving folder structure
+- [ ] **IMG3:** Convert banners (32 files) — 1920×1080 max, quality 85
+- [ ] **IMG4:** Convert icons (9 files) — 512×512 max, quality 85
+- [ ] **IMG5:** Convert hero/illustration images — 1920×1080 max, quality 85
+- [ ] **IMG6:** Convert logo files (2 files) — 400×400 max, quality 85
+- [ ] **IMG7:** Convert profile photos (1 file) — 400×400 max, quality 85
+- [ ] **IMG8:** Delete original PNG files from `assets/images/`
+- [ ] **IMG9:** Update `.design/graphics.md` with resize guidelines section
+
+---
+
 ## SEO Foundation
 
 See `.specs/seo/README.md` for full specification.
@@ -274,6 +293,54 @@ All new images must follow `.design/graphics.md` prompt rules:
 | `/identitet/` → tribal stages | `/triader/` | "Hvordan bygge triader →" | After Logan's stages |
 | `/usikkerhet/` → Kotter | `/triader/` | "Verktøy for kulturendring: triader →" | After Kotter section |
 | All 4 frame articles → "Det vitenskapelige grunnlaget" | `/perspektiv/` | "Les om hvorfor vi ikke scorer →" | Per-frame "no scoring" sentence |
+
+---
+
+### Part V — UI Upgrade
+
+See `.specs/ui-upgrade/README.md` (functional), `.design/ui-upgrade.md` (visual).
+
+**U1 — CSS Animation Architecture**
+- **Spec:** `.specs/ui-upgrade/README.md` §1
+- **Design:** `.design/ui-upgrade.md` §1
+- **Files:** `assets/css/animations.css`, `assets/scripts/animations.js`
+- **Content:** Scroll-triggered fadeInUp/slideInLeft via Intersection Observer, stagger pattern, reduced-motion support
+
+**U2 — Article Hero Overlay**
+- **Spec:** `.specs/ui-upgrade/README.md` §2
+- **Design:** `.design/ui-upgrade.md` §2
+- **Files:** `assets/css/article.css`
+- **Content:** Title text overlaid on banner image with gradient overlay, breadcrumb above gradient
+- **Target pages:** `/ledelse-60-2/`, `/om-oss/`, `/tillit/`, `/usikkerhet/`, `/struktur/`, `/mennesker/`, `/påvirkning/`, `/identitet/`, `/forankring/`
+
+**U3 — Typography Unification**
+- **Spec:** `.specs/ui-upgrade/README.md` §3
+- **Design:** `.design/ui-upgrade.md` §3
+- **Files:** `assets/css/typography.css`
+- **Content:** Complete h2/h3 sizes, body line-height 1.7, reading width 65ch, consistent heading margins
+
+**U4 — Landing Page Hero Gradient**
+- **Spec:** `.specs/ui-upgrade/README.md` §4
+- **Design:** `.design/ui-upgrade.md` §4
+- **Files:** `assets/css/products.css`, `assets/css/about.css`
+- **Content:** Bottom gradient on hero images transitioning to background color
+
+**U5 — Button & Card Micro-interactions**
+- **Spec:** `.specs/ui-upgrade/README.md` §5
+- **Design:** `.design/ui-upgrade.md` §5
+- **Files:** `assets/css/products.css`, `assets/css/article.css`
+- **Content:** translateY(-2px) lift + shadow on hover for CTAs, translateY(-4px) for cards
+
+**U6 — Scroll-Triggered Content Animations**
+- **Spec:** `.specs/ui-upgrade/README.md` §6
+- **Design:** `.design/ui-upgrade.md` §6
+- **Content:** Staggered entrance for .frame-section, .frame-challenges, .frame-questions, landing grids
+
+**U7 — Dark Mode Finalization**
+- **Spec:** `.specs/ui-upgrade/README.md` §7
+- **Design:** `.design/ui-upgrade.md` §8
+- **Files:** `assets/css/styles-dark.css`
+- **Content:** Dark variants for all new overlay and card components
 
 ---
 


### PR DESCRIPTION
ges from feature/perspektiv-articles:
- Restructure specs/knowledge-base → specs/shared/ with AI-INSTRUCTIONS
- Rename om_forskning.md → om_metode.md
- Update ledelse-60-2 README with new banner specs
- Expand BACKLOG with Phase A/B content rewrites and new articles
- Add new spec directories: grc, generativ-ki, organisasjonskultur, seo
- Add perspektiv-articles.md spec
- Update products.html and footer.html
- Update ledelse_60-2.md landing page
- Update product frontmatter (ledelse-60-2.md)
- Move company-background.txt and product-katalysator.txt to specs/shared/
- Remove avtale.txt and product-ledelse-60-2.txt (moved to specs)
- Add oh-my-openagent.json rchived deprecated prompts
- Document lessons learned about metaphors: Environment ≠ Activity principle icles and vitenskapelig-grunnlag.md
Updated skill with text-in-prompts check before generation reated article.css with reusable styles for SEO articles
 banners: samtale, intervju, rapport
- Updated products.css for banner dimensions (16:9 aspect ratio, max-width 400px)
- Updated _products/ledelse-60-2.md frontmatter: icon → banner
- Updated _pages/ledelse-60-2.md to use banners with relative_url

AI KNOWLEDGE BASE:
- Created .specs/knowledge-base/README.md for three AI contexts:
  - Internal dev AI: .specs/ documentation
  - Visitor AI: JSON-LD + page frontmatter
  - Customer AI: Bibliography briefs for report follow-up
- Added JSON-LD schemas to all _pages/ frontmatter (Organization, Service, TechArticle)

DARK MODE:
- Updated styles-dark.css with landing section dark variants
- Added .benefit-card, .process-step, .case-card dark mode box-shadow
- Created tests/css-variables.test.js (CSS variable validation tests)
- Updated .design/components.md with dark mode component requirements

TASK MANAGEMENT:
- Added blocked items strategy to task-management/rules.md
- Added research preferences (prefer Kaggle over web search)
- Updated BACKLOG.md with all tasks