### PR TITLE
docs: harmonize design documentation from design interview

### DIFF
--- a/.design/brand-perception.md
+++ b/.design/brand-perception.md
@@ -1,17 +1,29 @@
 # Brand Perception & Tone Guide - No Excuse AS
 
 ## Brand Personality
-- **Direct:** Say what we mean, no consultant-speak
+- **Direct & Clear:** Say what we mean, no consultant-speak. Easy to understand, impossible to misinterpret.
 - **Competent:** Proven results, real experience
-- **Scandinavian minimal:** Clean, functional, no fluff
-- **Anti-establishment:** Question the obvious, challenge conventions
+- **Nordic (Scandinavian minimal):** Clean, functional, no fluff. Democratic design — accessible to everyone, not exclusive.
+- **Rebellious / Anti-establishment:** Question the obvious, challenge conventions. We say what others think.
+- **Practical:** «Folk som synes latte er pretensiøst» — down-to-earth, no bullshit
 
 ## Target Perception
-- "We say what others think but don't say out loud" - slightly rebellious
+- "We say what others think but don't say out loud" — slightly rebellious
 - "These guys actually get it done"
 - "Not another consultancy with fancy words"
 - "Practical, not pretentious"
 - "They sound like real people"
+- "Premium, not pretentious" — like Apple, not like luxury
+
+## Visual Reference: Apple.com
+The primary visual reference for premium minimalism is **Apple.com**. Key qualities to borrow:
+- Confident whitespace — content breathes, nothing feels cramped
+- Typography-driven hierarchy — words do the heavy lifting
+- Restrained color — one accent color used sparingly (buttons, links, small highlights)
+- Photography as human element — real people in real settings breaks the minimal sterility
+- Everything has a reason — no decorative elements, no visual noise
+
+This is about the *visual tone* of Apple (premium, confident, effortless), not about mimicking their product layout or interaction patterns.
 
 ## Voice Guidelines
 

--- a/.design/colors.md
+++ b/.design/colors.md
@@ -102,3 +102,14 @@ These aliases ensure components using the old variable names still work.
 - Nav links use the inverted twin primary to contrast with the header background
 - Logo fill swaps via `--logo-fill` CSS variable — controlled by mode stylesheets on `.header`
 - Page link colors (`--link-color-light`/`--link-color-dark`) are for content links only; nav links use `--nav-link-*` variables
+
+### Color Intensity Levels
+
+Color is used sparingly — the brand is primarily typography and whitespace. There are two levels of color application:
+
+| Level | Application | Examples |
+|-------|-------------|---------|
+| **Full background** | Key navigational and structural elements only | Header, CTA buttons |
+| **Accent** (sparingly) | Interactive and highlight elements | Links on hover, small decorative accents, icons |
+
+Rule of thumb: if an element isn't structural (navigation) or a primary action (CTA), it should not use a full background color. Accent-level usage (text color, small highlights) is preferred for everything else.

--- a/.design/graphics.md
+++ b/.design/graphics.md
@@ -2,13 +2,18 @@
 
 ## Brand Aesthetic
 
-**Scandinavian minimal** — clean lines, generous whitespace, restrained color palette. Think IKEA meets Kinfolk magazine.
+**Scandinavian minimal / Nordic** — clean lines, generous whitespace, restrained color palette. Think IKEA meets Kinfolk magazine with Apple.com's confident minimalism.
+
+**Democratic design** — accessible to everyone, clear and open, no elitism. The minimalism serves *clarity and function*, not just aesthetics. If a visual choice makes something harder to understand, it's wrong regardless of how good it looks.
 
 **Core principles:**
 - Abstract over literal
 - Structural over decorative
 - Monochromatic with single accent (azure)
 - No text in any image (multilingual site)
+- Premium, not pretentious — confidence through restraint
+
+**Visual reference:** Apple.com (see `brand-perception.md` for details). Borrow the confidence in whitespace and typography-driven hierarchy, not the layout or interaction patterns.
 
 ## Color Palette for Generated Images
 
