### PR TITLE
fix(perspektiv): restore content and images on all 4 perspektiv pages

### DIFF
--- a/_layouts/perspektiv.html
+++ b/_layouts/perspektiv.html
@@ -4,7 +4,7 @@ layout: page
 
 <link rel="stylesheet" href="{{ '/assets/css/perspektiv-styles.css' | relative_url }}">
 
-{% assign frame_id = page.url | remove_first: '/' | split: '/' | first %}
+{% assign frame_id = page.frame_id %}
 {% assign frame = site.frames | where: "id", frame_id | first %}
 
 <!-- Hero Section -->

--- a/_pages/ledelse_identitet.md
+++ b/_pages/ledelse_identitet.md
@@ -2,4 +2,5 @@
 layout: perspektiv
 title: "Identitetsperspektivet i ledelse"
 permalink: /identitet/
+frame_id: identitet
 ---

--- a/_pages/ledelse_mennesker.md
+++ b/_pages/ledelse_mennesker.md
@@ -2,4 +2,5 @@
 layout: perspektiv
 title: "Menneskeperspektivet i ledelse"
 permalink: /mennesker/
+frame_id: mennesker
 ---

--- a/_pages/ledelse_påvirkning.md
+++ b/_pages/ledelse_påvirkning.md
@@ -2,4 +2,5 @@
 layout: perspektiv
 title: "Påvirkningsperspektivet i ledelse"
 permalink: /påvirkning/
+frame_id: påvirkning
 ---

--- a/_pages/ledelse_struktur.md
+++ b/_pages/ledelse_struktur.md
@@ -2,4 +2,5 @@
 layout: perspektiv
 title: "Strukturperspektivet i ledelse"
 permalink: /struktur/
+frame_id: struktur
 ---


### PR DESCRIPTION
## Summary

Perspektiv-artiklene (Struktur, Mennesker, Identitet, Påvirkning) viste tomme sider fordi layoutet ikke fant frame-data.

## Root Cause

URL-parsing for å finne frame_id var ustabil. Nå brukes eksplisitt `frame_id` i page frontmatter.

## Changes

- Added `frame_id` to all 4 perspektiv pages' frontmatter
- Updated `_layouts/perspektiv.html` to use `page.frame_id` instead of URL parsing

## Testing

- [x] Layout henter nå riktig frame fra `site.frames`
- [x] H1, breadcrumb, og all seksjonsinnhold vises
- [x] Bilder lastes korrekt

## Self-Review

- [x] Bug fix minimal og målrettet
- [x] Ingen breaking changes
- [x] Branch opprettet fra main