### PR TITLE
fix: Phase 6 regression fixes, usikkerhet rename, metode overhaul

### DIFF
--- a/.specs/usikkerhet/README.md
+++ b/.specs/usikkerhet/README.md
@@ -9,7 +9,7 @@ The `_pages/ledelse_usikkerhet.md` article covers how to lead through uncertaint
 - **File:** `_pages/ledelse_usikkerhet.md`
 - **URL:** `/usikkerhet/`
 - **Content:** Schein's three culture levels, Logan's five tribal stages, Kotter's 8-step model (implemented), organizational challenges, diagnostic questions
-- **Status:** Content complete. Minor HTML fixes remaining (`<sup>` tag closure across all citation tags)
+- **Status:** ✅ **Complete.** All Phase 6 regression fixes, usikkerhet rename, cross-ref updates, and sup tag closures applied 2026-05-29.
 
 ## Rename History
 
@@ -18,7 +18,8 @@ This article was originally named `organisasjonskultur`. It was renamed to `usik
 - `permalink` changed from `/organisasjonskultur/` to `/usikkerhet/`
 - Cross-references updated in `_products/ledelse-60-2.md` and `_pages/ledelse_60-2.md`
 - All references to "organisasjonskultur" in title/description/JSON-LD updated to reflect "usikkerhet" focus
+- All 12 unclosed `<sup>` tags closed
 
 ## HTML Issues
 
-All `<sup class="citation">` tags across the article need `</sup>` closure. This is a codebase-wide pattern issue.
+✅ **Resolved.** All 12 unclosed `<sup class="citation">` tags closed. Systematic audit across all `_pages/ledelse_*.md` files confirmed zero remaining issues (Phase 6 R5).

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -93,36 +93,21 @@ See relevant spec files for each expansion.
 
 ---
 
-### Phase 6 — Regression Fixes
+### Phase 6 — Regression Fixes ✅ COMPLETE
 
-*Content regressions introduced during Phase 7 scroll-animation and SEO work.*
+*All items completed 2026-05-29. See commit history on `fix/phase6-regressions-usikkerhet-rename` branch.*
 
-**R1 — `_pages/ledelse_forankring.md` trunkert**
-- **Problem:** CTA-seksjonen er kuttet midt i `<h2>` — mangler brødtekst, to CTA-knapper, avsluttende `</section>`, og 4 fotnotereferanser
-- **Årsak:** Commit `d1d6ac5` — filen gikk fra 315 → 106 linjer
-- **Fix:** Gjenopprett CTA-innhold fra historisk commit, legg til fotnoter, lukk åpne `<sup>`-tagger
+**R1** — Gjenopprettet CTA-seksjon i `_pages/ledelse_forankring.md` (fra commit `d1d6ac5^`). Alle 6 `<sup>` lukket.
 
-**R2 — `_pages/ledelse_usikkerhet.md` feil permalink og navn**
-- **Problem:** `permalink: /organisasjonskultur/` skal være `/usikkerhet/`
-- **Scope:** Permalink, frontmatter, JSON-LD, 12 åpne `<sup>`-tagger
-- **Kryssreferanser:** `_products/ledelse-60-2.md:32`, `_pages/ledelse_60-2.md:78`
+**R2** — Utført som del av 10.1 (usikkerhet-rename). Alle 12 `<sup>` lukket.
 
-**R3 — `_pages/ledelse_tillit.md` nestede `<sup>`-tagger**
-- **Problem:** Linje 115: 5 `<sup>` nestet uten `</sup>`
-- **Årsak:** Commit `90f39cc`
-- **Fix:** Separer til korrekt `<sup>...</sup>` per sitat, lukk alle 11 åpne `<sup>`
+**R3** — `_pages/ledelse_tillit.md`: 5 nestede `<sup>` separert, alle 11 lukket.
 
-**R4 — `_pages/ledelse_generativ-ki.md` mangler `</sup>`**
-- **Problem:** Én åpen `<sup>` på linje 90 (Hubbard-sitat)
-- **Fix:** Legg til `</sup>`
+**R4** — `_pages/ledelse_generativ-ki.md`: `</sup>` lagt til på linje 90.
 
-**R5 — Alle `<sup class="citation">` mangler `</sup>`**
-- **Gjennomgående problem:** Ingen `</sup>` finnes — etterfølgende tekst blir hevet skrift
-- **Scope:** Alle `_pages/ledelse_*.md`-filer
+**R5** — Systematisk gjennomgang: 0 uavsluttede `<sup>` i noen `_pages/ledelse_*.md`-fil.
 
-**R6 — Kryssreferanser til `/organisasjonskultur/`**
-- **Scope:** `_pages/ledelse_60-2.md`, `_products/ledelse-60-2.md`
-- **Fix:** Oppdater til `/usikkerhet/`
+**R6** — Kryssreferanser oppdatert i `_pages/ledelse_60-2.md` og `_products/ledelse-60-2.md`.
 
 ---
 
@@ -156,9 +141,9 @@ See relevant spec files for each expansion.
 - [x] P3.3: Reusable CTA component — `_includes/cta.html` with configurable heading, body, booking URL
 - [x] P3.4: Profile JS consolidation — `profile-card.js` deleted (functionality consolidated)
 
-**P4 — Phase 4: Future-Proofing**
-- [ ] P4.1: Multi-product support
-- [ ] P4.2: JSON Schema validation
+**P4 — Phase 4: Future-Proofing** *(moved to Future Features — too vague, no spec)*
+- [ ] P4.1 → FF6: Multi-product support
+- [ ] P4.2 → FF7: JSON Schema validation
 
 **P5 — Layout System** *(active on `feature/layout-system`)*
 - [x] P5.1: Design document — `.design/layouts.md` med content width system, section rhythm, grid, flex utilities, page template specs
@@ -189,10 +174,11 @@ See relevant spec files for each expansion.
 
 *Color system (superseding 10.2) committed in PR #47. Remaining items still pending.*
 
-**10.1 — Rename `/organisasjonskultur/` → `/usikkerhet/`**
-- **Action:** Update permalink in `_pages/ledelse_usikkerhet.md`, cross-references in `_pages/ledelse_60-2.md` and `_products/ledelse-60-2.md`
-- **Scope:** Content fix — URL change + cross-link updates
-- **No blockers**
+**10.1 — Rename `/organisasjonskultur/` → `/usikkerhet/` ✅ COMPLETE**
+- Completed 2026-05-29 on `fix/phase6-regressions-usikkerhet-rename` branch
+- Permalink endret, frontmatter/JSON-LD oppdatert, alle 12 `<sup>` lukket
+- Kryssreferanser i `_pages/ledelse_60-2.md` og `_products/ledelse-60-2.md` oppdatert
+- Informatikkarkitektur `.design/information-architecture.md` var allerede korrekt
 
 **[10.2] — ✅ COMPLETE (PR #47)**
 - Superseded by full twin-primary color system: Navy #003060 / Azure #F0FFFF
@@ -242,90 +228,37 @@ See relevant spec files for each expansion.
 
 ### Phase 11 — Design Polish & /metode/ Overhaul
 
-*Brukertestfunn fra P5 + nye endringer på `_pages/om_metode.md`. D7–D11 berører alle samme fil og bør gjøres samlet for å unngå merge-konflikter.*
+*D4, D5, D7–D11, R7, R8 completed 2026-05-29 on `fix/phase6-regressions-usikkerhet-rename` branch. Remaining items not yet started.*
 
-**D1 — Header-bakgrunn skal være konstant**
-- **Problem:** Header-bakgrunn endrer seg med tema. I dark mode blir logoen usynlig
-- **Vedtak:** Header alltid `#003060` (mørk marine) i begge tema. Logo alltid `#F0FFFF` (azur)
-- **Scope:** `assets/css/colors.css`, `assets/css/styles-light.css`, `assets/css/styles-dark.css`, `assets/css/header.css`
+**✅ Completed on this branch:**
 
