### PR TITLE
docs: reorganize backlog by dependency and add citation enhancement documents

### DIFF
--- a/.design/citation-enhancement.md
+++ b/.design/citation-enhancement.md
@@ -1,0 +1,296 @@
+# Citation Enhancement — Design Rules
+
+## Overview
+
+Three-layer citation architecture for the No Excuse website.
+
+```
+┌──────────────────────────────────────────┐
+│  Layer 1: kramdown native footnotes      │  ← Human-readable, authored in Markdown
+│  ([^ref] inline, [^ref]: at bottom)      │
+├──────────────────────────────────────────┤
+│  Layer 2: JSON-LD citation array          │  ← Machine-readable, in frontmatter
+│  (citation[] in json_ld block)           │
+├──────────────────────────────────────────┤
+│  Layer 3: JS enhancer                     │  ← Runtime microdata injection
+│  (citation-enhancer.js, reads JSON-LD)   │
+└──────────────────────────────────────────┘
+```
+
+## Layer 1 — kramdown Footnotes
+
+### Authoring Rules
+
+When adding a citation in an article:
+
+**Inline** (in prose):
+```markdown
+The four-frame model was first presented in 1984.[^bolman2017]
+```
+
+- Place `[^refname]` immediately after the claim being cited, before punctuation
+- `refname` should be a short, meaningful key: `[^bolman2017]`, `[^kotter2012]`, `[^logan2009]`, `[^schein2010]`, `[^pfeffer2010]`
+- Convention: `[^surnameYYYY]` — lowercase author surname + 4-digit year. If multiple sources from same author+year, append `a`, `b`: `[^pfeffer2010a]`, `[^pfeffer2010b]`
+
+**Footnote definition** (at bottom of page, after all content, before any sections):
+```markdown
+[^bolman2017]: Bolman, L. G. &amp; Deal, T. E. (2017). *Reframing Organizations* (6th ed.). Wiley. [Wiley →](https://www.wiley.com/en-us/Reframing+Organizations%3A+Artistry%2C+Choice%2C+and+Leadership%2C+6th+Edition-p-9781119281825)
+```
+
+### Link Strategy
+
+| Source Type | Anchor Text | Target |
+|-------------|-------------|--------|
+| Direct publisher link | Publisher name + `→` | `[Wiley →](https://...publisher-url...)` |
+| DOI | Publisher name + `→` | `[Wiley →](https://doi.org/10....)` |
+| Google Scholar (no direct link) | `Google Scholar →` | `[Google Scholar →](https://scholar.google.com/scholar?q=..."Title"+Author)` |
+| Open access / freely available | Publisher name (no `→`) | `[Harvard Business Review](https://hbr.org/...)` |
+
+### Page Number Handling
+
+Page numbers belong in the footnote body text, kramdown renders them as plain text:
+
+```markdown
+[^logan2009]: Logan, D., King, J., & Fischer-Wright, W. (2009). *Tribal Leadership*. Harper Business, pp. 38–41. [Google Scholar →](https://scholar.google.com/scholar?q=%22Tribal+Leadership%22+Logan)
+```
+
+### Multiple Citations for One Claim
+
+Use separate footnote markers, one per source:
+
+```markdown
+The failure rate of change initiatives is well documented.[^kotter2012][^beer2000]
+```
+
+### Configuration
+
+In `_config.yml`:
+```yaml
+kramdown:
+  footnote_backlink: "↩"
+```
+
+The ↩ backlink appears at the end of each footnote `<li>` and jumps the reader back to the superscript in the article body.
+
+## Layer 2 — JSON-LD Citation Array
+
+### Frontmatter Pattern
+
+Add a `citation` key to the existing `json_ld` block in each page's frontmatter:
+
+```yaml
+---
+layout: page
+title: "Page Title"
+permalink: /page/
+json_ld:
+  type: "Article"
+  name: "Page Title"
+  description: "SEO description"
+  author:
+    type: "Organization"
+    name: "No Excuse AS"
+  about:
+    - type: "Thing"
+      name: "Topic"
+  citation:                         # ← NEW
+    - "@id": "#fn:bolman2017"
+      "@type": "ScholarlyArticle"
+      name: "Reframing Organizations: Artistry, Choice, and Leadership"
+      author:
+        - "@type": "Person"
+          name: "Bolman, L. G."
+        - "@type": "Person"
+          name: "Deal, T. E."
+      datePublished: "2017"
+      publisher:
+        "@type": "Organization"
+        name: "Wiley"
+      url: "https://www.wiley.com/en-us/Reframing+Organizations%3A+Artistry%2C+Choice%2C+and+Leadership%2C+6th+Edition-p-9781119281825"
+      isAccessibleForFree: false
+    - "@id": "#fn:logan2009"
+      "@type": "ScholarlyArticle"
+      name: "Tribal Leadership: Leveraging Natural Groups to Build a Thriving Organization"
+      author:
+        - "@type": "Person"
+          name: "Logan, D."
+        - "@type": "Person"
+          name: "King, J."
+        - "@type": "Person"
+          name: "Fischer-Wright, W."
+      datePublished: "2009"
+      publisher:
+        "@type": "Organization"
+        name: "Harper Business"
+      url: "https://scholar.google.com/scholar?q=%22Tribal+Leadership%22+Logan"
+      isAccessibleForFree: true
+---
+```
+
+### Schema Rules
+
+1. **`@id` MUST match** kramdown's auto-generated footnote anchor: `#fn:bolman2017` for `[^bolman2017]`
+2. **Every `[^ref]` in the page body MUST have a corresponding entry** in the `citation` array — missing entries are a bug
+3. **`@type` choices:**
+   - `ScholarlyArticle` — academic books, journal articles, dissertations
+   - `CreativeWork` — reports, standards, legal documents, white papers
+   - `SoftwareApplication` — software, tools, platforms
+4. **`author` is always an array** even for single authors: `[{"@type": "Person", "name": "Hubbard, D. W."}]`
+5. **Date format:** Four-digit year only (`"2017"`) — month/day are not required for citation context
+
+### Rendering
+
+The existing `_includes/metadata.html` template renders `page.json_ld` as:
+
+```html
+<script type="application/ld+json">
+{{ page.json_ld | jsonify }}
+</script>
+```
+
+This already handles the `citation` array correctly — no template changes needed. Verify the compiled output includes the citation array.
+
+## Layer 3 — JavaScript Enhancer
+
+### Module Architecture
+
+```
+citation-enhancer.js
+├── getCitations()        → Reads JSON-LD block, returns citation[]
+├── enhanceFootnote(li, citation)
+│   ├── Sets itemscope + itemtype on <li>
+│   └── Injects nested <script type="application/ld+json"> with full citation
+├── enhanceSupers(citations[])
+│   └── Sets itemprop="citation" + itemid on <sup id="fnref:...">
+└── init()
+    └── Calls getCitations() → forEach citation → enhanceFootnote() + enhanceSupers()
+```
+
+### DOM Targets
+
+kramdown generates this HTML from `[^bolman2017]`:
+
+```html
+<!-- Inline superscript in article body -->
+<sup id="fnref:bolman2017"><a href="#fn:bolman2017" class="footnote">[1]</a></sup>
+
+<!-- In the footnotes list at bottom -->
+<li id="fn:bolman2017">
+  <p>Bolman, L. G. &amp; Deal, T. E. (2017). <em>Reframing Organizations</em> (6th ed.). Wiley. <a href="https://...">Wiley →</a>&nbsp;<a href="#fnref:bolman2017" aria-label="Back to content">↩</a></p>
+</li>
+```
+
+### After JS Enhancer Runs
+
+```html
+<sup id="fnref:bolman2017" itemprop="citation" itemid="#fn:bolman2017">
+  <a href="#fn:bolman2017" class="footnote">[1]</a>
+</sup>
+
+<li id="fn:bolman2017" itemscope itemtype="https://schema.org/ScholarlyArticle" itemid="#fn:bolman2017">
+  <script type="application/ld+json">
+    {"@id": "#fn:bolman2017", "@type": "ScholarlyArticle", "name": "Reframing Organizations", ...}
+  </script>
+  <p>Bolman, L. G. &amp; Deal, T. E. (2017). <em>Reframing Organizations</em> (6th ed.). Wiley. <a href="...">Wiley →</a> <a href="#fnref:bolman2017" aria-label="Back to content">↩</a></p>
+</li>
+```
+
+### Implementation Rules
+
+- **No dependencies** — vanilla JS, no DOM libraries
+- **Defer loading** — `defer` attribute in `<script>` tag ensures DOM is ready before execution
+- **Graceful degradation** — if no JSON-LD citation array exists, the module is a no-op (check `if (!citations.length) return;`)
+- **Idempotent** — running the enhancer multiple times on the same page should not duplicate attributes (check before setting)
+- **Console-free in production** — no `console.log` calls unless debugging
+
+### CSS for Footnotes
+
+Styles should be in a dedicated `assets/css/citations.css` (or merged into `article.css`):
+
+```css
+/* --- Citation / Footnote Styles --- */
+
+.footnotes {
+  margin-top: var(--space-xl, 3rem);
+  padding-top: var(--space-md, 1.5rem);
+  border-top: 1px solid var(--border-color-light);
+  font-size: 0.875em;
+}
+
+.footnotes ol {
+  padding-left: 1.25rem;
+}
+
+.footnotes li {
+  margin-bottom: 0.75rem;
+  line-height: 1.5;
+}
+
+/* Highlight the target footnote when navigated to via anchor */
+.footnotes li:target {
+  background: var(--highlight-bg, rgba(0, 48, 96, 0.05));
+  padding: 0.25rem 0.5rem;
+  border-radius: var(--radius-sm, 4px);
+  transition: background 0.3s ease;
+}
+
+/* Backlink ↩ */
+.footnote-backlink {
+  margin-left: 0.25rem;
+  text-decoration: none;
+  opacity: 0.5;
+  font-size: 0.85em;
+  transition: opacity 0.2s ease;
+}
+
+.footnote-backlink:hover {
+  opacity: 1;
+}
+
+/* Inline footnote reference numbers */
+sup .footnote {
+  color: var(--primary-accent);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+sup .footnote:hover {
+  text-decoration: underline;
+}
+
+/* Dark mode overrides */
+.dark-mode .footnotes {
+  border-top-color: var(--border-color-dark);
+}
+
+.dark-mode .footnotes li:target {
+  background: rgba(240, 255, 255, 0.08);
+}
+```
+
+### Accessibility
+
+- kramdown's auto-generated backlink includes `aria-label="Back to content"` — verify this in compiled output
+- Footnote superscript numbers should have sufficient color contrast against body text (WCAG AA)
+- The `:target` highlight on footnote list items helps users orient after clicking a backlink
+- No auto-scroll animations (respects reduced motion)
+
+## Authoring Workflow
+
+When creating a new article that cites sources:
+
+1. **Write** — Use `[^surnameYYYY]` inline citations during drafting
+2. **Define** — Add `[^surnameYYYY]: Full citation + link` at page bottom
+3. **Declare** — Add `citation:` key to frontmatter `json_ld` block with matching `@id`
+4. **Verify** — Check that compiled HTML includes both the footnotes list and the JSON-LD citation array
+5. **Test** — Click a footnote superscript → scrolls to definition; click ↩ → scrolls back
+
+## Anti-Patterns
+
+| Anti-Pattern | Why | Instead |
+|--------------|-----|---------|
+| Combining multiple sources in one `[^ref]` | Breaks link between footnote and individual JSON-LD entry | Use separate `[^ref]` markers per source |
+| Using HTML `<sup>` instead of `[^ref]` | kramdown won't process the inline/footnote relationship | Always use `[^ref]` Markdown syntax |
+| Omitting `url` from JSON-LD citation | Reduces usefulness for search engines and users | Always include a link (publisher or Google Scholar) |
+| Putting footnotes inside a `<section>` | May break kramdown's footnote placement | Put `[^ref]:` definitions at the very bottom of the file, outside any sections |
+| Inconsistent author name format in JSON-LD | Confuses search engines | Always use `"LastName, FirstInitial"` format |