@@ -148,6 +153,47 @@ blue green amber purple tones, corporate illustration, no text
 | File | Prompt |
 |------|--------|
 | `illustrasjon-*.cta.png` | "Clean minimal infographic showing leadership assessment and mapping process, clipboard with checkmarks, professional Scandinavian style, blue green amber purple tones, corporate illustration, no text" |
+
+---
+
+## Photography Guidelines
+
+While illustrations form the primary visual language, real photography is used selectively to add human warmth and credibility.
+
+### Where to Use Photos
+
+| Context | Use Photography | Why |
+|---------|----------------|-----|
+| Team profiles (`_profiles/*.md`) | ✅ Always | Real faces build trust |
+| Case studies (`_cases/*.md`) | ✅ Recommended | Real clients / settings ground the stories |
+| Hero sections | ❌ Use illustrations | Abstract illustrations support the brand better |
+| Benefit banners | ❌ Use illustrations | Illustrations communicate concepts cleaner |
+
+### Photo Style
+
+- **Natural light, not studio** — authentic, not corporate
+- **Candid over posed** — real moments, not stiff handshakes
+- **Environmental portraits** — show the person in their context (office, meeting room, not a white backdrop)
+- **Desaturated color palette** — tone down saturation to ~70% to harmonize with the muted illustration palette
+- **No staged business photos** — no fake phone calls, no whiteboard pointing, no crossed-arms-in-suit
+
+### Technical Requirements
+
+- Minimum resolution: 1200×1200px for full-width use
+- Format: WebP (converted from original PNG/JPEG)
+- Aspect ratio 1:1 for profile cards (displayed 100×100px)
+- Aspect ratio 16:9 for case study hero images
+- All photos must have descriptive `alt` text in Norwegian (see Alt Text section)
+
+### Examples
+
+✅ Good:
+
+> A person in a sweater sits at a wooden meeting table, mid-laugh, natural window light from the side. Desaturated colors, muted background.
+
+❌ Avoid:
+
+> A person in a suit shakes hands with another person in a suit in front of a gradient backdrop. Over-lit, over-saturated, corporate stock photo energy.
 
 ---
 

--- a/.design/ui-upgrade.md
+++ b/.design/ui-upgrade.md
@@ -10,18 +10,28 @@ Visual design upgrade for No Excuse AS article pages. This document describes th
 
 ### Motion Philosophy
 
-Animations are **purposeful and restrained** — they guide attention and communicate state, never distract. They reinforce the Scandinavian minimal brand: clean, functional, no excess.
+Animations follow a **layered approach** — expressive on brand surfaces, restrained on UI:
+
+| Layer | Treatment | When |
+|-------|-----------|------|
+| **Brand surfaces** (hero, page transitions, logo) | Expressive, memorable, bold | First impressions, brand moments |
+| **UI interactions** (cards, buttons, lists, micro-interactions) | Purposeful and restrained, never distracting | User interactions, scroll-triggered entries |
+
+This maps to the brand personality: rebellious confidence on brand surfaces, Scandinavian minimalism on UI. Both layers must feel like the same brand — the difference is volume, not character.
 
 ### Animation Types
 
-| Animation | Trigger | Duration | Easing | Use Case |
-|-----------|---------|----------|--------|----------|
-| `fadeIn` | viewport entry | 600ms | ease-out | Section containers |
-| `fadeInUp` | viewport entry | 600ms | ease-out | Cards, content blocks |
-| `slideInLeft` | viewport entry | 500ms | ease-out | Question list items |
-| `slideInRight` | viewport entry | 500ms | ease-out | (reserved) |
-| Micro-interaction | hover | 200ms | ease | Buttons, links |
-| Card lift | hover | 300ms | ease | Benefit cards, case cards |
+| Animation | Trigger | Duration | Easing | Use Case | Layer |
+|-----------|---------|----------|--------|----------|-------|
+| `heroReveal` | page load | 800ms | ease-out | Hero title, intro text | **Brand** |
+| `heroImageReveal` | page load | 1200ms | ease-out | Hero image scale-in | **Brand** |
+| `pageTransition` | page enter | 400ms | ease-out | Page-level entrance | **Brand** |
+| `fadeIn` | viewport entry | 600ms | ease-out | Section containers | UI |
+| `fadeInUp` | viewport entry | 600ms | ease-out | Cards, content blocks | UI |
+| `slideInLeft` | viewport entry | 500ms | ease-out | Question list items | UI |
+| `slideInRight` | viewport entry | 500ms | ease-out | (reserved) | UI |
+| Micro-interaction | hover | 200ms | ease | Buttons, links | UI |
+| Card lift | hover | 300ms | ease | Benefit cards, case cards | UI |
 
 ### Intersection Observer Configuration
 