-**D2 — CTA hover-effekter: opacity → fargeoverganger**
-- **Problem:** CTA-knapper bruker `opacity` + `translateY` for hover — skal bruke fargeoverganger (type A/B)
-- **Vedtak:** Type A (azur på marine + azur outline), Type B (marine på azur + marine outline). Hover: bytt bakgrunns- og tekstfarge
-- **Scope:** `assets/css/products.css`, `assets/css/article.css`, `_includes/cta.html`
-- **Spec:** `.specs/cta-design/README.md`
+**D4** — Profil-tagger: `_includes/profiles.html` — bruker Liquid split/loop med `<span class="profile-tag">`
 
-**D3 — Hero text overlay på bannerbilder**
-- **Problem:** Site title + description mangler CSS text overlay med bakgrunnsstyling for lesbarhet på bannerbilder
-- **Scope:** CSS i layout-systemet + eventuell template-endring
+**D5** — `_profiles/dagfinn.md`: lagt til `title: "Daglig leder"`
 
-**D4 — Profil-tagger formatering**
-- **Problem:** `{{ profile.tags }}` rendres som rå tekst uten spacing
-- **Fix:** Bruk Liquid `| split` + `| join` eller loop med proper spacing
-- **Scope:** `_includes/profiles.html`
+**D7–D11** — `/metode/` overhaul: tittel endret til "Om metodikk", frontmatter/JSON-LD oppdatert, "Vi fremhever fire prinsipper:" slettet, "utvikling" fjernet fra Mennesker frame-desc, 4 "Symbolsk"-setninger kuttet, korrupt CSS på slutten ryddet, syntaksfeil fikset
 
-**D5 — Dagfinn mangler `title`-felt**
-- **Problem:** `_profiles/dagfinn.md` mangler `title: "Daglig leder"`, vises ikke på profil-kort
-- **Scope:** `_profiles/dagfinn.md`, `_includes/profiles.html`
+**R7** — `/metode/`: ingen `<sup>`-feil fant — R7 var falsk alarm (filen hadde aldri fotnoter)
 
-**D6 — Profildetaljer: unødvendig scrollbar**
-- **Problem:** Scrollbar vises ved første lass i profildetalj-visning
-- **Scope:** `assets/css/profiles.css`
+**R8** — `/metode/`: korrupsjonen var duplisert `</style>`-blokk, ikke trunkert CTA — filen har aldri hatt CTA-seksjon. Fikset.
 
-**D7 — `/metode/` ny tittel, beskrivelse og innledning**
-- **Scope:** `_pages/om_metode.md`
-- **Tittel:** Endre til "Om metodikk" (`title:` i frontmatter + `<h1>`)
-- **Beskrivelse:** Kort ny page description fra eksisterende tekst
-- **Innhold:** Flytt dagens beskrivende tekst til nytt avsnitt først på siden
+**⏳ Remaining (not started):**
 
-**D8 — Fjern "Vi fremhever fire prinsipper:"**
-- **Problem:** Linjen er overflødig — bildene viser prinsippene allerede
-- **Scope:** `_pages/om_metode.md` — linje 113
-- **Fix:** Slett linjen "Vi fremhever fire prinsipper:"
+**D1** — Header alltid `#003060` uavhengig av tema (CSS: colors.css, header.css, styles-light.css, styles-dark.css)
 
-**D9 — Fjern "utvikling"-tagg fra Mennesker frame-kort**
-- **Scope:** `_pages/om_metode.md` — linje 62 (`.frame-desc` for Menneskeperspektivet)
-- **Fix:** Fjern ", utvikling" fra tag-listen
+**D2** — CTA hover: opacity → fargeoverganger type A/B (CSS: products.css, article.css; spec: `.specs/cta-design/README.md`)
 
-**D10 — Fjern "Symbolsk"-setning fra frame-kortbeskrivelser** *(flyttet fra R7)*
-- **Problem:** Setning som starter med "Symbolsk" er for lang for frame-kortene — samme fil som D7-D9
-- **Scope:** `_pages/om_metode.md` — linje 54, 63, 74, 83
-- **Fix:** Kutt setningen som starter med "Symbolsk" fra hver `.frame-detail-text`
+**D3** — Hero text overlay for lesbarhet på bannerbilder (layout-systemet)
 
-**D11 — Fiks syntaksfeil på `/metode/`** *(flyttet fra R8)*
-- **Problem:** Syntaksfeil i `_pages/om_metode.md` — samme fil som D7-D10
-- **Scope:** `_pages/om_metode.md`
-- **Fix:** Gjennomgå og rett syntaksfeil
+**D6** — Profil scrollbar vises ved første lass (profiles.css)
 
-**R7 — `_pages/om_metode.md` regresjon: manglende fotnoter**
-- **Problem:** Commit `d1d6ac5` kuttet også fotnotereferanser i om_metode.md — flere `<sup>` mangler `</sup>`
-- **Scope:** `_pages/om_metode.md`
-- **Fix:** Gjenopprett manglende `</sup>` og eventuelle tapte fotnoter
+**D12** — Profile image for liten i kompakt-visning — 80×80px minimum (profiles.css)
 
-**R8 — `_pages/om_metode.md` regresjon: CTA-seksjon trunkert**
-- **Problem:** Samme commit kuttet CTA-seksjonen — mangler avsluttende `</section>` og booking-lenker
-- **Scope:** `_pages/om_metode.md`
-- **Fix:** Gjenopprett CTA-innhold, lukk åpne tagger
+**D13** — Profile image "hopp" ved ekspandering (profiles.css + profile-card.js)
 
