### PR TITLE
fix(site-review): UI improvements and article specs

### DIFF
--- a/.specs/makt/README.md
+++ b/.specs/makt/README.md
@@ -1,0 +1,184 @@
+# Makt eller tjeneste — Article Specification
+
+## Purpose and Scope
+
+Create `_pages/ledelse_makt.md` exploring the central tension between power acquisition (Pfeffer) and servant leadership (Blanchard & Barrett). This article addresses the diagnostic question: does your leadership culture optimize for power or service?
+
+## URL
+
+`/makt/`
+
+## Sources
+
+- **Primary (Power):** Pfeffer, J. (2010). *Power: Why Some People Have It — and Others Don't*. Harper Business.
+- **Primary (Service):** Blanchard, K., & Barrett, C. (2011). *Lead with LUV: A Different Way to Create Real Success*. FT Press.
+- **Meta:** Bolman & Deal (2017) Ch. 16 — "Integrating the Frames"
+
+## Content Direction
+
+### Theme
+
+Organizations need both power and service. The question isn't which to choose — it's whether you have a conscious culture that balances them. This article maps the spectrum from power-optimized to service-optimized leadership, and the costs of each extreme.
+
+### Key Message
+
+Power without service becomes extraction. Service without power becomes martyrdom. Effective leadership cultures know where they sit on this spectrum and why.
+
+### NOT This Article
+
+- Moralizing about "good" vs "bad" leadership
+- Political maneuvering tactics
+- Religious or spiritual servant leadership
+
+### Core Sections
+
+#### 1. The Diagnostic Tension
+
+Introducing the two poles and why they matter.
+
+**Key points:**
+- Pfeffer: "Power is the ability to get things done"
+- Blanchard: "Leadership is not about you; it's about the people you serve"
+- The tension is structural, not personal
+- Organizations drift toward one pole without conscious effort
+
+#### 2. The Power Side (Pfeffer)
+
+What power-oriented leadership looks like and when it works.
+
+**Key points:**
+- Power as capacity — the ability to mobilize resources
+- Power protects against organizational chaos
+- Career implications: power correlates with advancement
+- Risk: power becomes self-justifying ("I'm powerful because I'm right")
+
+#### 3. The Service Side (Blanchard & Barrett)
+
+What service-oriented leadership looks like and when it works.
+
+**Key points:**
+- Servant leadership as organizational culture enabler
+- Service creates trust, which reduces transaction costs
+- Evidence: servant leadership correlates with commitment, satisfaction, performance
+- Risk: service becomes submission ("I serve therefore I'm exploited")
+
+#### 4. The Price of Power
+
+The full treatment of power's costs.
+
+**Key points:**
+- **Trade-offs:** Time spent building power is time not spent on substance
+- **Corrupting effect:** Power increases narcissism and overconfidence (research-backed)
+- **Psychological toll:** Loneliness, distrust, constant vigilance
+- **Relationship costs:** Power changes how others relate to you — even when you don't want it to
+
+#### 5. The Spectrum
+
+Mapping real leadership cultures.
+
+**Key points:**
+- Pure power: transactional, competitive, high turnover, short-term
+- Pure service: collaborative, slow decisions, potential for exploitation
+- Balanced: conscious use of power in service of mission
+- Logan's Stage 4-5: "We" cultures that distribute power while maintaining service ethos
+
+#### 6. Questions for Self-Diagnosis
+
+**Key questions:**
+- When you make decisions, do you think first about impact or about who supports you?
+- How many people would help you if you lost your formal authority?
+- Does your organization reward power acquisition or service delivery?
+- What would change if your team knew your private motivations?
+
+## Content Guidelines
+
+### Tone
+
+Balanced, direct, no moralizing. Scandinavian minimal. Acknowledge both sides as valid, then show the synthesis.
+
+### Length
+
+~1800 words (longer due to dual-argument structure), semi-formal, scannable.
+
+### Structure
+
+Follow the existing frame article pattern:
+1. Hero with intro sentence
+2. Problem framing (The Diagnostic Tension)
+3. Dual-argument core (Power side, Service side)
+4. Price of Power (full treatment)
+5. Synthesis (The Spectrum)
+6. Questions section
+7. CTA linking to Ledelse 60:2
+
+### Citations
+
+- Pfeffer (2010) on power dynamics, costs, and career effects
+- Blanchard & Barrett (2011) on servant leadership outcomes
+- Logan et al. (2011) on Stage 4-5 cultures as synthesis
+- Research on power's psychological effects (Dacher Keltner, "The Power Paradox")
+
+## Design
+
+- **Hero:** Style 2 (banner with text overlay)
+- **Illustrations:** 1 hero banner, 2-3 section illustrations (Style 3)
+- **Images needed:**
+  - Hero: abstract representing tension/duality (balance, scales, or opposing forces)
+  - Section 2: upward trajectory / staircase (power)
+  - Section 3: hands supporting / circle of people (service)
+  - Section 5: spectrum or bridge imagery (synthesis)
+
+## Connections to Site Content
+
+### Link to Ledelse 60:2
+
+CTA section linking to Ledelse 60:2 as the diagnostic that reveals where the organization sits on the power-service spectrum.
+
+### Link to Existing Articles
+- Cross-link from `/påvirkning/` (brief mention: "Les om maktens kostnader i /makt/ →")
+- Cross-link from `/mennesker/` (servant leadership context)
+- Cross-link from `/perspektiv/` (multiframe thinking as the resolution)
+
+## File
+
+**New file:** `_pages/ledelse_makt.md`
+
+**Frontmatter:**
+```yaml
+---
+layout: page
+title: "Makt eller tjeneste — Hvor sitter din ledergruppe på spekteret?"
+description: "Organisasjoner trenger både makt og tjeneste. Lær hvorfor effektive ledelseskulturer bevisst balanserer begge."
+permalink: /makt/
+json_ld:
+  type: "Article"
+  name: "Makt eller tjeneste"
+  description: "Hvor sitter din ledergruppe på spekteret mellom makt og tjeneste?"
+  author:
+    type: "Organization"
+    name: "No Excuse AS"
+  about:
+    - type: "Thing"
+      name: "Maktdynamikk"
+    - type: "Thing"
+      name: "Servant Leadership"
+    - type: "Thing"
+      name: "Organisasjonskultur"
+---
+```
+
+## Dependencies
+
+- 4 images (1 hero, 3 section illustrations)
+- Cross-links from existing articles
+- Reference to Pfeffer and Blanchard & Barrett briefs in `.specs/shared/`
+
+## Acceptance Criteria
+
+- [ ] Both power and service arguments presented fairly
+- [ ] "Price of Power" section covers trade-offs, corruption, and psychological toll
+- [ ] Spectrum section shows synthesis, not false dichotomy
+- [ ] CTA connects to Ledelse 60:2
+- [ ] Brand voice consistent with rest of site
+- [ ] Dark mode tested
+- [ ] Mobile layout tested