--- a/.specs/citation-enhancement/README.md
+++ b/.specs/citation-enhancement/README.md
@@ -1,0 +1,215 @@
+# Citation Enhancement — Functional Specification
+
+## Purpose and Scope
+
+Replace the current ad-hoc citation system (raw `<sup class="citation">` HTML + orphan `[^ref]:` definitions) with a three-layer citation architecture:
+
+1. **kramdown native footnotes** for human-readable inline references and auto-generated footnote lists
+2. **JSON-LD `citation` array** in page frontmatter for machine-readable structured data
+3. **JavaScript enhancer** that reads the JSON-LD citation block at runtime and injects microdata (`itemprop`, `itemscope`) into kramdown's auto-generated footnote HTML
+
+The result is a citation system that is:
+- Authorable in clean Markdown (`[^ref]` syntax)
+- Machine-readable for search engines, AI tools, and academic crawlers
+- Semantically enriched in the rendered DOM for JS-enabled browsers
+- Linkable to original sources (publisher direct link where available, Google Scholar as fallback)
+
+## Pages in Scope
+
+All existing and future pages that cite academic or professional sources:
+
+| Page | Current Citation Method | Change Required |
+|------|------------------------|-----------------|
+| `/struktur/` | Hand-written reference list + some `<sup>` | Full conversion |
+| `/mennesker/` | Hand-written reference list + some `<sup>` | Full conversion |
+| `/påvirkning/` | Hand-written reference list + some `<sup>` | Full conversion |
+| `/identitet/` | Hand-written reference list + some `<sup>` | Full conversion |
+| `/usikkerhet/` | Orphan `[^ref]:` definitions + `<sup class="citation">` | Full conversion |
+| `/forankring/` | Hand-written reference list + some `<sup>` | Full conversion |
+| `/tillit/` | Hand-written reference list + some `<sup>` | Full conversion |
+| `/metode/` | Hand-written `<ul>` reference list | Full conversion |
+| `/ledelse-60-2/` | Hand-written reference list + some `<sup>` | Full conversion |
+| `/perspektiv/` | No citations (future) | Schema ready |
+| `/triader/` | No citations (future) | Schema ready |
+| `/makt/` | No citations (future) | Schema ready |
+| /generativ-ki/ | Hand-written reference list | Full conversion |
+
+## Requirements
+
+### R1 — kramdown native footnotes
+
+**Inline citation syntax** (in page body):
+
+```markdown
+... as described by Bolman & Deal.[^bolman2017]
+```
+
+**Footnote definition** (at bottom of page, before any sections or footnotes area):
+
+```markdown
+[^bolman2017]: Bolman, L. G. &amp; Deal, T. E. (2017). *Reframing Organizations* (6th ed.). Wiley. [Wiley →](https://www.wiley.com/...)
+```
+
+**Link strategy:**
+- If a freely accessible direct link exists (publisher, DOI, open access repository): use the **publisher's name** as anchor text, e.g. `[Wiley →](https://www.wiley.com/...)`, `[Harvard Business Review →](https://hbr.org/...)`, `[Harper Business →](https://www.harperbusiness.com/...)`
+- If no direct link exists: use `[Google Scholar →](https://scholar.google.com/scholar?q=...)` as fallback
+- Multi-source footnotes (e.g. a claim supported by two references) should use separate `[^ref]` markers, not be combined
+
+**kramdown configuration** (in `_config.yml`):
+
+```yaml
+kramdown:
+  footnote_backlink: "↩"
+```
+
+This adds a clickable ↩ backlink from each footnote to its citation point in the text.
+
+**CSS styling** (in `assets/css/article.css` or `assets/css/citations.css`):
+
+```css
+.footnotes {
+  margin-top: 3rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--border-color-light);
+  font-size: 0.875em;
+}
+
+.footnotes ol {
+  padding-left: 1.25rem;
+}
+
+.footnotes li {
+  margin-bottom: 0.75rem;
+  line-height: 1.5;
+}
+
+.footnotes li:target {
+  background: var(--highlight-bg, rgba(0, 48, 96, 0.05));
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+}
+
+.footnote-backlink {
+  margin-left: 0.25rem;
+  text-decoration: none;
+  opacity: 0.5;
+  font-size: 0.85em;
+}
+
+.footnote-backlink:hover {
+  opacity: 1;
+}
+
+.dark-mode .footnotes {
+  border-top-color: var(--border-color-dark);
+}
+
+.dark-mode .footnotes li:target {
+  background: rgba(240, 255, 255, 0.08);
+}
+```
+
+**Reduced motion:** No animation on footnote backlinks.
+
+### R2 — JSON-LD citation array in frontmatter
+
+Each page with citations adds a `citation` key to its existing `json_ld` frontmatter block.
+
+**Schema:**
+
+```yaml
+json_ld:
+  type: "Article"                    # or "TechArticle", "ScholarlyArticle"
+  # ... existing fields ...
+  citation:
+    - "@id": "#fn:refname"          # must match kramdown's auto-generated anchor
+      "@type": "ScholarlyArticle"
+      name: "Full Title of Work"
+      author:
+        - "@type": "Person"
+          name: "AuthorLastName, FirstInitial"
+      datePublished: "YYYY"
+      publisher:
+        "@type": "Organization"
+        name: "Wiley"
+      url: "https://..."             # direct link or Google Scholar
+      sameAs: "https://doi.org/..."  # DOI when available (optional)
+      isAccessibleForFree: true      # true if direct link is freely available
+```
+
+**Required fields per citation entry:**
+| Field | Required | Notes |
+|-------|----------|-------|
+| `@id` | **Yes** | Must match `#fn:refname` from kramdown |
+| `@type` | **Yes** | `"ScholarlyArticle"` for academic works, `"CreativeWork"` for reports/standards |
+| `name` | **Yes** | Full title |
+| `author` | **Yes** | Array of `{"@type": "Person", "name": "..."}` |
+| `datePublished` | **Yes** | Four-digit year |
+| `publisher` | Recommended | `{"@type": "Organization", "name": "..."}` |
+| `url` | **Yes** | Direct link or Google Scholar fallback |
+| `isAccessibleForFree` | Recommended | Boolean |
+
+**Generation rule:** Every `[^ref]` in the page body MUST have a corresponding entry in the `citation` array, and its `@id` MUST match `#fn:refname`.
+
+### R3 — JavaScript enhancer module
+
+**File:** `assets/scripts/citation-enhancer.js`
+
+**Behavior:**
+1. On `DOMContentLoaded`, read the page's `<script type="application/ld+json">` block
+2. Extract the `citation` array
+3. For each citation with `@id` matching `#fn:refname`:
+   - Find kramdown's auto-generated `<li id="fn:refname">` in the `.footnotes` list
+   - Inject `itemscope` + `itemtype="https://schema.org/ScholarlyArticle"` on the `<li>`
+   - Inject a nested `<script type="application/ld+json">` inside the `<li>` with the full citation data (microdata + embedded JSON-LD coexist per Schema.org)
+   - Find the corresponding `<sup id="fnref:refname">` in the article body
+   - Inject `itemprop="citation"` and `itemid="#fn:refname"` on the `<sup>`
+4. No-op if no `citation` array exists
+
+**Edge cases:**
+- Multiple `[^ref]` markers to the same footnote (`[^logan2009]` used 5 times in a page) → all `<sup id="fnref:logan2009">` get the same `itemprop` injection (kramdown creates unique IDs via appended counter)
+- No JSON-LD on page → module does nothing, no console errors
+- Missing citation entry for a footnote → silent skip, no crash
+
+**Loading:** Include via `<script src="/assets/scripts/citation-enhancer.js" defer></script>` in `_includes/scripts.html`.
+
+### R4 — Footnote backlink styling
+
+kramdown's `footnote_backlink: "↩"` generates a backlink from each footnote list item to its citation point. Style the backlink with:
+- Subtle opacity (0.5) with hover → full opacity
+- Small font size (0.85em)
+- No underline on the link itself
+
+## File Changes
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `.specs/citation-enhancement/README.md` | **Create** | This document |
+| `.design/citation-enhancement.md` | **Create** | Design rules for citation JSON-LD, microdata, CSS, and JS |
+| `_config.yml` | **Update** | Add `kramdown.footnote_backlink: "↩"` |
+| `assets/css/article.css` | **Update** | or create `assets/css/citations.css` — footnote list styling |
+| `assets/css/styles-dark.css` | **Update** | Dark mode footnote styles |
+| `assets/scripts/citation-enhancer.js` | **Create** | JS microdata injection module |
+| `_includes/scripts.html` | **Update** | Include `citation-enhancer.js` |
+| `_includes/metadata.html` | **Update** | Verify JSON-LD `citation` array renders (likely already works) |
+| All article `_pages/*.md` | **Update** | Replace `<sup class="citation">` + orphan `[^ref]:` with kramdown native footnotes + frontmatter citation entries |
+
+## Dependencies
+
+- No external libraries (vanilla JS)
+- kramdown is Jekyll's default Markdown processor — no gem changes needed
+- Frontmatter `json_ld` blocks already render via `_includes/metadata.html` — no template changes needed for JSON-LD output
+
+## Testing Checklist
+
+- [ ] `[^ref]` syntax renders as superscript linked to footnote definition
+- [ ] Footnote backlink (↩) appears on each footnote and scrolls to citation point
+- [ ] Clicking superscript scrolls to footnote definition
+- [ ] JSON-LD `citation` array appears in compiled HTML `<script type="application/ld+json">`
+- [ ] Google Structured Data Testing Tool validates `citation` entries
+- [ ] JS enhancer injects `itemprop` and `itemscope` into footnote DOM
+- [ ] JS enhancer handles missing JSON-LD gracefully (no errors)
+- [ ] Dark mode footnote styles render correctly
+- [ ] Reduced motion: no animation on footnotes
+- [ ] Mobile: footnote list readable at all breakpoints
+- [ ] No regressions in existing page layout or content

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -262,11 +262,26 @@ See relevant spec files for each expansion.
 - **Scope:** CSS — hero section width adjustments
 - **No blockers**
 