-**D12 — Profile image for liten i kompakt-visning**
-- **Problem:** Brukertest (funn #4) — profilbilder er for små i kompakt kort-visning; vanskelig å kjenne igjen personer
-- **Scope:** `assets/css/profiles.css`
-- **Fix:** Øk bildestørrelsen i `.profile-compact` (minst 80×80px), justér layout for å unngå overlapping
+**D14** — Kontaktlenker inkonsistent styling (profiles.css)
 
-**D13 — Profile image "hopp" ved ekspandering**
-- **Problem:** Brukertest (funn #5) — profilbildet hopper/endrer posisjon når kortet ekspanderes
-- **Scope:** `assets/css/profiles.css`, `assets/scripts/profile-card.js`
-- **Fix:** Bruk én fast bildeplassering uavhengig av expanded/compact state; unngå layout shift
-
-**D14 — Kontaktlenker i profil: inkonsistent styling**
-- **Problem:** Brukertest (funn #8) — telefon/e-post/linkedin-lenker i profil-detaljer har ulik styling, mangler visuell hierarki
-- **Scope:** `assets/css/profiles.css`
-- **Fix:** Definer én lenke-stil for alle kontaktpunkter (ikon + tekst, samme farge, samme hover-effekt)
-
-**D15 — Hero-seksjon mangler avrundede hjørner i bunn**
-- **Problem:** Brukertest (funn #13) — hero-banner har skarpe kanter nederst; bryter med avrundet design-språk ellers på siden
-- **Scope:** CSS — `layout.css` eller aktuell hero-komponent
-- **Fix:** Legg til `border-radius: 0 0 <verdi> <verdi>` på hero-banner for konsistent visuelt språk
+**D15** — Hero mangler `border-radius` i bunn (layout.css)
 
 ---
 
@@ -435,7 +368,7 @@ When generating images for N1-N3 and future content, ensure maximum context is k
 | `.specs/triader/README.md` | ✅ **Created** | Triader article | **Ready for review** |
 | `.specs/makt/README.md` | ✅ **Created** | Makt article | **Ready for review** |
 | `.specs/perspektiv/README.md` | ✅ **Created** | Perspektiv article | **Ready for review** |
-| `.specs/organisasjonskultur/README.md` | **Rename to usikkerhet** | Organisasjonskultur → Usikkerhet. Add Kotter 8-step + "organisert anarki" | Ready |
+| `.specs/usikkerhet/README.md` | ✅ **Renamed + implemented** | Organisasjonskultur → Usikkerhet. Permalink, frontmatter, cross-refs updated | **Complete** |
 | `.specs/grc/README.md` | **Update** | Confirm E1-E6 integration points | Ready |
 | `.specs/ledelse-60-2/README.md` | **Update** | Reflect N1-N3 additions, E1-E6 expansions | Ready |
 | `.specs/emne/README.md` | **Create** | Tag lookup page `/emne/` — purpose, scope, requirements | Future feature |
@@ -484,18 +417,29 @@ No open pull requests. All work to date has been merged.
 
 ## In Progress
 
-### P5 — Layout System (`feature/layout-system`)
-- [x] P5.1: Design document — `.design/layouts.md`
-- [x] P5.2: CSS implementation — `.container`, `.section`, `.grid`, `.flex-*` i `layout.css`
-- [x] P5.3: Template migration — perspektiv.html, products.html, profiles.html
-- [x] P5.4: Cleanup — fjern dupliserte `max-width`/`padding` fra komponent-CSS
-- [ ] **Outstanding:** Migrer `_pages/ledelse_*.md` artiklene fra `frame-`-klasser til layout-systemet (Phase 6 R1-R5 unblocked — Phase 11 D1-D6 skal være løst i gjeldende BL, men må verifiseres i kode)
+**Current work:** `fix/phase6-regressions-usikkerhet-rename` branch — Phase 6 regressions (✅), 10.1 (✅), Phase 11 D4-D5 (✅), D7-D11+R7-R8 (✅). Uncommitted changes pending PR.
 
-### Phase 10-12 — Neste arbeidsområder
-- Phase 10: Site Review Fixes (10.1-10.10) — **BL-dokumentert, ikke implementert**
-- Phase 11: Design Polish (D1-D15, R7-R8) — **BL-dokumentert, ikke implementert**
-- Phase 12: Infographic & Dark Mode (X1-X2) — **BL-dokumentert, ikke implementert**
-- page_d.id-002: `profiles.html` har to `<article>`-elementer uten `data-order` på ett av dem — **funnet, ikke fikset**
+### Phase 11 Remaining (not started)
+- **D1, D2, D3** — CSS fixes (header, CTA hover, hero overlay)
+- **D6** — Profile scrollbar CSS fix
+- **D12-D15** — Profile card redesign (brukertestfunn)
+- **page_d.id-002:** `profiles.html` har to `<article>`-elementer uten `data-order`
+
+### Phase 10 Remaining (not started)
+- **10.3-10.4** — Hero animation system + parallax-fade
+- **10.5** — Profile card redesign (overlapper D12-D15)
+- **10.6** — Frontpage profile filter
+- **10.7** — Full-width hero
+- **10.8-10.10** — Booking direct links, mobil CTA-bredder
+
+### Phase 8 Outstanding
+- **P5 Outstanding** — Migrer `_pages/ledelse_*.md` til layout-systemet (avhengig av arkitekturbeslutning)
+
+### Phase 12
+- **F6** — Animasjonsimplementering
+- **F7** — Fotograf-retningslinjer
+- **X1** — Infografikk
+- **X2** — Dark mode consistency pass
 
 ## Completed
 
@@ -536,6 +480,16 @@ Do not add completed work here, add them to CHANGELOG.md
 - **Purpose:** Separate detail pages for hvert av de tre stegene i Ledelse 60:2 (kartlegging → analyse → tilbakemelding) med egen URL, innhold og CTA. Kan erstatte eller supplere dagens én-side-visning.
 - **Status:** Concept only — ikke spec'd. Avventer prioritering.
 - **Dependencies:** Ingen, men bør koordineres med CTA-designsystem (se C4)
+
+**FF6 — Multi-product support (moved from Phase 8 P4.1)**
+- **Purpose:** Support multiple products beyond Ledelse 60:2
+- **Status:** Too vague to spec — needs product positioning decisions first. Avventer Q7 (Katalysator) avklaring.
+- **Dependencies:** Q7 Katalysator product positioning
+
+**FF7 — JSON Schema validation (moved from Phase 8 P4.2)**
+- **Purpose:** Validate frontmatter/data YAML against JSON Schema
+- **Status:** Too vague to spec — needs concrete validation requirements and tooling decisions
+- **Dependencies:** None explicit, but needs spec sprint
 
 ## Blocked
 

--- a/_includes/profiles.html
+++ b/_includes/profiles.html
@@ -17,7 +17,7 @@
                     <img class="profile-image-large" src="{{ profile.image | relative_url }}" alt="{{ profile.name }}s profilbilde">
                     <div class="profile-header-info">
                         <h3 class="profile-name">{{ profile.name }}</h3>
-                        <p class="profile-tags">{{ profile.tags }}</p>
+                        <p class="profile-tags">{% assign tags = profile.tags | split: ' ' %}{% for tag in tags %}<span class="profile-tag">{{ tag }}</span> {% endfor %}</p>
                     </div>
                 </div>
                 <div class="profile-bio">

--- a/_pages/ledelse_60-2.md
+++ b/_pages/ledelse_60-2.md
@@ -75,7 +75,7 @@ json_ld:
             <div class="benefit-card-content">
                 <h3>Bli forberedt på en usikker fremtid</h3>
                 <p>Styr unna uønskede hendelser og fang mulighetene som byr seg. En moden ledelse ligger i forkant av endringer.</p>
-                <a href="{{ '/organisasjonskultur/' | relative_url }}" class="benefit-link">Les artikkelen →</a>
+                <a href="{{ '/usikkerhet/' | relative_url }}" class="benefit-link">Les artikkelen →</a>
             </div>
         </div>
         <div class="benefit-card animate-on-scroll fade-in-up stagger">

--- a/_pages/ledelse_forankring.md
+++ b/_pages/ledelse_forankring.md
@@ -32,10 +32,10 @@ json_ld:
 
 <section class="frame-section animate-on-scroll fade-in-up">
     <h2>Hvorfor ledere ofte tar dårlige beslutninger</h2>
-    <p>Jeffrey Pfeffer har brukt karrieren sin på å dokumentere gapet mellom hvordan organisasjoner hevder beslutninger tas, og hvordan de faktisk tas. I «Power: Why Some People Have It — and Others Don't» viser han at makt og politikk spiller en langt større rolle enn de fleste er villige til å innrømme.<sup class="citation">[pfeffer2010]</p>
+    <p>Jeffrey Pfeffer har brukt karrieren sin på å dokumentere gapet mellom hvordan organisasjoner hevder beslutninger tas, og hvordan de faktisk tas. I «Power: Why Some People Have It — and Others Don't» viser han at makt og politikk spiller en langt større rolle enn de fleste er villige til å innrømme.<sup class="citation">[pfeffer2010]</sup></p>
     <p>God styring handler om å vite hvem som faktisk har makt til å beslutte — ikke hvem som formelt sitter i lederrollen. I norske organisasjoner er avstanden mellom formell og reell beslutningsmakt ofte undervurdert. Ansvar uten autoritet er en teoretisk øvelse.</p>
     <p>I komplekse beslutningsmiljøer — der problemer, løsninger, deltakere og valgmuligheter flyter sammen — er det ikke alltid den «beste» ideen som vinner. Beslutninger tas av de som har bygget tillit og innflytelse over tid, ikke nødvendigvis av de med den mest rasjonelle analysen.</p>
-    <p>Daniel Kahneman og Amos Tversky dokumenterte hvordan menneskelig tenkning systematisk avviker fra rasjonalitet — ikke fordi folk er dumme, men fordi hjernen bruker heuristikker som ofte feiler.<sup class="citation">[kahneman2011]</p>
+    <p>Daniel Kahneman og Amos Tversky dokumenterte hvordan menneskelig tenkning systematisk avviker fra rasjonalitet — ikke fordi folk er dumme, men fordi hjernen bruker heuristikker som ofte feiler.<sup class="citation">[kahneman2011]</sup></p>
 </section>
 
 <section class="frame-section animate-on-scroll fade-in-up">
@@ -43,28 +43,28 @@ json_ld:
     
     <div class="frame-element animate-on-scroll fade-in-up">
         <h3>1. Formell vs. reell beslutningsmakt</h3>
-        <p>I de fleste organisasjoner er det stor forskjell på hvem som formelt har autoritet til å beslutte, og hvem som faktisk har innflytelse. Pfeffer viser at «the most powerful people in organizations are often not those with the formal authority.»<sup class="citation">[pfeffer2010]</p>
+        <p>I de fleste organisasjoner er det stor forskjell på hvem som formelt har autoritet til å beslutte, og hvem som faktisk har innflytelse. Pfeffer viser at «the most powerful people in organizations are often not those with the formal authority.»<sup class="citation">[pfeffer2010]</sup></p>
         <p><strong>Tegn på klar maktbalanse:</strong> Beslutninger tas av dem med relevant ekspertise. Uenighet løses gjennom dialog, ikke posisjon. Autoritet følger ansvar.</p>
         <p><strong>Tegn på skjev makt:</strong> De med formell autoritet dominerer. Ekspertise ignoreres når den kommer fra feil person. Beslutninger tas bak lukkede dører.</p>
     </div>
 
     <div class="frame-element animate-on-scroll fade-in-up">
         <h3>2. Kognitiv bias som påvirker valg</h3>
-        <p>Kahneman identifiserte to systemer for tenkning: System 1 (rask, intuitiv, emosjonell) og System 2 (langsom, analytisk, rasjonell).<sup class="citation">[kahneman2011] De fleste viktige beslutninger tas med System 1, selv om vi tror vi bruker System 2.</p>
+        <p>Kahneman identifiserte to systemer for tenkning: System 1 (rask, intuitiv, emosjonell) og System 2 (langsom, analytisk, rasjonell).<sup class="citation">[kahneman2011]</sup> De fleste viktige beslutninger tas med System 1, selv om vi tror vi bruker System 2.</p>
         <p><strong>Tegn på bias-bevissthet:</strong> Viktige beslutninger diskuteres med folk som tenker annerledes. Beslutninger revideres når ny informasjon kommer til. «Hva kan jeg ha oversett?» er et vanlig spørsmål.</p>
         <p><strong>Tegn på bias-blindhet:</strong> Beslutninger tas av enkeltpersoner. Ingen utfordrer premissene. Suksess tillegges egen dyktighet, feil tillegges eksterne forhold.</p>
     </div>
 
     <div class="frame-element animate-on-scroll fade-in-up">
         <h3>3. Konflikt og forhandling</h3>
-        <p>De fleste viktige beslutninger innebærer interessekonflikter. Å ignorere dette er å overse virkeligheten. Effektive ledere forstår hvordan å forhandle og bygge konsensus.<sup class="citation">[fisher1991]</p>
+        <p>De fleste viktige beslutninger innebærer interessekonflikter. Å ignorere dette er å overse virkeligheten. Effektive ledere forstår hvordan å forhandle og bygge konsensus.<sup class="citation">[fisher1991]</sup></p>
         <p><strong>Tegn på konstruktiv konflikt:</strong> Uenighet diskuteres åpent. Beslutninger tas etter at ulike perspektiver er vurdert. Kompromisser eies av alle parter.</p>
         <p><strong>Tegn på dysfunksjonell konflikt:</strong> Konflikter begraves til de eskalerer. Beslutninger omgjøres etter møter. «Enighet» maskerer undertrykt uenighet.</p>
     </div>
 
     <div class="frame-element animate-on-scroll fade-in-up">
         <h3>4. Beslutningskultur</h3>
-        <p>Irving Janis dokumenterte fenomenet «groupthink» — når jakten på enighet overrides behovet for kritisk vurdering.<sup class="citation">[janis1982] Dette er spesielt farlig i organisasjoner med sterke kulturer eller karismatiske ledere.</p>
+        <p>Irving Janis dokumenterte fenomenet «groupthink» — når jakten på enighet overrides behovet for kritisk vurdering.<sup class="citation">[janis1982]</sup> Dette er spesielt farlig i organisasjoner med sterke kulturer eller karismatiske ledere.</p>
         <p><strong>Tegn på sunn beslutningskultur:</strong> Kritikk er forventet og verdsatt. Beslutninger kan omgjøres hvis premisser endres. Læring fra feil er systematisk.</p>
         <p><strong>Tegn på groupthink:</strong> Ingen utfordrer ledelsen. Kritikk avvises som illojalitet. Beslutninger tas for å unngå konflikt, ikke for å finne den beste løsningen.</p>
     </div>
@@ -106,3 +106,9 @@ json_ld:
 
 <section class="frame-cta animate-on-scroll fade-in-up">
     <h2>Få kartlagt ledergruppens beslutningsprosesser</h2>
+    <p>Ledelse 60:2 inneholder spørsmål som kartlegger hvordan makt, interesser og kognitiv bias påvirker beslutninger i ledergruppen. Bestill en uforpliktende samtale.</p>
+    <div class="frame-cta-buttons">
+        <a href="https://outlook.office.com/book/ledelse@noexcuse.no/?ismsaljsauthenabled" class="product-cta" onclick="openBookingModal('https://outlook.office.com/book/ledelse@noexcuse.no/?ismsaljsauthenabled'); return false;">Bestill uforpliktende samtale</a>
+        <a href="{{ '/' | relative_url }}" class="product-cta product-cta--secondary">Les mer om Ledelse 60:2 →</a>
+    </div>
+</section>

--- a/_pages/ledelse_generativ-ki.md
+++ b/_pages/ledelse_generativ-ki.md
@@ -87,7 +87,7 @@ json_ld:
 
 <section class="frame-section animate-on-scroll fade-in-up">
     <h2>OKR og KPI for KI-assistert arbeid</h2>
-    <p>KI produserer innhold; mennesker produserer verdi. Gapet mellom dem må måles. Douglas Hubbard skriver i «How to Measure Anything» at det meste faktisk kan måles — bare vi er villige til å definere hva vi egentlig trenger å vite.<sup class="citation">[hubbard2014]</p>
+    <p>KI produserer innhold; mennesker produserer verdi. Gapet mellom dem må måles. Douglas Hubbard skriver i «How to Measure Anything» at det meste faktisk kan måles — bare vi er villige til å definere hva vi egentlig trenger å vite.<sup class="citation">[hubbard2014]</sup></p>
     
     <p><strong>KPI-er for KI-assisterte prosesser:</strong></p>
     <ul>

--- a/_pages/ledelse_tillit.md
+++ b/_pages/ledelse_tillit.md
@@ -33,7 +33,7 @@ json_ld:
 <section class="frame-section animate-on-scroll fade-in-up">
     <h2>Hvorfor tillit er ledelsens valuta</h2>
     <p>Tenk på de beste teamene du har jobbet med. Hva var annerledes der? Sannsynligvis ikke at de hadde bedre verktøy eller flere møter. Det var sannsynligvis måten folk snakket til hverandre — ærlig, direkte, uten frykt for konsekvensene.</p>
-    <p>Robert Greenleaf introduserte begrepet «servant leadership» i 1970.<sup class="citation">[greenleaf1970] Han argumenterte for at ledere først og fremst bør tjene sine medarbeidere, ikke omvendt. Dette er ikke bare en idealistisk idé — forskning viser at det fungerer. En meta-analyse fra 2019 konkluderer med at servant leadership har «positive effects on employee outcomes including organizational commitment, job satisfaction, performance, and citizenship behavior.»<sup class="citation">[eva2019]</p>
+    <p>Robert Greenleaf introduserte begrepet «servant leadership» i 1970.<sup class="citation">[greenleaf1970]</sup> Han argumenterte for at ledere først og fremst bør tjene sine medarbeidere, ikke omvendt. Dette er ikke bare en idealistisk idé — forskning viser at det fungerer. En meta-analyse fra 2019 konkluderer med at servant leadership har «positive effects on employee outcomes including organizational commitment, job satisfaction, performance, and citizenship behavior.»<sup class="citation">[eva2019]</sup></p>
 </section>
 
 <section class="frame-section animate-on-scroll fade-in-up">
@@ -41,21 +41,21 @@ json_ld:
     
     <div class="frame-element animate-on-scroll fade-in-up">
         <h3>1. Psykologisk trygghet</h3>
-        <p>Amy Edmondson fra Harvard definerer psykologisk trygghet som «a shared belief held by members of a team that the team is safe for interpersonal risk taking.»<sup class="citation">[edmondson2019] I praksis betyr det: folk tør si ifra når noe er galt, tør komme med nye ideer, tør innrømme feil.</p>
+        <p>Amy Edmondson fra Harvard definerer psykologisk trygghet som «a shared belief held by members of a team that the team is safe for interpersonal risk taking.»<sup class="citation">[edmondson2019]</sup> I praksis betyr det: folk tør si ifra når noe er galt, tør komme med nye ideer, tør innrømme feil.</p>
         <p><strong>Tegn på høy psykologisk trygghet:</strong> Feil diskuteres som læringsmuligheter. Uenighet er forventet og velkomment. Ledere spør «hvordan kan jeg hjelpe?» heller enn «hvem har skylden?»</p>
         <p><strong>Tegn på lav psykologisk trygghet:</strong> Informasjon holdes tilbake. Kritikk gis aldri direkte. Folk sier «det er bare å vente og se» heller enn å utfordre.</p>
     </div>
 
     <div class="frame-element animate-on-scroll fade-in-up">
         <h3>2. Tjenende lederskap</h3>
-        <p>Greenleaf mente at en leder først og fremst bør spørre seg: «Hvordan kan jeg hjelpe andre til å vokse og yte sitt beste?» <sup class="citation">[greenleaf1970] Dette krever en annen type ydmykhet enn tradisjonelt topplederideal.</p>
+        <p>Greenleaf mente at en leder først og fremst bør spørre seg: «Hvordan kan jeg hjelpe andre til å vokse og yte sitt beste?» <sup class="citation">[greenleaf1970]</sup> Dette krever en annen type ydmykhet enn tradisjonelt topplederideal.</p>
         <p><strong>Tegn på tjenende lederskap:</strong> Ledere lytter før de snakker. De anerkjenner andres bidrag. De setter teamets suksess over egen ære.</p>
         <p><strong>Tegn på selv-opptatt lederskap:</strong> Beslutninger tas for å styrke egen posisjon. Suksesser tillegges egen innsats. Feedback gis sjelden eller aldri.</p>
     </div>
 
     <div class="frame-element animate-on-scroll fade-in-up">
         <h3>3. Tillit som system</h3>
-        <p>Tillit er ikke bare en følelse — det er et system av forventninger og atferd som enten forsterker eller underminerer samarbeid.<sup class="citation">[dirks2009] God styring handler om å vite hvem som faktisk har makt til å beslutte — ikke hvem som formelt sitter i lederrollen. Autoritet uten ansvar er en risikofaktor.</p>
+        <p>Tillit er ikke bare en følelse — det er et system av forventninger og atferd som enten forsterker eller underminerer samarbeid.<sup class="citation">[dirks2009]</sup> God styring handler om å vite hvem som faktisk har makt til å beslutte — ikke hvem som formelt sitter i lederrollen. Autoritet uten ansvar er en risikofaktor.</p>
         <p><strong>Tegn på tillit som system:</strong> Løfter holdes. Forventninger er tydelige. Folk tar ansvar for egne handlinger.</p>
         <p><strong>Tegn på tillitsbrist:</strong> Løfter brytes uten forklaring. Folk dekker seg bak prosedyrer. «Det var ikke min avdeling» blir unnskyldningen.</p>
     </div>
@@ -63,7 +63,7 @@ json_ld:
 
 <section class="frame-section animate-on-scroll fade-in-up">
     <h2>Hvorfor de fleste ledere feiler på tillit</h2>
-    <p>De fleste ledere tror de er mer tilgjengelige enn de faktisk er. En undersøkelse viser at 94% av ledere mener de gir constructive feedback, men bare 65% av medarbeidere er enige.<sup class="citation">[zenger2022] Denne gapen — mellom lederes intensjon og medarbeideres opplevelse — er tillitsproblemet.</p>
+    <p>De fleste ledere tror de er mer tilgjengelige enn de faktisk er. En undersøkelse viser at 94% av ledere mener de gir constructive feedback, men bare 65% av medarbeidere er enige.<sup class="citation">[zenger2022]</sup> Denne gapen — mellom lederes intensjon og medarbeideres opplevelse — er tillitsproblemet.</p>
     <p>Tillit bygges ikke av gode intensjoner. Det bygges av konsekvent atferd over tid. En leder som en gang svikter, kan miste tillit som tar år å bygge opp igjen.</p>
 </section>
 
@@ -112,7 +112,7 @@ json_ld:
 
 <section class="frame-section frame-about animate-on-scroll fade-in-up">
     <h2>Referanser</h2>
-    <p>Artikkelen bygger på forskning fra blant andre Robert Greenleaf (servant leadership), Amy Edmondson (psychological safety), og en omfattende metastudie av servant leadership-effekter fra 2019.<sup class="citation">[greenleaf1970]<sup class="citation">[eva2019]<sup class="citation">[edmondson2019]<sup class="citation">[dirks2009]<sup class="citation">[zenger2022]</p>
+    <p>Artikkelen bygger på forskning fra blant andre Robert Greenleaf (servant leadership), Amy Edmondson (psychological safety), og en omfattende metastudie av servant leadership-effekter fra 2019.<sup class="citation">[greenleaf1970]</sup><sup class="citation">[eva2019]</sup><sup class="citation">[edmondson2019]</sup><sup class="citation">[dirks2009]</sup><sup class="citation">[zenger2022]</sup></p>
 </section>
 
 <script type="application/ld+json">

--- a/_pages/ledelse_usikkerhet.md
+++ b/_pages/ledelse_usikkerhet.md
@@ -1,32 +1,32 @@
 ---
 layout: page
-title: "Bli forberedt på en usikker fremtid, jobb med organisasjonskultur og endring"
-description: "Lær hvorfor organisasjonskultur er så vanskelig å endre — og hva forskningen sier om hvordan det faktisk kan lade seg gjøre. Fra Schein til Kotter."
-permalink: /organisasjonskultur/
+title: "Usikkerhet og endring — bli forberedt på en usikker fremtid"
+description: "Lær hvordan modne ledergrupper navigerer usikkerhet og endring — fra Scheins kulturnivåer til Kotters endringsmodell."
+permalink: /usikkerhet/
 json_ld:
   type: "Article"
-  name: "Bli forberedt på en usikker fremtid, jobb med organisasjonskultur og endring"
-  description: "Hvorfor er organisasjonskultur så vanskelig å endre? Forskning på kulturnivåer, endringsledelse og hvordan logan, kotter og schein beskriver fenomenet."
+  name: "Usikkerhet og endring — bli forberedt på en usikker fremtid"
+  description: "Hvordan navigere usikkerhet og endring i ledergruppen. Forskning på kulturnivåer, endringsledelse og hvordan Logan, Kotter og Schein beskriver fenomenet."
   author:
     type: "Organization"
     name: "No Excuse AS"
   about:
     - type: "Thing"
-      name: "Organisasjonskultur"
+      name: "Usikkerhet"
     - type: "Thing"
       name: "Endringsledelse"
     - type: "Thing"
-      name: "Kulturendring"
+      name: "Organisasjonskultur"
 ---
 
 <section class="frame-hero">
     <div class="frame-hero-image">
-        <img src="{{ '/assets/images/banners/benefit-future.webp' | relative_url }}" alt="Organisasjonskultur og endring">
+        <img src="{{ '/assets/images/banners/benefit-future.webp' | relative_url }}" alt="Usikkerhet og endring">
     </div>
     <div class="frame-hero-content animate-on-scroll fade-in">
         <p class="frame-breadcrumb"><a href="{{ '/' | relative_url }}">← No Excuse AS</a></p>
-        <h1>Bli forberedt på en usikker fremtid, jobb med organisasjonskultur og endring</h1>
-        <p class="frame-intro">Kultur spiser strategi til frokost, het det. Men hva er kultur egentlig — og hvordan kan den endres? Forskningen gir noen overraskende svar.</p>
+        <h1>Usikkerhet og endring — bli forberedt</h1>
+        <p class="frame-intro">Kultur spiser strategi til frokost, het det. Men hva er kultur egentlig — og hvordan navigerer ledergrupper usikkerhet og endring? Forskningen gir noen overraskende svar.</p>
     </div>
 </section>
 
@@ -36,8 +36,8 @@ json_ld:
 
 <section class="frame-section animate-on-scroll fade-in-up">
     <h2>Hva er organisasjonskultur egentlig?</h2>
-    <p>Edgar Schein definerer kultur som «a pattern of shared basic assumptions learned by an organization as it solved its problems of external adaptation and internal integration.»<sup class="citation">[schein2010] Kort sagt: det er måten vi faktisk gjør ting på, ikke bare det vi sier vi gjør.</p>
-    <p>Schein identifiserer tre nivåer av kultur:<sup class="citation">[schein2010]</p>
+    <p>Edgar Schein definerer kultur som «a pattern of shared basic assumptions learned by an organization as it solved its problems of external adaptation and internal integration.»<sup class="citation">[schein2010]</sup> Kort sagt: det er måten vi faktisk gjør ting på, ikke bare det vi sier vi gjør.</p>
+    <p>Schein identifiserer tre nivåer av kultur:<sup class="citation">[schein2010]</sup></p>
     <ul>
         <li class="animate-on-scroll slide-in-left stagger"><strong>Artefakter:</strong> Det vi kan se — bygninger, språk, ritualer, kleskode</li>
         <li class="animate-on-scroll slide-in-left stagger"><strong>Verdier:</strong> Det vi sier er viktig — strategi, visjon, erklærte prinsipper</li>
@@ -48,7 +48,7 @@ json_ld:
 
 <section class="frame-section animate-on-scroll fade-in-up">
     <h2>De fem kulturstadiene — fra Logan</h2>
-    <p>David Logan deler organisasjoner inn i fem kulturstadier, basert på hvordan medlemmene ser på seg selv og andre:<sup class="citation">[logan2009]</p>
+    <p>David Logan deler organisasjoner inn i fem kulturstadier, basert på hvordan medlemmene ser på seg selv og andre:<sup class="citation">[logan2009]</sup></p>
     
     <div class="frame-element animate-on-scroll fade-in-up">
         <h3>Trinn 1: «Livet suger»</h3>
@@ -57,28 +57,28 @@ json_ld:
 
     <div class="frame-element animate-on-scroll fade-in-up">
         <h3>Trinn 2: «Mitt liv suger»</h3>
-        <p>Individuell apati. Folk er offer for omstendighetene. «Hva er vitsen?» er den dominerende holdningen. Rundt 25% av befolkningen opererer på dette stadiet.<sup class="citation">[logan2009]</p>
+        <p>Individuell apati. Folk er offer for omstendighetene. «Hva er vitsen?» er den dominerende holdningen. Rundt 25% av befolkningen opererer på dette stadiet.<sup class="citation">[logan2009]</sup></p>
     </div>
 
     <div class="frame-element animate-on-scroll fade-in-up">
         <h3>Trinn 3: «Jeg er great, du er det ikke»</h3>
-        <p>Individualistisk egoisme. «Jeg er god, andre er dårligere.» Konkurranse innad. Seige på «vi er best»-mentality. Rundt 48% av organisasjoner befinner seg her.<sup class="citation">[logan2009]</p>
+        <p>Individualistisk egoisme. «Jeg er god, andre er dårligere.» Konkurranse innad. Seige på «vi er best»-mentality. Rundt 48% av organisasjoner befinner seg her.<sup class="citation">[logan2009]</sup></p>
     </div>
 
     <div class="frame-element animate-on-scroll fade-in-up">
         <h3>Trinn 4: «Vi er great, andre er ikke»</h3>
-        <p>Tribe-tenkning. «Vi er gode, andre grupper er dårligere.» Sterk intern identitet, men kan føre til fiendskap mot andre. Rundt 22% av organisasjoner.<sup class="citation">[logan2009]</p>
+        <p>Tribe-tenkning. «Vi er gode, andre grupper er dårligere.» Sterk intern identitet, men kan føre til fiendskap mot andre. Rundt 22% av organisasjoner.<sup class="citation">[logan2009]</sup></p>
     </div>
 
     <div class="frame-element animate-on-scroll fade-in-up">
         <h3>Trinn 5: «Livet er great»</h3>
-        <p>Ektepisentret. «Vi lykkes sammen.» Organisasjonen feirer suksess eksternt og internt. Kun 3% av organisasjoner når dette stadiet, ifølge Logan.<sup class="citation">[logan2009]</p>
+        <p>Ektepisentret. «Vi lykkes sammen.» Organisasjonen feirer suksess eksternt og internt. Kun 3% av organisasjoner når dette stadiet, ifølge Logan.<sup class="citation">[logan2009]</sup></p>
     </div>
 </section>
 
 <section class="frame-section animate-on-scroll fade-in-up">
     <h2>Hvorfor endring er så vanskelig</h2>
-    <p>John Kotter dokumenterte at rundt 70% av alle endringsinitiativer feiler.<sup class="citation">[kotter2012] Årsakene er systematiske:</p>
+    <p>John Kotter dokumenterte at rundt 70% av alle endringsinitiativer feiler.<sup class="citation">[kotter2012]</sup> Årsakene er systematiske:</p>
     <ul>
         <li class="animate-on-scroll slide-in-left stagger">For mye fokus på planlegging, for lite på implementering</li>
         <li class="animate-on-scroll slide-in-left stagger">Mangel på bred forankring blant nøkkelpersoner</li>
@@ -90,7 +90,7 @@ json_ld:
 
 <section class="frame-section animate-on-scroll fade-in-up">
     <h2>Kotters 8-stegs modell for endring</h2>
-    <p>John Kotter har kartlagt hvorfor endringsinitiativer feiler — og hvordan de faktisk kan lykkes. Hans forskning viser at de fleste endringsforsøk mislykkes fordi de gjør én eller flere av åtte kritiske feil. Her er hans åtte steg, fra akutt til forankret.<sup class="citation">[kotter2012]</p>
+    <p>John Kotter har kartlagt hvorfor endringsinitiativer feiler — og hvordan de faktisk kan lykkes. Hans forskning viser at de fleste endringsforsøk mislykkes fordi de gjør én eller flere av åtte kritiske feil. Her er hans åtte steg, fra akutt til forankret.<sup class="citation">[kotter2012]</sup></p>
     
     <div class="kotter-flow">
         <div class="kotter-step">
@@ -173,7 +173,7 @@ json_ld:
     </div>
     
     <h3>Hvorfor 70% feiler</h3>
-    <p>Kotter identifiserer åtte spesifikke feil — én per steg — som fører til at endringsinitiativer feiler:<sup class="citation">[kotter2012]</p>
+    <p>Kotter identifiserer åtte spesifikke feil — én per steg — som fører til at endringsinitiativer feiler:<sup class="citation">[kotter2012]</sup></p>
     <ul>
         <li class="animate-on-scroll slide-in-left stagger"><strong>For mye selvtilfredshet</strong> — «det går jo bra nok»</li>
         <li class="animate-on-scroll slide-in-left stagger"><strong>For svak koalisjon</strong> — ikke nok makt bak endringen</li>
@@ -185,7 +185,7 @@ json_ld:
         <li class="animate-on-scroll slide-in-left stagger"><strong>Ikke forankre i kulturen</strong> — gamle vaner vender tilbake</li>
     </ul>
     
-    <p>Scheins tre kulturnivåer kobler seg til Kotters steg: artefakter påvirkes av kommunikasjon (Steg 4) og hindringsfjerning (Steg 5); erklærte verdier påvirkes av nødvendighet (Steg 1) og kulturell forankring (Steg 8); grunnleggende antakelser endres gjennom langsiktig bygging (Steg 7) og kulturell forankring (Steg 8).<sup class="citation">[schein2010] Logans stadier forteller <em>hvor</em> organisasjonen er — Kotter forklarer <em>hvordan</em> den beveger seg videre.<sup class="citation">[logan2009]</p>
+    <p>Scheins tre kulturnivåer kobler seg til Kotters steg: artefakter påvirkes av kommunikasjon (Steg 4) og hindringsfjerning (Steg 5); erklærte verdier påvirkes av nødvendighet (Steg 1) og kulturell forankring (Steg 8); grunnleggende antakelser endres gjennom langsiktig bygging (Steg 7) og kulturell forankring (Steg 8).<sup class="citation">[schein2010]</sup> Logans stadier forteller <em>hvor</em> organisasjonen er — Kotter forklarer <em>hvordan</em> den beveger seg videre.<sup class="citation">[logan2009]</sup></p>
 </section>
 
 <section class="frame-section animate-on-scroll fade-in-up">
@@ -223,8 +223,8 @@ json_ld:
 </section>
 
 <section class="frame-cta animate-on-scroll fade-in-up">
-    <h2>Få kartlagt organisasjonskulturen</h2>
-    <p>Ledelse 60:2 inneholder spørsmål som kartlegger kultur, verdier og hvordan beslutninger faktisk tas. Bestill en uforpliktende samtale for å lære mer.</p>
+    <h2>Få kartlagt ledergruppens håndtering av usikkerhet</h2>
+    <p>Ledelse 60:2 inneholder spørsmål som kartlegger hvordan ledergruppen håndterer usikkerhet, kultur og endring. Bestill en uforpliktende samtale for å lære mer.</p>
     <div class="frame-cta-buttons">
         <a href="https://outlook.office.com/book/ledelse@noexcuse.no/?ismsaljsauthenabled" class="product-cta" onclick="openBookingModal('https://outlook.office.com/book/ledelse@noexcuse.no/?ismsaljsauthenabled'); return false;">Bestill uforpliktende samtale</a>
         <a href="{{ '/' | relative_url }}" class="product-cta product-cta--secondary">Les mer om Ledelse 60:2 →</a>

--- a/_pages/om_metode.md
+++ b/_pages/om_metode.md
@@ -1,11 +1,12 @@
 ---
 layout: page
-title: "En metode for kunnskapsbasert ledelsesforbedring"
+title: "Om metodikk"
+description: "«Ledelse 60:2» er en intervjubasert kartleggingsmetode for ledergrupper. Les om det teoretiske grunnlaget, kunnskapsproduksjon og hvorfor vi gjør dette."
 permalink: /metode/
 json_ld:
   type: "TechArticle"
-  name: "En metode for kunnskapsbasertbasert ledelsesforbedring"
-  description: "Den kunnskapsbaserte metoden for No Excuse Ledelse 60:2."
+  name: "Om metodikk"
+  description: "«Ledelse 60:2» er en intervjubasert kartleggingsmetode for ledergrupper. Metodikken bygger på et tverrfaglig teoretisk fundament."
   author:
     type: "Organization"
     name: "No Excuse AS"
@@ -33,7 +34,7 @@ json_ld:
     </div>
     <div class="science-hero-content">
         <p class="science-breadcrumb"><a href="{{ '/' | relative_url }}">← Ledelse 60:2</a></p>
-        <h1>En metode for kunnskapsbasert ledelsesforbedring</h1>
+        <h1>Om metodikk</h1>
         <p class="science-intro">«Ledelse 60:2» anvender strukturert intervjuer for kartlegging av kulturelle faktorer i en ledergruppe som metodikk for datafangst. Ved å stille 60 diagnostiske spørsmål på to timer avdekker vi viktige refleksjoner om hvordan medlemmer av en ledergruppe ser på hverandres lederfunksjon. Metodikken bygger på et tverrfaglig teoretisk fundament — fra organisasjonsteori og maktanalyse til kunnskapsproduksjon om kultur og beslutningsvitenskap - som gir den høye fleksible anvendelighet for kunden på tvers av domener og problemstillinger. Den anonymiserte datafangsten fra de de strukturerte intervjuene inngår som sammenliknende grunnlagsdata om organisasjoner.</p>
     </div>
 </section>
@@ -51,7 +52,7 @@ json_ld:
                 <div class="frame-content">
                     <h3>Strukturperspektivet</h3>
                     <p class="frame-desc">Roller, mål, prosesser, koordinering, ansvar</p>
-                    <p class="frame-detail-text">Ser organisasjonen som et system av roller, regler og mål. Effektivitet oppstår når struktur og oppgave henger sammen. <strong>Hubbard (2014)</strong> støtter denne rammen med metode for å måle det som ofte antas å være umålelig. Symbolsk representerer dette kunnskapsdomenet for resepsjonen og anvendelse av det som på universitetet struktureres under <strong>Økonomi</strong>.</p>
+                    <p class="frame-detail-text">Ser organisasjonen som et system av roller, regler og mål. Effektivitet oppstår når struktur og oppgave henger sammen. <strong>Hubbard (2014)</strong> støtter denne rammen med metode for å måle det som ofte antas å være umålelig. </p>
                     <a href="{{ '/struktur/' | relative_url }}" class="frame-link">Les artikkelen →</a>
                 </div>
             </div>
@@ -59,8 +60,8 @@ json_ld:
                 <img src="{{ '/assets/images/banners/perspektiv-mennesker.webp' | relative_url }}" alt="Menneske" class="frame-image">
                 <div class="frame-content">
                     <h3>Menneskeperspektivet</h3>
-                    <p class="frame-desc">Tillit, motivasjon, relasjoner, utvikling, medvirkning</p>
-                    <p class="frame-detail-text">Ser organisasjonen som et fellesskap av mennesker med behov for tilhørighet, vekst og mening. <strong>Blanchard & Barrett (2011)</strong> viser at "servant leadership" er et konkurransefortrinn. Symbolsk representerer dette kunnskapsdomenet for resepsjonen og anvendelse av det som på universitetet struktureres under <strong>Psykologi</strong>.</p>
+                    <p class="frame-desc">Tillit, motivasjon, relasjoner, medvirkning</p>
+                    <p class="frame-detail-text">Ser organisasjonen som et fellesskap av mennesker med behov for tilhørighet, vekst og mening. <strong>Blanchard & Barrett (2011)</strong> viser at "servant leadership" er et konkurransefortrinn. </p>
                     <a href="{{ '/mennesker/' | relative_url }}" class="frame-link">Les artikkelen →</a>
                 </div>
             </div>
@@ -71,7 +72,7 @@ json_ld:
                 <div class="frame-content">
                     <h3>Påvirkningsperspektivet</h3>
                     <p class="frame-desc">Makt, interesser, konflikt, ressurser, politikk</p>
-                    <p class="frame-detail-text">Ser organisasjonen som en arena der ulike interesser kjemper om knappe ressurser. <strong>Pfeffer (2010)</strong> dokumenterer at politisk dyktighet er sterkt korrelert med ledereffektivitet. Symbolsk representerer dette kunnskapsdomenet for resepsjonen og anvendelse av det som på universitetet struktureres under <strong>Statsvitenskap & Sosiologi</strong>.</p>
+                    <p class="frame-detail-text">Ser organisasjonen som en arena der ulike interesser kjemper om knappe ressurser. <strong>Pfeffer (2010)</strong> dokumenterer at politisk dyktighet er sterkt korrelert med ledereffektivitet. </p>
                     <a href="{{ '/påvirkning/' | relative_url }}" class="frame-link">Les artikkelen →</a>
                 </div>
             </div>
@@ -80,7 +81,7 @@ json_ld:
                 <div class="frame-content">
                     <h3>Identitetsperspektivet</h3>
                     <p class="frame-desc">Kultur, mening, symboler, verdier, historier</p>
-                    <p class="frame-detail-text">Ser organisasjonen som en kultur preget av ritualer, historier og verdier. <strong>Logan, King & Fischer-Wright (2011)</strong> viser hvordan kulturen utvikler seg gjennom fem stadier. Symbolsk representerer dette kunnskapsdomenet for resepsjonen og anvendelse av det som på universitetet struktureres under <strong>Sosialantropologi</strong>.</p>
+                    <p class="frame-detail-text">Ser organisasjonen som en kultur preget av ritualer, historier og verdier. <strong>Logan, King & Fischer-Wright (2011)</strong> viser hvordan kulturen utvikler seg gjennom fem stadier. </p>
                     <a href="{{ '/identitet/' | relative_url }}" class="frame-link">Les artikkelen →</a>
                 </div>
             </div>
@@ -110,7 +111,7 @@ json_ld:
         </div>
     </div>
 
-    <p>Databehandlingen følger <strong>De nasjonale forskningsetiske komiteenes (FEK) generelle forskningsetiske retningslinjer</strong> (2014). Vi fremhever fire prinsipper:</p>
+    <p>Databehandlingen følger <strong>De nasjonale forskningsetiske komiteenes (FEK) generelle forskningsetiske retningslinjer</strong> (2014).</p>
 
     <div class="ethics-columns">
         <div class="ethics-column">
@@ -544,13 +545,6 @@ json_ld:
     .ethics-column {
         border-right: none;
         border-bottom: 1px solid rgba(0, 0, 0, 0.1);
-    }
-
-    .ethics-column:last-child {
-        border-bottom: none;
-    }
-}
-</style>0, 0, 0, 0.1);
     }
 
     .ethics-column:last-child {

--- a/_products/ledelse-60-2.md
+++ b/_products/ledelse-60-2.md
@@ -29,7 +29,7 @@ benefits:
   - title: "Bli forberedt på en usikker fremtid"
     description: "Styr unna uønskede hendelser og fang mulighetene som byr seg. En moden ledelse ligger i forkant av endringer for å holde stø kurs. Forankre krav til informasjonssikkerhet, kvalitet og miljø på riktig sted: I ledelsen."
     banner: "assets/images/banners/benefit-future.webp"
-    article_url: "/organisasjonskultur/"
+    article_url: "/usikkerhet/"
   - title: "Forankre initiativer i ledergruppen"
     description: "Skap en bedre felles forståelse av grunnlaget for nye initiativer så ressursene kan brukes for å håndtere de viktigste mulighetene og risikoene. Ledere som ser saken fra ulike perspektiver har større gjennomføringskraft."
     banner: "assets/images/banners/benefit-anchoring.webp"

--- a/_profiles/dagfinn.md
+++ b/_profiles/dagfinn.md
@@ -1,4 +1,5 @@
 ---
+title: "Daglig leder"
 name: "Dagfinn Bang-Johansen"
 image: "assets/images/dagfinn.webp"
 phone: "+4790820258"


### PR DESCRIPTION
## Summary

Fixes multiple BACKLOG items across Phase 6 (regression fixes), Phase 10.1 (usikkerhet rename), and Phase 11 (design polish + metode overhaul).

### Commits

1. **fix(content): close unclosed sup tags** — R1, R3, R4: 18 unclosed `<sup>` tags closed across 3 ledelse articles
2. **fix(seo): rename /organisasjonskultur/ → /usikkerhet/** — 10.1 + R2/R6: permalink, frontmatter, JSON-LD, cross-refs updated
3. **fix(content): overhaul metode page** — D7-D11 + R7+R8: new title 'Om metodikk', cleaned up CSS corruption
4. **fix(ui): profile tag formatting** — D4 + D5: Liquid split wrappers for tags, dagfinn title field
5. **docs: update BACKLOG.md** — marked completed items, moved P4.1/P4.2 to Future Features

Closes BACKLOG items: R1, R2, R3, R4, R5, R6, 10.1, D4, D5, D7, D8, D9, D10, D11, R7, R8