--- a/.specs/perspektiv/README.md
+++ b/.specs/perspektiv/README.md
@@ -1,0 +1,192 @@
+# Fire perspektiver — Article Specification
+
+## Purpose and Scope
+
+Create `_pages/ledelse_perspektiv.md` as the capstone article explaining multiframe thinking as the actual leadership skill. This article synthesizes all four Bolman & Deal frames and provides the "no scoring" philosophical backing.
+
+## URL
+
+`/perspektiv/`
+
+## Source
+
+- **Primary:** Bolman, L. G., & Deal, T. E. (2017). *Reframing Organizations: Artistry, Choice, and Leadership* (6th ed.). Jossey-Bass. Chapter 16 — "Integrating the Frames"
+- **Supporting:** Hubbard, D. W. (2014). *How to Measure Anything: Finding the Value of Intangibles in Business* (3rd ed.). Wiley.
+- **Supporting:** Logan, D., King, J., & Fischer-Wright, H. (2011). *Tribal Leadership*. Harper Business.
+
+## Content Direction
+
+### Theme
+
+Most leaders see the world through one lens. The best leaders see through four — and know which lens to use when. This article explains why single-frame thinking fails, what multiframe thinking looks like in practice, and why "no scoring" is actually the most rigorous approach.
+
+### Key Message
+
+Leadership is not about being right. It's about being complete. Multiframe thinking — seeing situations through structural, human resource, political, and symbolic lenses simultaneously — is the skill that separates diagnostic leaders from ideological ones.
+
+### NOT This Article
+
+- Summary of the four frames (each frame has its own article)
+- Academic discussion of frame theory
+- Prescriptive "use frame X in situation Y" checklist
+
+### Core Sections
+
+#### 1. The Single-Frame Trap
+
+Why most leaders fail: they have a favorite frame and apply it everywhere.
+
+**Key points:**
+- Engineers see structure; HR sees people; politicians see power; marketers see symbols
+- Every profession trains a single-frame reflex
+- The trap: when your only tool is a hammer, every problem looks like a nail
+- Bolman & Deal: "Leaders who master only one frame are doomed to repeat its limitations"
+
+#### 2. What Multiframe Thinking Is
+
+Defining the skill, not the theory.
+
+**Key points:**
+- Not knowing four theories — it's seeing four aspects simultaneously
+- The mental habit: "What would this look like through a different lens?"
+- Diagnostic discipline: which frame explains the most variance?
+- Practical: takes 2 minutes to reframe, saves months of misdirected effort
+
+#### 3. The "No Scoring" Backing
+
+Why Ledelse 60:2 doesn't score — and why that's more rigorous.
+
+**Key points:**
+- **Hubbard:** "The most important measurement is knowing what you don't know"
+- **Logan:** Culture stages describe, they don't prescribe. Stage labels are diagnostic, not evaluative.
+- **Pfeffer:** "Numbers are political" — scoring creates gaming, not improvement
+- Scoring implies a single dimension. Organizations are multi-dimensional.
+- Descriptive framing: "Your culture shows Stage 3 patterns" vs. evaluative: "You are Stage 3 (average)"
+- The alternative: pattern recognition + conscious choice, not ranking
+
+#### 4. Integrating the Frames in Practice
+
+How multiframe thinking works in real situations.
+
+**Key points:**
+- **Case 1:** Restructuring — structure first, then culture, then power, then meaning
+- **Case 2:** Merger — symbolic integration before structural; political before HR
+- **Case 3:** Crisis — all four frames simultaneously; no time for sequential analysis
+- The sequence matters: which frame leads depends on context
+
+#### 5. How to Develop Multiframe Capability
+
+Practices for leaders and teams.
+
+**Key points:**
+- Explicit reframing in meetings: "Let's look at this from a [different] perspective"
+- Rotating perspectives: assign each frame to a different person in the room
+- Reading across disciplines: leaders should read outside their function
+- The 60:2 interview itself as multiframe practice: questions force perspective-switching
+
+#### 6. Questions for Multiframe Diagnosis
+
+**Key questions:**
+- Which frame do you reach for first when something goes wrong?
+- When did you last change your mind because of a different perspective?
+- Does your team have a "designated skeptic" for each frame?
+- What would your biggest problem look like through the lens you use least?
+
+## Content Guidelines
+
+### Tone
+
+Synthesizing, authoritative but humble. This is the capstone — it should feel like the article that ties everything together.
+
+### Length
+
+~2000 words (capstone article, longer due to synthesis role), semi-formal, scannable.
+
+### Structure
+
+Follow the existing frame article pattern with expanded synthesis sections:
+1. Hero with intro sentence
+2. Problem framing (Single-Frame Trap)
+3. Core concept (What Multiframe Thinking Is)
+4. Philosophical backing (No Scoring)
+5. Practical application (Integrating in Practice)
+6. Development (How to Develop)
+7. Questions section
+8. CTA linking to Ledelse 60:2
+
+### Citations
+
+- Bolman & Deal (2017) Ch. 16 on frame integration
+- Hubbard (2014) on measurement rigor and knowing uncertainty
+- Logan et al. (2011) on descriptive vs. evaluative culture work
+- Pfeffer (2010) on politics of measurement and scoring
+
+## Design
+
+- **Hero:** Style 2 (banner with text overlay)
+- **Illustrations:** 1 hero banner, 1-2 section illustrations (Style 3)
+- **Images needed:**
+  - Hero: abstract representing multiplicity — four overlapping lenses, prism, or kaleidoscope
+  - Section 3: abstract representing clarity without reduction (perhaps a network or constellation)
+
+## Connections to Site Content
+
+### Link to Ledelse 60:2
+
+CTA section linking to Ledelse 60:2 as the diagnostic tool that operationalizes multiframe thinking — the interview forces perspective-switching through its 60 questions.
+
+### Link to Existing Articles
+- Cross-links from **all four perspektiv articles** in their "Referanser" sections:
+  - "Les om hvordan perspektivene henger sammen i /perspektiv/ →"
+- Link from `/makt/` (multiframe thinking as resolution of power-service tension)
+- Link from `/triader/` (structural tool that serves multiple frames)
+
+### "No Scoring" Integration
+
+This article is the canonical reference for why No Excuse doesn't score. All four frame articles should reference it:
+- In each frame's "Referanser" section: "No Excuse 60:2 er bevisst beskrivende, ikke evaluerende. [Les hvorfor →](/perspektiv/)"
+
+## File
+
+**New file:** `_pages/ledelse_perspektiv.md`
+
+**Frontmatter:**
+```yaml
+---
+layout: page
+title: "Fire perspektiver — Multiframe thinking som lederferdighet"
+description: "Hvorfor en-rame-tenkning feiler, og hvordan multiframe thinking gir bedre diagnostikk. Det egentlige argumentet for 'no scoring'."
+permalink: /perspektiv/
+json_ld:
+  type: "Article"
+  name: "Fire perspektiver"
+  description: "Hvorfor en-rame-tenkning feiler, og hvordan multiframe thinking gir bedre diagnostikk."
+  author:
+    type: "Organization"
+    name: "No Excuse AS"
+  about:
+    - type: "Thing"
+      name: "Bolman og Deals fire rammeverk"
+    - type: "Thing"
+      name: "Multiframe thinking"
+    - type: "Thing"
+      name: "Ledelsesdiagnostikk"
+---
+```
+
+## Dependencies
+
+- 2-3 images (1 hero, 1-2 section illustrations)
+- Cross-links from all four perspektiv articles
+- Link from `/makt/` and potentially `/triader/`
+
+## Acceptance Criteria
+
+- [ ] Article positions multiframe thinking as a skill, not theory
+- [ ] "No Scoring" section is philosophically rigorous (cites Hubbard, Logan, Pfeffer)
+- [ ] Practical cases show integration in action
+- [ ] All four existing perspektiv articles link back to this article
+- [ ] CTA connects to Ledelse 60:2
+- [ ] Brand voice consistent with rest of site
+- [ ] Dark mode tested
+- [ ] Mobile layout tested

