### PR TITLE
fix(site-review): fix broken links, page titles, perspektiv images, and footer emoji

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -2,6 +2,6 @@
     <p>&copy; {{ site.data.metadata.impressum.copyright_year }} {{ site.data.metadata.title }},
         <a href="https://virksomhet.brreg.no/nb/oppslag/enheter/935794420">{{ site.data.metadata.impressum.orgnr }}</a>,
         <a href="mailto:{{ site.data.metadata.impressum.email }}">{{ site.data.metadata.impressum.email }}</a>.
-        Oslo, 🇳🇴 
+        Oslo, Norge
     </p>
 </footer>

--- a/_layouts/perspektiv.html
+++ b/_layouts/perspektiv.html
@@ -4,7 +4,7 @@ layout: page
 
 <link rel="stylesheet" href="{{ '/assets/css/perspektiv-styles.css' | relative_url }}">
 
-{% assign frame_id = page.url | split: '/' | last %}
+{% assign frame_id = page.url | remove_first: '/' | split: '/' | first %}
 {% assign frame = site.frames | where: "id", frame_id | first %}
 
 <!-- Hero Section -->

--- a/_pages/ledelse_60-2.md
+++ b/_pages/ledelse_60-2.md
@@ -70,7 +70,7 @@ json_ld:
             <img src="{{ '/assets/images/banners/benefit-future.webp' | relative_url }}" alt="Bli forberedt på en usikker fremtid" class="benefit-banner">
             <h3>Bli forberedt på en usikker fremtid</h3>
             <p>Styr unna uønskede hendelser og fang mulighetene som byr seg. En moden ledelse ligger i forkant av endringer for å holde stø kurs. Forankre krav til informasjonssikkerhet, kvalitet og miljø på riktig sted: I ledelsen.</p>
-            <a href="{{ '/usikkerhet/' | relative_url }}" class="benefit-link">Les artikkelen →</a>
+            <a href="{{ '/organisasjonskultur/' | relative_url }}" class="benefit-link">Les artikkelen →</a>
         </div>
         <div class="benefit-card animate-on-scroll fade-in-up stagger">
             <img src="{{ '/assets/images/banners/benefit-anchoring.webp' | relative_url }}" alt="Forankre initiativer i ledergruppen" class="benefit-banner">

--- a/_pages/ledelse_identitet.md
+++ b/_pages/ledelse_identitet.md
@@ -1,4 +1,5 @@
 ---
 layout: perspektiv
+title: "Identitetsperspektivet i ledelse"
 permalink: /identitet/
 ---

--- a/_pages/ledelse_mennesker.md
+++ b/_pages/ledelse_mennesker.md
@@ -1,4 +1,5 @@
 ---
 layout: perspektiv
+title: "Menneskeperspektivet i ledelse"
 permalink: /mennesker/
 ---

--- a/_pages/ledelse_påvirkning.md
+++ b/_pages/ledelse_påvirkning.md
@@ -1,4 +1,5 @@
 ---
 layout: perspektiv
+title: "Påvirkningsperspektivet i ledelse"
 permalink: /påvirkning/
 ---

--- a/_pages/ledelse_struktur.md
+++ b/_pages/ledelse_struktur.md
@@ -1,4 +1,5 @@
 ---
 layout: perspektiv
+title: "Strukturperspektivet i ledelse"
 permalink: /struktur/
 ---

--- a/_products/ledelse-60-2.md
+++ b/_products/ledelse-60-2.md
@@ -29,7 +29,7 @@ benefits:
   - title: "Bli forberedt på en usikker fremtid"
     description: "Styr unna uønskede hendelser og fang mulighetene som byr seg. En moden ledelse ligger i forkant av endringer for å holde stø kurs. Forankre krav til informasjonssikkerhet, kvalitet og miljø på riktig sted: I ledelsen."
     banner: "assets/images/banners/benefit-future.webp"
-    article_url: "/usikkerhet/"
+    article_url: "/organisasjonskultur/"
   - title: "Forankre initiativer i ledergruppen"
     description: "Skap en bedre felles forståelse av grunnlaget for nye initiativer så ressursene kan brukes for å håndtere de viktigste mulighetene og risikoene. Ledere som ser saken fra ulike perspektiver har større gjennomføringskraft."
     banner: "assets/images/banners/benefit-anchoring.webp"


### PR DESCRIPTION
## Summary

Published site review identified several issues across desktop and mobile. This PR fixes all critical and high-priority items.

## Issues Fixed

### Critical
- **Broken link**: /usikkerhet/ → /organisasjonskultur/ in landing page and product data
- **Missing page titles**: Perspektiv layout pages (struktur, identitet, påvirkning, mennesker) showed filename as browser title instead of proper Norwegian titles
- **Missing perspektiv images**: Double-dash in image URLs (illustrasjon--hovedelementer.png) caused by incorrect frame_id extraction from trailing-slash URLs

### High
- **Broken emoji**: Norwegian flag 🇳🇴 rendered as missing glyph box on some systems → replaced with 'Norge'

## Review Findings (Not Addressed in This PR)

### Medium Priority
- Button contrast on 'Les mer →' card links may be insufficient on some displays
- Footer text appears small on mobile
- Inconsistent 'Les mer →' styling across hero vs cards
- Navigation links may have insufficient touch target size on mobile

### Low Priority
- Card image aspect ratios are inconsistent in 2×2 grid
- Primary CTA 'Book en uforpliktende samtale' could use more visual prominence
- Header logo scale relative to wordmark could be rebalanced

## How to Test
1. Visit https://noexcuse.no/ and verify 'Bli forberedt på en usikker fremtid' links to /organisasjonskultur/
2. Visit /struktur/, /identitet/, /påvirkning/, /mennesker/ and verify browser tab shows correct Norwegian title
3. Verify perspektiv page images load without 404 errors
4. Check footer shows 'Oslo, Norge' instead of broken emoji

## Self-Review Checklist
- [x] Changes are minimal and focused on identified issues
- [x] No new dependencies added
- [x] Branch created from current main
- [x] Commit messages follow convention