+**10.8 — "Velg et tidspunkt" — ikke i iframe**
+- **Problem:** Booking-modal åpnes i iframe, bør være direkte lenke
+- **Scope:** Booking modal / CTA-knapper
+- **No blockers**
+
+**10.9 — "Book en uforpliktende samtale" — ikke i iframe**
+- **Problem:** Samme som 10.8 — CTA åpnes i iframe
+- **Scope:** CTA-knapper
+- **No blockers**
+
+**10.10 — Mobil: konsistente CTA-bredder**
+- **Problem:** "Bestill Ledelse 60:2" og "Book en uforpliktende samtale" har ulik bredde på mobil
+- **Scope:** CSS for CTA-knapper på mobilbreakpoint
+- **No blockers**
+
 ---
 
-### Phase 11 — Design Polish (P5 User Testing Findings)
+### Phase 11 — Design Polish & /metode/ Overhaul
 
-*Brukertestfunn fra P5 som ble dokumentert i forrige sesjon. Krever ingen nye designbeslutninger — avklaringene er allerede gjort.*
+*Brukertestfunn fra P5 + nye endringer på `_pages/om_metode.md`. D7–D11 berører alle samme fil og bør gjøres samlet for å unngå merge-konflikter.*
 
 **D1 — Header-bakgrunn skal være konstant**
 - **Problem:** Header-bakgrunn endrer seg med tema. I dark mode blir logoen usynlig