--- a/.specs/triader/README.md
+++ b/.specs/triader/README.md
@@ -1,0 +1,178 @@
+# Triader — Article Specification
+
+## Purpose and Scope
+
+Create `_pages/ledelse_triader.md` as a standalone article exploring triads as a structural tool for building resilient teams and organizations, based on Logan, King & Fischer-Wright's *Tribal Leadership* (2011).
+
+## URL
+
+`/triader/`
+
+## Source
+
+- **Primary:** Logan, D., King, J., & Fischer-Wright, H. (2011). *Tribal Leadership: Leveraging Natural Groups to Build a Thriving Organization*. Harper Business.
+- **Related:** Bolman & Deal (2017) Ch. 3 — Structural frame on coordination and role design
+
+## Content Direction
+
+### Theme
+
+Dyads (two-person relationships) are fragile — when one person leaves, the connection breaks. Triads (three-person structures) are resilient. This article explains why triads are the fundamental building block of high-performing teams, how to form them, and what prevents them from working.
+
+### Key Message
+
+The strongest organizational relationships are triangular, not dyadic. Triads create stability, distribute information, and prevent single points of failure in collaboration networks.
+
+### NOT This Article
+
+- General networking advice
+- Team-building exercises
+- Org chart restructuring without cultural backing
+
+### Core Sections
+
+#### 1. The Dyad Problem
+
+Why two-person relationships fail under stress.
+
+**Key points:**
+- Dyads are personal — conflict becomes existential
+- Information is trapped in pairs; others are excluded
+- When one person leaves, knowledge and relationships evaporate
+- Common in Stage 2 ("my life sucks") and early Stage 3 ("I'm great") cultures
+
+#### 2. What Triads Are
+
+Defining the structural form and why it matters.
+
+**Key points:**
+- Three people with mutual, non-exclusive relationships
+- No single person controls the connection
+- Information flows through multiple paths
+- Resilient to any one person leaving
+
+#### 3. Formation: How Triads Emerge
+
+The three conditions for triad formation.
+
+**Key points:**
+- Shared values or purpose (symbolic anchor)
+- Complementary capabilities (structural fit)
+- Willingness to connect others (political generosity)
+- Logan: "Triads only form when people are willing to share their network"
+
+#### 4. Triads in Practice
+
+Examples and applications.
+
+**Key points:**
+- Project triads: sponsor, lead, expert
+- Mentorship triads: mentor, mentee, peer
+- Leadership triads: operational, strategic, people leader
+- Cross-functional triads: bridge-building across silos
+
+#### 5. Warning Signs
+
+When triads don't work or revert to dyads.
+
+**Key points:**
+- Triangulation (talking *about* instead of *with*)
+- Two people colluding against the third
+- Power hoarding — one person refuses to share connections
+- Lack of mutual value — the relationship becomes extractive
+
+#### 6. Questions for Mapping Triads
+
+Diagnostic questions for leaders.
+
+**Key questions:**
+- Who in your team would keep working together even if you left?
+- Are your key relationships dyads or triads?
+- Who benefits when two people in your organization don't talk?
+- What information is trapped in pairwise relationships?
+
+## Content Guidelines
+
+### Tone
+
+Direct, structural, Scandinavian minimal. Focus on practical application, not theory.
+
+### Length
+
+~1500 words, semi-formal, scannable with H2/H3 headers.
+
+### Structure
+
+Follow the existing frame article pattern:
+1. Hero with intro sentence
+2. Problem framing (The Dyad Problem)
+3. Core content (4-5 sections)
+4. Key questions section
+5. CTA linking to Ledelse 60:2
+
+### Citations
+
+- Logan et al. (2011) on triad formation and cultural stages
+- Bolman & Deal (2017) on structural coordination
+
+## Design
+
+- **Hero:** Style 2 (banner with text overlay)
+- **Illustrations:** 1 hero banner, 2 section illustrations (Style 3)
+- **Images needed:** 
+  - Hero: abstract geometric representing three connected nodes
+  - Section 1: dyad vs triad diagram (simple, two vs three circles)
+  - Section 4: network/connection illustration
+
+## Connections to Site Content
+
+### Link to Ledelse 60:2
+
+CTA section linking to Ledelse 60:2 as the diagnostic tool for understanding team structures.
+
+### Link to Existing Articles
+- Cross-link from `/identitet/` (symbolic frame — shared values enable triads)
+- Cross-link from `/usikkerhet/` or `/organisasjonskultur/` (cultural maturity enables triad formation)
+
+## File
+
+**New file:** `_pages/ledelse_triader.md`
+
+**Frontmatter:**
+```yaml
+---
+layout: page
+title: "Triader — Bygg robuste team med trekantede relasjoner"
+description: "Lær hvorfor trekantede relasjoner er sterkere enn to-og-to. Fra dyader til triader — strukturelle verktøy for resilient organisasjon."
+permalink: /triader/
+json_ld:
+  type: "Article"
+  name: "Triader"
+  description: "Hvorfor trekantede relasjoner er sterkere enn to-og-to. Fra dyader til triader."
+  author:
+    type: "Organization"
+    name: "No Excuse AS"
+  about:
+    - type: "Thing"
+      name: "Tribal Leadership"
+    - type: "Thing"
+      name: "Organisasjonsstruktur"
+    - type: "Thing"
+      name: "Teamdynamikk"
+---
+```
+
+## Dependencies
+
+- 3 images (1 hero, 2 section illustrations)
+- Cross-links from existing articles
+
+## Acceptance Criteria
+
+- [ ] Article covers dyad vs triad distinction clearly
+- [ ] Practical examples (project triad, mentorship triad, etc.)
+- [ ] Warning signs section addresses common failure modes
+- [ ] CTA connects to Ledelse 60:2
+- [ ] Brand voice consistent with rest of site
+- [ ] Dark mode tested
+- [ ] Mobile layout tested

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -7,7 +7,7 @@ Completed tasks are tracked in CHANGELOG.md and should not appear here.
 
 ---
 