@@ -37,6 +47,45 @@ Animations are **purposeful and restrained** — they guide attention and commun
 ### Keyframe Definitions
 
 ```css
+/* --- Brand Surface Animations (Expressive) --- */
+
+@keyframes heroReveal {
+    from {
+        opacity: 0;
+        transform: translateY(40px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@keyframes heroImageReveal {
+    from {
+        opacity: 0;
+        transform: scale(1.05);
+        filter: blur(4px);
+    }
+    to {
+        opacity: 1;
+        transform: scale(1);
+        filter: blur(0);
+    }
+}
+
+@keyframes pageTransition {
+    from {
+        opacity: 0;
+        transform: translateY(20px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+/* --- UI Animations (Restrained) --- */
+
 @keyframes fadeIn {
     from { opacity: 0; }
     to { opacity: 1; }
@@ -100,7 +149,7 @@ Children animate sequentially with CSS variable `--stagger-delay`:
 
 ### Reduced Motion
 
-For users with `prefers-reduced-motion: reduce`:
+For users with `prefers-reduced-motion: reduce` — all animations (brand and UI) are disabled:
 ```css
 @media (prefers-reduced-motion: reduce) {
     .animate-on-scroll {
@@ -110,6 +159,17 @@ For users with `prefers-reduced-motion: reduce`:
     .animate-on-scroll.is-visible {
         opacity: 1;
         transform: none;
+    }
+
+    /* Brand surface animations */
+    .hero-title,
+    .hero-intro,
+    .hero-image,
+    .page-transition {
+        animation: none !important;
+        opacity: 1;
+        transform: none;
+        filter: none;
     }
 }
 ```
@@ -186,12 +246,12 @@ background: linear-gradient(
 
 ### Animation Sequence (Hero Load)
 
-| Time | Action |
-|------|--------|
-| 0ms | Page loads, image visible |
-| 0ms | Title begins fadeInUp (0.8s duration) |
-| 150ms | Intro begins fadeInUp (0.8s duration, 150ms delay) |
-| 200ms | Breadcrumb fades in |
+| Time | Action | Animation |
+|------|--------|-----------|
+| 0ms | Page loads | Hero image begins `heroImageReveal` (1.2s) |
+| 200ms | Title begins entrance | `heroReveal` (0.8s) |
+| 350ms | Intro begins entrance | `heroReveal` (0.8s, added delay) |
+| 400ms | Breadcrumb fades in | `fadeIn` (0.6s) |
 
 ---
 
@@ -442,8 +502,10 @@ assets/
 
 ## 13. Animation Performance
 
-- Use `transform` and `opacity` only (GPU-accelerated)
+- Use `transform` and `opacity` for UI animations (GPU-accelerated, cheap)
+- `filter: blur()` is GPU-accelerated but more expensive — reserve for hero/brand animations only (one-shot)
 - No layout-triggering properties (width, height, margin, padding)
 - `will-change: transform, opacity` on `.animate-on-scroll` elements
+- `will-change: transform, opacity, filter` on hero elements (removed after animation completes)
 - Intersection Observer for efficient scroll detection
 - One-shot animations (no `animation-iteration-count` looping)

--- a/.specs/ui-upgrade/README.md
+++ b/.specs/ui-upgrade/README.md
@@ -28,9 +28,19 @@ This is a pure visual/styling upgrade — no content changes, no structural chan
 
 ### 1. CSS Animation Module (`animations.css`)
 
-New module providing scroll-triggered animations via Intersection Observer.
+New module providing scroll-triggered and page-load animations via Intersection Observer.
 
-**Classes:**
+**Motion Philosophy:** Animations follow a layered approach — expressive on brand surfaces, restrained on UI:
+- **Brand surfaces** (hero, page transitions): Expressive, memorable — `heroReveal`, `heroImageReveal`, `pageTransition`
+- **UI interactions** (cards, buttons, scroll-triggered): Purposeful, restrained — `fadeIn`, `fadeInUp`, `slideInLeft`, `slideInRight`
+
+**Classes (Brand):**
+- `.hero-title` — page-load entrance via `heroReveal` (0.8s ease-out)
+- `.hero-intro` — page-load entrance via `heroReveal` (0.8s ease-out, delayed)
+- `.hero-image` — page-load scale-in via `heroImageReveal` (1.2s ease-out)
+- `.page-transition` — page-level entrance (0.4s ease-out)
+
+**Classes (UI):**
 - `.animate-on-scroll` — base class that triggers animation when element enters viewport
 - `.fade-in` — opacity 0 → 1, duration 0.6s
 - `.fade-in-up` — opacity 0 + translateY(30px) → opacity 1 + translateY(0), duration 0.6s
@@ -43,7 +53,14 @@ New module providing scroll-triggered animations via Intersection Observer.
 --stagger-delay: 0ms; /* Set per parent to stagger children */
 ```
 
-**Keyframes:**
+**Keyframes (Brand):**
+```css
+@keyframes heroReveal { ... }
+@keyframes heroImageReveal { ... }
+@keyframes pageTransition { ... }
+```
+
+**Keyframes (UI):**
 ```css
 @keyframes fadeInUp { ... }
 @keyframes fadeIn { ... }
@@ -55,11 +72,19 @@ New module providing scroll-triggered animations via Intersection Observer.
 ```css
 @media (prefers-reduced-motion: reduce) {
     .animate-on-scroll { animation: none; transition: none; }
+    .animate-on-scroll.is-visible { opacity: 1; transform: none; }
+    .hero-title, .hero-intro, .hero-image, .page-transition {
+        animation: none !important;
+        opacity: 1;
+        transform: none;
+        filter: none;
+    }
 }
 ```
 
 **JavaScript:**
-- Intersection Observer in `assets/scripts/animations.js`
+- Page-load: Hero elements animate on DOMContentLoaded (one-shot)
+- Intersection Observer in `assets/scripts/animations.js` for scroll-triggered elements
 - Adds `.is-visible` class when element enters viewport (threshold: 0.15)
 - Disconnect after first trigger (one-shot animations)
 
@@ -96,9 +121,11 @@ Changes the article hero from separate image + content sections to a single imag
 - `.dark-mode .article-hero-overlay` — background gradient adjusts for dark theme
 - Text color remains `var(--banner-text-dark)` which is azure (#F0FFFF)
 
-**Animation:**
-- Title fades in with `fadeInUp` (0.8s ease-out)
-- Intro paragraph fades in with `fadeInUp` (0.8s ease-out, 0.15s delay)
+**Animation (Brand layer — expressive):**
+- Hero image scale-in with `heroImageReveal` (1.2s ease-out, starts at 0ms)
+- Title entrance with `heroReveal` (0.8s ease-out, starts at 200ms)
+- Intro paragraph entrance with `heroReveal` (0.8s ease-out, starts at 350ms)
+- Breadcrumb fades in with `fadeIn` (0.6s, starts at 400ms)
 
 **Mobile:**
 - Overlay padding reduces to 20px
@@ -210,7 +237,7 @@ Same treatment for `/om-oss/` hero.
 | `assets/css/products.css` | **Update** | Hero gradient overlay, hover interactions |
 | `assets/css/about.css` | **Update** | Hero gradient overlay |
 | `assets/css/styles-dark.css` | **Update** | Dark mode for overlay elements |
-| `assets/scripts/animations.js` | **Create** | Scroll animation controller |
+| `assets/scripts/animations.js` | **Create** | Page-load brand animations + scroll animation controller |
 | `_includes/scripts.html` | **Update** | Include animations.js |
 
 ## CSS Architecture Compliance
@@ -231,6 +258,7 @@ Per `.opencode/rules/css/rules.md`:
 
 ## Testing Checklist
 
+- [ ] Brand animations (heroReveal, heroImageReveal) trigger correctly on page load
 - [ ] Scroll animations trigger correctly on all article pages
 - [ ] Hero overlay renders correctly with banner images
 - [ ] Typography scale consistent across all pages

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -19,45 +19,7 @@ Phase 0 (Health Sprint), Phase 1 (Quick Wins), Phase 2 (Perspektiv Architecture)
 
 ### Phase 4 — New Articles
 
-*Specs created 2026-05-26. Implementation after spec review.*
-
-See `.specs/triader/README.md`, `.specs/makt/README.md`, `.specs/perspektiv/README.md`.
-
-**N1 — Triader** ✅ Spec complete
-- **New file:** `_pages/ledelse_triader.md`
-- **URL:** `/triader/`
-- **Source:** Logan, King & Fischer-Wright — *Tribal Leadership* (2011)
-- **Spec:** ✅ `.specs/triader/README.md` created
-- **Content:** Triads as structural tool, dyad vs. triad stability, formation steps, warning signs
-- **Design:** Style 3 (Section Illustration) for inline illustrations, Style 2 for hero
-- **Cross-links:** From `/identitet/` and `/usikkerhet/`
-- **Images needed:** 1 hero banner (Style 2), 2 section illustrations (Style 3)
-- **CTA:** Links to Ledelse 60:2
-- **Status:** Spec complete. **Blocked:** Images + content draft needed.
-
-**N2 — Makt eller tjeneste** ✅ Spec complete
-- **New file:** `_pages/ledelse_makt.md`
-- **URL:** `/makt/`
-- **Source:** Pfeffer (*Power*, 2010) ↔ Blanchard & Barrett (*Lead with LUV*, 2011) — tension pair from synthesis.md
-- **Spec:** ✅ `.specs/makt/README.md` created
-- **Content:** The central diagnostic tension: power acquisition vs. servant leadership. Pfeffer side + Blanchard side + spectrum. Includes full "The Price of Power" subsection.
-- **Design:** Style 2 for hero, Style 3 for section illustrations
-- **Cross-links:** To `/påvirkning/` (brief Price of Power there), to `/mennesker/` (servant leadership)
-- **Images needed:** 1 hero banner (Style 2), 2-3 section illustrations (Style 3)
-- **CTA:** Links to Ledelse 60:2
-- **Status:** Spec complete. **Blocked:** Images + content draft needed.
-
-**N3 — Fire perspektiver** ✅ Spec complete
-- **New file:** `_pages/ledelse_perspektiv.md`
-- **URL:** `/perspektiv/`
-- **Source:** Bolman & Deal Ch.16 — "Integrating the Frames"
-- **Spec:** ✅ `.specs/perspektiv/README.md` created
-- **Content:** Multiframe thinking as the actual leadership skill. Why single-frame thinking fails. "No scoring" philosophical backing grounded in Bolman + Hubbard + Logan.
-- **Design:** Style 2 for hero, Style 3 for section illustrations
-- **Cross-links:** To all four perspektiv articles ("no scoring" backing in each frame's reference section)
-- **Images needed:** 1 hero banner (Style 2), 1-2 section illustrations (Style 3)
-- **CTA:** Links to Ledelse 60:2
-- **Status:** Spec complete. **Blocked:** Images + content draft needed.
+*Specs created 2026-05-26. N1 (Triader), N2 (Makt), N3 (Perspektiv) moved to **Blocked** section — waiting on article content from user. See `.specs/triader/README.md`, `.specs/makt/README.md`, `.specs/perspektiv/README.md` for specs.*
 
 ---
 
@@ -297,6 +259,35 @@ See relevant spec files for each expansion.
 
 ---
 
+### Phase 12 — Design Alignment (Post-Interview)
+
+*Tasks identified from design interview conflict resolution and documentation harmonization.*
+
+**F5 — Bildegenerering (oppdatert design) → moved to Blocked**
+- *F5 is blocked waiting on N1-N3 article content (must be drafted and approved before image generation, per Image Generation Context Requirements). See Blocked section.*
+
+**F6 — Animasjonsimplementering (layered approach)**
+- **Scope:** Implement the layered animation system from updated `.design/ui-upgrade.md`
+- **Brand layer:** `heroReveal`, `heroImageReveal`, `pageTransition` keyframes + CSS classes + JS trigger
+- **UI layer:** Existing scroll-triggered animations stay (fadeInUp, slideInLeft, etc.)
+- **Reduced motion:** Extended to cover brand animation classes
+- **Spec:** `.design/ui-upgrade.md` + `.specs/ui-upgrade/README.md`
+- **Status:** Ready for implementation
+
+**F7 — Fotograf-retningslinjer (profilbilder)**
+- **Scope:** Write a human-readable, concrete photographer brief based on the new photography guidelines in `.design/graphics.md` (Photography Guidelines section)
+- **Deliverable:** Separate document (`.design/photography-brief.md`) written in Norwegian, targeted at a professional portrait photographer
+- **Content must include:** Light style (natural, desaturated), composition (environmental portraits, candid), technical specs (WebP, 1:1 aspect ratio), mood references, examples of good/bad, and the brand personality context (rebellious/nordic/democratic)
+- **Status:** Spec complete, deliverable pending
+
+---
+
+### Phase 13 — Customer Cases (Inbound Sales)
+
+*C1-C4 moved to **Blocked** section — all require user input or dependency completion before work can start.*
+
+---
+
 ## Design Decisions
 
 ### Brand & Visual (2026-05-25)
@@ -416,11 +407,61 @@ Do not add completed work here, add them to CHANGELOG.md
 - **Dependencies:** None
 
 **FF3 — Nye artikler (Triader, Makt, Perspektiv)**
-- **Status:** Specs complete. **Blocked on:** images + content draft needed
-- **Reference:** `.specs/triader/README.md`, `.specs/makt/README.md`, `.specs/perspektiv/README.md`
+- **Status:** Moved to **Blocked** section — N1/N2/N3 waiting on article content from user.
+- **Reference:** See N1, N2, N3 under Blocked section.
 
 ## Blocked
 
-- **Q7 — Katalysator:** Behold som planlagt funksjon. **blocked:** Deferred to June 2026. Iterative research + brainstorming session required before any implementation.
-  - **Reference:** `.specs/shared/product-katalysator.txt`
-  - **Dependencies:** User availability for brainstorming, product positioning decision
+*Items that cannot proceed without user input or dependency completion. Each entry defines its unblock condition.*
+
+### N1 — Triader (article content)
+- **Goal:** Write `_pages/ledelse_triader.md` — triads as structural tool for resilient teams
+- **Spec:** ✅ `.specs/triader/README.md` complete
+- **Images needed:** 1 hero banner (Style 2), 2 section illustrations (Style 3)
+- **Unblock condition:** User provides/dictates article content. Images (F5) are downstream of content.
+- **Reference:** `.specs/triader/README.md`
+
+### N2 — Makt eller tjeneste (article content)
+- **Goal:** Write `_pages/ledelse_makt.md` — power vs. servant leadership spectrum
+- **Spec:** ✅ `.specs/makt/README.md` complete
+- **Images needed:** 1 hero banner (Style 2), 2-3 section illustrations (Style 3)
+- **Unblock condition:** User provides/dictates article content. Images (F5) are downstream of content.
+- **Reference:** `.specs/makt/README.md`
+
+### N3 — Fire perspektiver (article content)
+- **Goal:** Write `_pages/ledelse_perspektiv.md` — multiframe thinking as leadership skill
+- **Spec:** ✅ `.specs/perspektiv/README.md` complete
+- **Images needed:** 1 hero banner (Style 2), 1-2 section illustrations (Style 3)
+- **Unblock condition:** User provides/dictates article content. Images (F5) are downstream of content.
+- **Reference:** `.specs/perspektiv/README.md`
+
+### F5 — Bildegenerering (image generation)
+- **Goal:** Generate N1-N3 images using updated `.design/graphics.md` guidelines
+- **Dependency:** N1, N2, N3 article content must be drafted and approved first (per Image Generation Context Requirements: «Article content is drafted and approved»)
+- **Unblock condition:** N1, N2, N3 content complete and approved.
+- **Reference:** `.design/graphics.md` (Style 2/3 guidelines, prompt templates)
+
+### C1 — Customer Case Planning & Discovery
+- **Goal:** Define what makes a compelling case for target audience. Update `.specs/cases/README.md`
+- **Unblock condition:** Brainstorm session with user — what questions must a case answer? What objections must it overcome?
+- **Blocks:** C2, C3, C4 downstream.
+
+### C2 — Customer Case Intake Form
+- **Goal:** Write `.design/case-intake-form.md` — human-facing form for consultants to gather case data
+- **Dependency:** C1 must complete first to define case structure and required data fields
+- **Unblock condition:** C1 completed (case structure defined), then spec work can proceed.
+
+### C3 — Case Presentation Design
+- **Goal:** Design case layout, typography, photo placement, quote treatment. Update `.design/components.md`
+- **Dependency:** C1 (content structure) + C2 (what data exists)
+- **Unblock condition:** C1 and C2 completed.
+
+### C4 — Visitor Flow / Inbound Sales Journey
+- **Goal:** Map entry points → case exposure → CTA progression. Write `.design/visitor-flow.md`
+- **Dependency:** Cases are placed at specific journey stages — needs C1-C3 foundations first.
+- **Unblock condition:** C1, C2, C3 completed.
+
+### Q7 — Katalysator (product)
+- **Goal:** Define and build Katalysator product positioning
+- **Unblock condition:** Deferred to June 2026. User availability for iterative research + brainstorming session. Product positioning decision.
+- **Reference:** `.specs/shared/product-katalysator.txt`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Design interview harmonization: brand personality expanded to 5 traits (Direct & Clear, Competent, Nordic, Rebellious, Practical)
+- Apple.com visual reference added to brand guidelines
+- Democratic design value and photography guidelines added to `.design/graphics.md`
+- Color Intensity Levels (full background vs accent) added to `.design/colors.md`
+- Layered animation design: expressive brand keyframes (heroReveal, heroImageReveal, pageTransition) + restrained UI scroll-triggered animations — documented in `.design/ui-upgrade.md` and `.specs/ui-upgrade/README.md`
+- BACKLOG.md restructured: N1-N3, F5, C1-C4 moved to dedicated Blocked section with explicit unblock conditions
 - Twin-primary color system: Navy #003060 / Azure #F0FFFF
   - Header bg swaps per mode (navy light, azure dark)
   - Page bg light changed to #c0d4e8, old #e2e8f0 stashed as --bg-neutral-light


### PR DESCRIPTION
## Summary

Three atomic commits aligning .design/ and .specs/ documentation with decisions from the design interview, plus backlog cleanup.

### Commits

1. **docs(brand): update brand docs** — Expand brand personality to 5 traits (Direct & Clear, Competent, Nordic, Rebellious, Practical). Add Apple.com visual reference. Add Democratic design value and photography guidelines. Add Color Intensity Levels.

2. **docs(animation): update animation design doc and spec** — Change motion philosophy to layered approach: expressive on brand surfaces (heroReveal, heroImageReveal, pageTransition) + restrained on UI (existing scroll-triggered). Extended reduced motion. Mirrored in .specs/ui-upgrade/README.md.

3. **docs(backlog): restructure blocked items** — Moved N1-N3, F5, C1-C4 to dedicated Blocked section with explicit unblock conditions. 20 items remain available for immediate work.

### Specific conflict resolved

Animation philosophy: design interview said memorable animations while ui-upgrade.md said restrained. Resolution: layered approach — expressive on brand surfaces, restrained on UI.