@@ -294,6 +309,49 @@ See relevant spec files for each expansion.
 **D6 — Profildetaljer: unødvendig scrollbar**
 - **Problem:** Scrollbar vises ved første lass i profildetalj-visning
 - **Scope:** `assets/css/profiles.css`
+
+**D7 — `/metode/` ny tittel, beskrivelse og innledning**
+- **Scope:** `_pages/om_metode.md`
+- **Tittel:** Endre til "Om metodikk" (`title:` i frontmatter + `<h1>`)
+- **Beskrivelse:** Kort ny page description fra eksisterende tekst
+- **Innhold:** Flytt dagens beskrivende tekst til nytt avsnitt først på siden
+
+**D8 — Fjern "Vi fremhever fire prinsipper:"**
+- **Problem:** Linjen er overflødig — bildene viser prinsippene allerede
+- **Scope:** `_pages/om_metode.md` — linje 113
+- **Fix:** Slett linjen "Vi fremhever fire prinsipper:"
+
+**D9 — Fjern "utvikling"-tagg fra Mennesker frame-kort**
+- **Scope:** `_pages/om_metode.md` — linje 62 (`.frame-desc` for Menneskeperspektivet)
+- **Fix:** Fjern ", utvikling" fra tag-listen
+
+**D10 — Fjern "Symbolsk"-setning fra frame-kortbeskrivelser** *(flyttet fra R7)*
+- **Problem:** Setning som starter med "Symbolsk" er for lang for frame-kortene — samme fil som D7-D9
+- **Scope:** `_pages/om_metode.md` — linje 54, 63, 74, 83
+- **Fix:** Kutt setningen som starter med "Symbolsk" fra hver `.frame-detail-text`
+
+**D11 — Fiks syntaksfeil på `/metode/`** *(flyttet fra R8)*
+- **Problem:** Syntaksfeil i `_pages/om_metode.md` — samme fil som D7-D10
+- **Scope:** `_pages/om_metode.md`
+- **Fix:** Gjennomgå og rett syntaksfeil
+
+---
+
+### Phase 12 — Broader Improvements
+
+*Items that don't fit existing phases — cross-cutting design and asset work.*
+
+**X1 — Infografikk: tre kjerneverdier under "Oppdrag og verdier"**
+- **Problem:** Trenger en enkel infografisk illustrasjon av de tre kjerneverdiene
+- **Scope:** Ny banner/illustrasjon på `/om-oss/` eller aktuell side
+- **Design:** Følg `.design/graphics.md` retningslinjer — ingen tekst, skandinavisk minimal
+- **No blockers**
+
+**X2 — Dark mode consistency pass**
+- **Scope:** Alle sider — cards, frames, seksjoner, bakgrunner
+- **Problem:** Dark mode har harde hvite bakgrunner enkelte steder. Ser dårlig ut i nattmodus.
+- **Prosess:** (1) Oppdater `.design/` med definitive dark mode-regler → (2) Oppdater `.specs/` → (3) Gjennomgå implementering for regresjoner
+- **Avhengighet:** Bør gjøres etter at andre designoppdateringer er ferdige
 
 ---
 