-## Execution Order (Refined 2026-05-25)
+## Execution Order (Refined 2026-05-26)
 
 Following the design interview and health survey, tasks are grouped into phases that respect dependencies and maximize visible progress.
 
@@ -19,9 +19,45 @@ Phase 0 (Health Sprint), Phase 1 (Quick Wins), Phase 2 (Perspektiv Architecture)
 
 ### Phase 4 — New Articles
 
-*Specs to be created tomorrow (2026-05-26). Implementation after spec review.*
+*Specs created 2026-05-26. Implementation after spec review.*
 
-See `.specs/triader/README.md`, `.specs/makt/README.md`, `.specs/perspektiv/README.md` (to be created).
+See `.specs/triader/README.md`, `.specs/makt/README.md`, `.specs/perspektiv/README.md`.
+
+**N1 — Triader** ✅ Spec complete
+- **New file:** `_pages/ledelse_triader.md`
+- **URL:** `/triader/`
+- **Source:** Logan, King & Fischer-Wright — *Tribal Leadership* (2011)
+- **Spec:** ✅ `.specs/triader/README.md` created
+- **Content:** Triads as structural tool, dyad vs. triad stability, formation steps, warning signs
+- **Design:** Style 3 (Section Illustration) for inline illustrations, Style 2 for hero
+- **Cross-links:** From `/identitet/` and `/usikkerhet/`
+- **Images needed:** 1 hero banner (Style 2), 2 section illustrations (Style 3)
+- **CTA:** Links to Ledelse 60:2
+- **Status:** Spec complete. **Blocked:** Images + content draft needed.
+
+**N2 — Makt eller tjeneste** ✅ Spec complete
+- **New file:** `_pages/ledelse_makt.md`
+- **URL:** `/makt/`
+- **Source:** Pfeffer (*Power*, 2010) ↔ Blanchard & Barrett (*Lead with LUV*, 2011) — tension pair from synthesis.md
+- **Spec:** ✅ `.specs/makt/README.md` created
+- **Content:** The central diagnostic tension: power acquisition vs. servant leadership. Pfeffer side + Blanchard side + spectrum. Includes full "The Price of Power" subsection.
+- **Design:** Style 2 for hero, Style 3 for section illustrations
+- **Cross-links:** To `/påvirkning/` (brief Price of Power there), to `/mennesker/` (servant leadership)
+- **Images needed:** 1 hero banner (Style 2), 2-3 section illustrations (Style 3)
+- **CTA:** Links to Ledelse 60:2
+- **Status:** Spec complete. **Blocked:** Images + content draft needed.
+
+**N3 — Fire perspektiver** ✅ Spec complete
+- **New file:** `_pages/ledelse_perspektiv.md`
+- **URL:** `/perspektiv/`
+- **Source:** Bolman & Deal Ch.16 — "Integrating the Frames"
+- **Spec:** ✅ `.specs/perspektiv/README.md` created
+- **Content:** Multiframe thinking as the actual leadership skill. Why single-frame thinking fails. "No scoring" philosophical backing grounded in Bolman + Hubbard + Logan.
+- **Design:** Style 2 for hero, Style 3 for section illustrations
+- **Cross-links:** To all four perspektiv articles ("no scoring" backing in each frame's reference section)
+- **Images needed:** 1 hero banner (Style 2), 1-2 section illustrations (Style 3)
+- **CTA:** Links to Ledelse 60:2
+- **Status:** Spec complete. **Blocked:** Images + content draft needed.
 
 **N1 — Triader**
 - **New file:** `_pages/ledelse_triader.md`
@@ -58,9 +94,9 @@ See `.specs/triader/README.md`, `.specs/makt/README.md`, `.specs/perspektiv/READ
 
 ---
 
-### Phase 5 — Existing Article Expansions
+### Phase 5 — Existing Article Expansions ✅ COMPLETE
 
-*Depends on N1-N3 existing. Order: E1 → E2/E3 → E4 → E5 → E6.*
+*Completed 2026-05-26. See CHANGELOG.md [1.6.0].*
 
 See relevant spec files for each expansion.
 
@@ -126,37 +162,13 @@ See relevant spec files for each expansion.
 
 ---
 
-### Phase 7 — Assets & Performance
+### Phase 7 — Assets & Performance ✅ COMPLETE
 
-*Batch operations after all content and UI work is done.*
+*Completed 2026-05-26. See CHANGELOG.md [1.6.0].*
 
-**Image Optimization**
+**Image Optimization** ✅ All tasks complete
 
-See `.specs/image-optimization/README.md` and `.design/graphics.md` §Image Resize Guidelines.
-
-Convert all PNG images to WebP format with appropriate resizing for web performance.
-
-- [ ] **IMG1:** Create `.design/graphics/originals/` directory structure
-- [ ] **IMG2:** Copy all 44 PNG files to `.design/graphics/originals/` preserving folder structure
-- [ ] **IMG3:** Convert banners (32 files) — 1920×1080 max, quality 85
-- [ ] **IMG4:** Convert icons (9 files) — 512×512 max, quality 85
-- [ ] **IMG5:** Convert hero/illustration images — 1920×1080 max, quality 85
-- [ ] **IMG6:** Convert logo files (2 files) — 400×400 max, quality 85
-- [ ] **IMG7:** Convert profile photos (1 file) — 400×400 max, quality 85
-- [ ] **IMG8:** Delete original PNG files from `assets/images/`
-- [ ] **IMG9:** Update `.design/graphics.md` with resize guidelines section
-
-**SEO Foundation**
-
-See `.specs/seo/README.md` for full specification.
-
-- [ ] **S1:** Generate comprehensive sitemap.xml with all pages, products, profiles
-- [ ] **S2:** Add canonical URLs to metadata.html
-- [ ] **S3:** Implement page-specific meta description fallback
-- [ ] **S4:** Update robots.txt with sitemap reference
-- [ ] **S5:** Create site.webmanifest (PWA manifest)
-- [ ] **S6:** Add BreadcrumbList JSON-LD to all pages
-- [ ] **S7:** Add FAQPage schema to /tillit/ and relevant content pages
+**SEO Foundation** ✅ All tasks complete
 
 ---
 
@@ -225,9 +237,9 @@ When generating images for N1-N3 and future content, ensure maximum context is k
 
 | Spec file | Action | Purpose | Status |
 |-----------|--------|---------|--------|
-| `.specs/triader/README.md` | **Create** | Triader article: concept, mechanics, formation, cross-links | **Blocked: tomorrow** |
-| `.specs/makt/README.md` | **Create** | Makt article: Pfeffer vs. Blanchard tension, Price of Power full | **Blocked: tomorrow** |
-| `.specs/perspektiv/README.md` | **Create** | Perspektiv article: multiframe thinking, "no scoring" backing | **Blocked: tomorrow** |
+| `.specs/triader/README.md` | ✅ **Created** | Triader article: concept, mechanics, formation, cross-links | **Ready for review** |
+| `.specs/makt/README.md` | ✅ **Created** | Makt article: Pfeffer vs. Blanchard tension, Price of Power full | **Ready for review** |
+| `.specs/perspektiv/README.md` | ✅ **Created** | Perspektiv article: multiframe thinking, "no scoring" backing | **Ready for review** |
 | `.specs/organisasjonskultur/README.md` | **Update** | Add Kotter 8-step + "organisert anarki" integration | Ready |
 | `.specs/grc/README.md` | **Update** | Confirm E1-E6 integration points | Ready |
 | `.specs/ledelse-60-2/README.md` | **Update** | Reflect N1-N3 additions, E1-E6 expansions | Ready |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Specifications for N1-N3 new articles: `.specs/triader/README.md`, `.specs/makt/README.md`, `.specs/perspektiv/README.md`
+
+### Changed
+
+- "Les mer →" benefit card links restyled as pill buttons with accent color, hover lift effect, and 44px minimum touch target
+- Benefit cards redesigned with image + content separation, flexbox layout, and enhanced shadows
+- Navbar links increased to 44px touch targets with hover background and dark mode support
+- Header stacks vertically on mobile (<600px) for better logo + navigation fit
+
 ## [1.6.0] - 2026-05-26
 
 ### Added

--- a/_pages/ledelse_60-2.md
+++ b/_pages/ledelse_60-2.md
@@ -56,27 +56,35 @@ json_ld:
     <div class="landing-benefits-grid stagger-parent" style="--stagger-delay: 100ms;">
         <div class="benefit-card animate-on-scroll fade-in-up stagger">
             <img src="{{ '/assets/images/banners/benefit-control.webp' | relative_url }}" alt="Få kontroll uten byråkrati" class="benefit-banner">
-            <h3>Bedre ledelse uten byråkrati</h3>
-            <p>Styrk den tillitsbaserte ledelsen fremfor rutiner og skjema. Dyrk engasjement og eierskap blant ansatte, ikke regler og regimer. Ikke fall for fristelsen å møte økt kompleksitet med micromanagement og mistenksomhet - ha tro på at ansatte kan bruke sunn fornuft!</p>
-            <a href="{{ '/tillit/' | relative_url }}" class="benefit-link">Les artikkelen →</a>
+            <div class="benefit-card-content">
+                <h3>Bedre ledelse uten byråkrati</h3>
+                <p>Styrk den tillitsbaserte ledelsen fremfor rutiner og skjema. Dyrk engasjement og eierskap blant ansatte, ikke regler og regimer.</p>
+                <a href="{{ '/tillit/' | relative_url }}" class="benefit-link">Les artikkelen →</a>
+            </div>
         </div>
         <div class="benefit-card animate-on-scroll fade-in-up stagger">
             <img src="{{ '/assets/images/banners/benefit-ai.webp' | relative_url }}" alt="Oppnå målbare gevinster med KI" class="benefit-banner">
-            <h3>Målbare gevinster med GenKI</h3>
-            <p>Generativ KI vil ikke gjøre ansatte overflødige, men de må ledes annerledes. Alle proklamerer om hvor bra KI er som teknologi og skal selge programvare, men få snakker om hvordan å utvikle de ansatte som KI-ledere.</p>
-            <a href="{{ '/generativ-ki/' | relative_url }}" class="benefit-link">Les artikkelen →</a>
+            <div class="benefit-card-content">
+                <h3>Målbare gevinster med GenKI</h3>
+                <p>Generativ KI vil ikke gjøre ansatte overflødige, men de må ledes annerledes. Få snakker om hvordan å utvikle de ansatte som KI-ledere.</p>
+                <a href="{{ '/generativ-ki/' | relative_url }}" class="benefit-link">Les artikkelen →</a>
+            </div>
         </div>
         <div class="benefit-card animate-on-scroll fade-in-up stagger">
             <img src="{{ '/assets/images/banners/benefit-future.webp' | relative_url }}" alt="Bli forberedt på en usikker fremtid" class="benefit-banner">
-            <h3>Bli forberedt på en usikker fremtid</h3>
-            <p>Styr unna uønskede hendelser og fang mulighetene som byr seg. En moden ledelse ligger i forkant av endringer for å holde stø kurs. Forankre krav til informasjonssikkerhet, kvalitet og miljø på riktig sted: I ledelsen.</p>
-            <a href="{{ '/organisasjonskultur/' | relative_url }}" class="benefit-link">Les artikkelen →</a>
+            <div class="benefit-card-content">
+                <h3>Bli forberedt på en usikker fremtid</h3>
+                <p>Styr unna uønskede hendelser og fang mulighetene som byr seg. En moden ledelse ligger i forkant av endringer.</p>
+                <a href="{{ '/organisasjonskultur/' | relative_url }}" class="benefit-link">Les artikkelen →</a>
+            </div>
         </div>
         <div class="benefit-card animate-on-scroll fade-in-up stagger">
             <img src="{{ '/assets/images/banners/benefit-anchoring.webp' | relative_url }}" alt="Forankre initiativer i ledergruppen" class="benefit-banner">
-            <h3>Forankre initiativer i ledergruppen</h3>
-            <p>Skap en bedre felles forståelse av grunnlaget for nye initiativer så ressursene kan brukes for å håndtere de viktigste mulighetene og risikoene. Ledere som ser saken fra ulike perspektiver har større gjennomføringskraft.</p>
-            <a href="{{ '/forankring/' | relative_url }}" class="benefit-link">Les artikkelen →</a>
+            <div class="benefit-card-content">
+                <h3>Forankre initiativer i ledergruppen</h3>
+                <p>Skap en bedre felles forståelse av grunnlaget for nye initiativer. Ledere som ser saken fra ulike perspektiver har større gjennomføringskraft.</p>
+                <a href="{{ '/forankring/' | relative_url }}" class="benefit-link">Les artikkelen →</a>
+            </div>
         </div>
     </div>
 </section>

--- a/assets/css/article.css
+++ b/assets/css/article.css
@@ -192,15 +192,24 @@
 }
 
 .benefit-link {
-    display: inline-block;
-    margin-top: 12px;
-    font-size: 0.9em;
-    color: var(--link-color-light);
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    margin-top: 16px;
+    padding: 10px 20px;
+    font-size: 0.95em;
+    font-weight: 500;
+    color: var(--primary-accent-contrast);
+    background-color: var(--primary-accent);
     text-decoration: none;
+    border-radius: 8px;
+    min-height: 44px;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .benefit-link:hover {
-    text-decoration: underline;
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px rgba(0,0,0,0.15);
 }
 
 .section-illustration {
@@ -226,6 +235,11 @@
 
 .dark-mode .frame-breadcrumb a {
     color: var(--link-color-dark);
+}
+
+.dark-mode .benefit-link {
+    color: var(--primary-accent-contrast);
+    background-color: var(--primary-accent);
 }
 
 @media (max-width: 768px) {

--- a/assets/css/header.css
+++ b/assets/css/header.css
@@ -43,3 +43,15 @@
 .dark-mode .logo-dark {
     display: block;
 }
+
+@media (max-width: 599px) {
+    .banner {
+        flex-direction: column;
+        gap: 12px;
+        padding: 12px 16px;
+    }
+
+    .logo {
+        height: 40px;
+    }
+}

--- a/assets/css/navbar.css
+++ b/assets/css/navbar.css
@@ -2,30 +2,45 @@
     display: flex;
     justify-content: center;
     align-items: center;
-    gap: 32px;
-    padding: 10px 0;
-    background-color: var(--navbar-background);
+    gap: 8px;
+    padding: 8px 0;
 }
 
 .navbar a {
     text-decoration: none;
-    color: var(--navbar-link-color);
-    font-size: 1.1em;
+    color: var(--link-color-light);
+    font-size: 1.05em;
     font-weight: 600;
-    transition: color 0.3s ease, opacity 0.3s ease;
+    padding: 10px 16px;
+    min-height: 44px;
+    display: flex;
+    align-items: center;
+    border-radius: 8px;
+    transition: color 0.2s ease, background-color 0.2s ease;
 }
 
 .navbar a:hover {
-    color: var(--navbar-link-hover-color);
-    opacity: 0.8;
+    color: var(--link-hover-light);
+    background-color: rgba(0, 0, 0, 0.05);
+}
+
+.dark-mode .navbar a {
+    color: var(--link-color-dark);
+}
+
+.dark-mode .navbar a:hover {
+    color: var(--link-hover-dark);
+    background-color: rgba(255, 255, 255, 0.1);
 }
 
 @media (max-width: 599px) {
     .navbar {
-        gap: 20px;
+        gap: 4px;
+        padding: 4px 0;
     }
 
     .navbar a {
         font-size: 0.95em;
+        padding: 8px 12px;
     }
 }

--- a/assets/css/products.css
+++ b/assets/css/products.css
@@ -92,35 +92,47 @@
 }
 
 .benefit-card {
-    padding: 24px;
-    border-radius: 12px;
+    padding: 0;
+    border-radius: 16px;
     box-shadow: var(--box-shadow-light);
     background-color: var(--box-background-light);
-    transition: transform 0.2s;
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
 }
 
 .benefit-card:hover {
-    transform: translateY(-4px);
-    box-shadow: 0 12px 24px rgba(0,0,0,0.1);
+    transform: translateY(-6px);
+    box-shadow: 0 16px 32px rgba(0,0,0,0.12);
 }
 
 .benefit-banner {
     width: 100%;
     aspect-ratio: 16/9;
     object-fit: cover;
-    border-radius: 8px;
-    margin-bottom: 12px;
+    display: block;
+}
+
+.benefit-card-content {
+    padding: 24px;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
 }
 
 .benefit-card h4 {
-    font-size: 1.1em;
-    margin-bottom: 8px;
+    font-size: 1.15em;
+    margin-bottom: 12px;
+    line-height: 1.3;
 }
 
 .benefit-card p {
     font-size: 0.95em;
-    line-height: 1.5;
-    opacity: 0.8;
+    line-height: 1.6;
+    opacity: 0.85;
+    margin-bottom: 16px;
+    flex: 1;
 }
 
 .product-cta-footer {
@@ -348,8 +360,12 @@
     color: var(--banner-text-dark);
 }
 
+.dark-mode .benefit-card {
+    background-color: var(--box-background-dark);
+}
+
 .dark-mode .benefit-card:hover {
-    box-shadow: 0 12px 24px rgba(0,0,0,0.3);
+    box-shadow: 0 16px 32px rgba(0,0,0,0.4);
 }
 
 .dark-mode .process-step:hover {


### PR DESCRIPTION
## Summary

Fortsettelse av site review med UI-forbedringer og spesifikasjoner for nye artikler.

## Endringer

### Style
- **Knapper**: "Les mer →" links omgjort til pill-knapper med accent-farge, hover lift-effekt, og 44px touch target
- **Benefit-kort**: Bilde + innhold separasjon, flexbox-layout for konsistent høyde, forbedrede skygger og hover-effekter
- **Navbar**: 44px minimum touch targets, hover-bakgrunn, mobil-tilpasning (<600px)
- **Header**: Vertikal stack på mobil for bedre logo+nav pasning

### Specs
- `.specs/triader/README.md` — Triader som strukturelt verktøy (N1)
- `.specs/makt/README.md` — Maktspektrum vs servant leadership (N2)
- `.specs/perspektiv/README.md` — Multiframe thinking og "no scoring" backing (N3)

## Sjekkliste
- [x] Branch fra oppdatert main (04d2b81)
- [x] Cherry-pick av commits som ble pushet direkte til main
- [x] Ingen breaking changes
- [x] Mørk modus støttet
- [x] Mobil-layout bevart