@@ -352,6 +410,7 @@ When generating images for N1-N3 and future content, ensure maximum context is k
 | `.specs/ledelse-60-2/README.md` | **Update** | Reflect N1-N3 additions, E1-E6 expansions | Ready |
 | `.specs/emne/README.md` | **Create** | Tag lookup page `/emne/` — purpose, scope, requirements | Future feature |
 | `.specs/i18n/README.md` | **Create** | i18n multilingual support — approach, scope, constraints | Future feature |
+| `.specs/citation-enhancement/README.md` | ✅ **Created** | kramdown footnotes + JSON-LD citations + JS enhancer | Future feature (FF4) |
 
 ---
 
@@ -418,6 +477,11 @@ Do not add completed work here, add them to CHANGELOG.md
 **FF3 — Nye artikler (Triader, Makt, Perspektiv)**
 - **Status:** Specs complete. **Blocked on:** images + content draft needed
 - **Reference:** `.specs/triader/README.md`, `.specs/makt/README.md`, `.specs/perspektiv/README.md`
+
+**FF4 — Citation Enhancement (kramdown footnotes + JSON-LD + JS enhancer)**
+- **Status:** Spec'd in `.specs/citation-enhancement/README.md`. Design in `.design/citation-enhancement.md`. Not yet scheduled.
+- **Dependencies:** Must be implemented across all existing article pages. Best done as part of a content pass.
+- **Reference:** `.specs/citation-enhancement/README.md`, `.design/citation-enhancement.md`
 
 ## Blocked
 


### PR DESCRIPTION
## Summary

Two atomic commits refining BACKLOG.md with correct dependency groupings and adding spec + design documents for citation enhancement.

### Commits

1. **docs(backlog): reorganize by dependency** — Moves R7/R8 (om_metode.md fixes) from Phase 6 into Phase 11 where D7-D9 already live (same file, must be batched). Adds 10.8-10.10 (iframe fixes, mobile CTA widths), D7-D11 (/metode/ redesign + Symbolsk cut + syntax), Phase 12 (values infographic, dark mode consistency pass), and FF4 (citation enhancement).

2. **docs(citation): add spec and design documents** — Three-layer citation architecture: kramdown native footnotes, JSON-LD citation array in frontmatter, JS enhancer for microdata injection. Link strategy (publisher direct vs Google Scholar fallback). 511 lines across 2 files.

### Dependency Structure After This PR

| Phase | Items | Dependency |
|-------|-------|------------|
| 6 (Regression Fixes) | R1-R6 only | All independent |
| 10 (Site Review) | 10.1, 10.3-10.10 | 10.4 depends on 10.3 |
| 11 (Design Polish) | D1-D6 + D7-D11 (om_metode.md batch) | D7-D11 must be batched (same file) |
| 12 (Broader Improvements) | X1 (infographic), X2 (dark mode) | Both independent |