### PR TITLE
docs: add 15 spec and design documentation files

### DIFF
--- a/.design/information-architecture.md
+++ b/.design/information-architecture.md
@@ -1,0 +1,23 @@
+# Information Architecture — Cross-Link Map
+
+## Purpose
+
+Documents all cross-references between content pages on noexcuse.no. When adding or modifying pages, update this map to keep cross-links consistent.
+
+## Cross-Reference Map
+
+| From | To | Link Text |
+|------|----|-----------|
+| `/påvirkning/` → "Maktens kostnader" brief paragraph | `/makt/` | "Les om maktens kostnader →" |
+| `/struktur/` → "Det vitenskapelige grunnlaget" | `/perspektiv/` | "Les om multiframe-tenkning →" |
+| `/mennesker/` → "Verdier og mening" (Noble Cause → servant leadership) | `/makt/` | Noble cause connects to servant leadership |
+| `/identitet/` → tribal stages (Logan) | `/triader/` | "Hvordan bygge triader →" |
+| `/usikkerhet/` → Kotter section | `/triader/` | "Verktøy for kulturendring: triader →" |
+| All 4 frame articles → "Det vitenskapelige grunnlaget" | `/perspektiv/` | "Les om hvorfor vi ikke scorer →" |
+
+## Rules
+
+1. Every cross-link must be bidirectional — if page A links to page B, verify B has a relevant context or return link.
+2. Link text should be action-oriented ("Les om ..."), not generic ("Klikk her").
+3. When a page is renamed or removed, update all incoming cross-links.
+4. This map lives in `.design/` as reference for content work — the actual links are hardcoded in `_pages/*.md`.

--- a/.specs/TEMPLATE.md
+++ b/.specs/TEMPLATE.md
@@ -1,0 +1,93 @@
+# Spec Template
+
+Use this template when creating a new `.specs/<feature-name>/README.md`.  
+Every spec must include the **Required** sections. Add **Optional** sections as needed.
+
+---
+
+## Required Sections
+
+### 1. Title
+
+```
+# <Kebab-case name> — <Fix|Feature|Chore> Specification
+```
+
+### 2. Purpose / Problem
+
+**For fixes:** Describe the problem. What's broken, where, and why it matters.
+
+**For features:** Describe the goal. What will this enable, and why does it belong here?
+
+### 3. Scope
+
+List the files and directories that will be changed. Be specific — include file paths, CSS classes, or functions when relevant.
+
+### 4. Acceptance Criteria
+
+Bulleted checklist of verifiable outcomes. Each item must be testable by an agent or human reviewer.
+
+```
+## Acceptance Criteria
+
+- [ ] First verifiable outcome
+- [ ] Second verifiable outcome
+- [ ] Dark mode tested (if UI change)
+- [ ] Mobile layout tested (if UI change)
+```
+
+---
+
+## Optional Sections
+
+### Backlog References
+
+Map spec to backlog item IDs. Helps trace work across documents.
+
+```
+## Backlog References
+
+Fix-260524-01, Fix-260524-02
+```
+
+### Design Constraints
+
+Brand rules, accessibility minimums, or technical invariants the implementation must respect.
+
+```
+## Design Constraints
+
+- Touch targets: minimum 44×44px
+- Use CSS variables from `colors.css` for all colors
+```
+
+### Dependencies
+
+Items that must be completed before this one can start.
+
+```
+## Dependencies
+
+- Fix-260524-01 must be done first (shared file scope)
+```
+
+---
+
+## Conventions
+
+- One file per feature or fix group. If multiple BL items affect the same file, use one spec — do not create N separate spec directories.
+- Required: `## Purpose / Problem`, `## Scope`, `## Acceptance Criteria`
+- Optional: `## Backlog References`, `## Design Constraints`, `## Dependencies`
+- Reference `.design/` doc paths when a design decision already exists (e.g., `.design/colors.md` for color rules).
+- For features that require generated images, add a subsection:
+
+```
+### Image Assets Required
+
+| Image | Style | Description |
+|-------|-------|-------------|
+| Hero banner | Style 2 | ... |
+| Section 1 | Style 3 | ... |
+
+See `.design/graphics.md` for prompt templates and style guidelines.
+```

--- a/.specs/booking-direct-links/README.md
+++ b/.specs/booking-direct-links/README.md
@@ -1,0 +1,31 @@
+# Booking Direct Links — Fix Specification
+
+## Problem
+
+Booking CTAs open in an iframe modal instead of linking directly to Microsoft Bookings. This adds an unnecessary intermediary step, can cause mobile usability issues, and prevents users from directly bookmarking the booking page.
+
+Affected flows:
+- "Velg et tidspunkt" (booking modal)
+- "Book en uforpliktende samtale" (CTA)
+
+## Scope
+
+- `_includes/booking-modal.html` or equivalent — replace iframe with direct `<a href>` link
+- CTA components (`_includes/cta.html`, `_includes/products.html`) — ensure booking URLs point directly to Microsoft Bookings
+- Remove any related iframe JS if it becomes dead code
+
+## Backlog References
+
+Fix-260524-05 (was 10.8/10.9 in old Phase 10)
+
+## Design Constraints
+
+- Microsoft Bookings URL pattern is preserved — only the delivery mechanism changes
+- Direct links must open in same tab (unless specified otherwise) to avoid tab fatigue
+
+## Acceptance Criteria
+
+- [ ] All booking CTAs are direct links, not iframe modals
+- [ ] Microsoft Bookings opens in the same tab by default
+- [ ] Mobile: booking link is tappable (44px minimum touch target — already met by CTA styling)
+- [ ] No broken booking flow after change

--- a/.specs/brand-trait-reconciliation/README.md
+++ b/.specs/brand-trait-reconciliation/README.md
@@ -1,0 +1,97 @@
+# Brand Trait Reconciliation
+
+> **Status:** Draft — task not yet scheduled
+> **Related:** D1 in merge-conflict resolution (feature/plan-outdate-fixes)
+> **Created:** 2026-05-29
+
+## Problem Statement
+
+There are two competing 5-trait brand personality models documented across the codebase, and neither has been formally decided as the canonical version.
+
+### Model A — Design Interview (PR #51)
+
+Source: `.design/brand-perception.md` (current file on main and this branch)
+
+| Trait | Descriptor |
+|-------|------------|
+| Direct & Clear | Say what we mean, no consultant-speak |
+| Competent | Proven results, real experience |
+| Nordic (Scandinavian minimal) | Clean, functional, no fluff |
+| Rebellious / Anti-establishment | Question the obvious |
+| Practical | Down-to-earth, no bullshit |
+
+Context: Came from the design interview harmonization PR (#51), authored by the design-interview branch. Format: English bullet list, no Norwegian labels, no evolution trace.
+
+### Model B — Plan-Outdate-Fixes (our branch)
+
+Source: `BACKLOG.md § Design Decisions` (line 383) and the original 722ce3e commit
+
+| Trait | Norwegian | Description |
+|-------|-----------|-------------|
+| Rebellious | Opprørsk | Utfordrer etablerte sannheter, tar upopulære standpunkt |
+| Clear | Tydelig | Komplekse ideer gjort enkle, null konsulentspråk |
+| Nordic | Nordisk | Demokratisk design, ærlig, intim, jordnær |
+| Trustworthy | Troverdig | Faglig tyngde, forskningsbasert, transparent |
+| Bold | Modig | Tydelige standpunkt, visuelt mot, upretensiøs selvsikkerhet |
+
+Context: Written during the plan-outdate-fixes analysis. Format: Norwegian-labeled table, includes evolution note from the original 4-trait model (Direct, Competent, Scandinavian minimal, Anti-establishment → mapped to new traits).
+
+### Key Differences
+
+| Dimension | Model A (design-interview) | Model B (plan-outdate-fixes) |
+|-----------|---------------------------|------------------------------|
+| **"Practical" vs "Bold"** | A fifth of being down-to-earth, no-nonsense | A fifth of visual/verbal courage |
+| **"Competent" vs "Trustworthy"** | Proven results/experience | Factual authority, research-based |
+| **Language** | English only | Norwegian trait labels + English descriptions |
+| **Format** | Flat bullet list | Table with mapping from old 4 traits |
+| **Evolution trace** | None | Explicit 4→5 mapping |
+| **BACKLOG.md § Design Decisions** | Not updated | References Model B traits |
+| **brand-perception.md** | References Model A traits | — |
+
+### Current Inconsistency
+
+On this branch right now:
+
+- `BACKLOG.md` line 383 references **Model B** (Rebellious — Clear — Nordic — Trustworthy — Bold)
+- `.design/brand-perception.md` contains **Model A** (Direct & Clear, Competent, Nordic, Rebellious/Anti-establishment, Practical)
+
+These must be reconciled into one canonical model.
+
+## Resolution Options
+
+### Option 1: Adopt Model B (Norwegian-labeled, with Bold)
+
+**Rationale:** BACKLOG.md already uses this model. It has Norwegian labels which aligns with the site's Norwegian Bokmål content language. The "Bold" trait captures the visual/verbal courage that's a differentiator from traditional consulting blandness. The evolution trace helps future agents understand the history.
+
+**Changes needed:**
+- Rewrite `.design/brand-perception.md` to use Model B's table format and Norwegian labels
+- Move the evolution note to an appendix or keep it inline
+- Ensure all content examples and voice guidelines still align with the new trait set
+
+### Option 2: Adopt Model A (English, with Practical)
+
+**Rationale:** This was reviewed and merged in PR #51. The "Practical" trait connects to the "folk som synes latte er pretensiøst" audience alignment — a strong differentiator. The "Competent" trait is more concrete than "Trustworthy".
+
+**Changes needed:**
+- Update `BACKLOG.md` § Design Decisions to match Model A
+- Could add Norwegian translations as a secondary column
+
+### Option 3: Hybrid
+
+Combine elements from both. E.g.:
+- Keep "Practical" (strong audience hook) but add "Bold" as a sub-trait or dimension
+- Keep "Trustworthy" (research foundation is real) but keep "Competent" as execution side
+- Norwegian labels + English descriptions
+
+## Dependencies
+
+- **None** — purely a documentation decision. No code or content changes depend on this.
+- Should be resolved before any new visual design work (F6, F7, X2) to ensure consistent language.
+
+## Acceptance Criteria
+
+- [ ] One canonical 5-trait model is documented in both `BACKLOG.md` and `.design/brand-perception.md`
+- [ ] The other model is either replaced or moved to a history/appendix section
+- [ ] No contradictory references remain in the codebase
+- [ ] All trait descriptions are in Norwegian Bokmål (matching site language)
+- [ ] Evolution from 4-trait model is documented for future agent context

--- a/.specs/hero-layout-fixes/README.md
+++ b/.specs/hero-layout-fixes/README.md
@@ -1,0 +1,28 @@
+# Hero Layout Fixes — Fix Specification
+
+## Problems
+
+1. **Full-width hero (Fix-260524-04):** Hero sections are constrained by `max-width` — they should be full-bleed (edge-to-edge) for a more premium visual treatment.
+2. **Hero text overlay (Fix-260524-10):** Site title and description on banner images lack proper CSS text overlay for readability — needs gradient overlay styling as specified in `.design/ui-upgrade.md`.
+
+## Scope
+
+- `assets/css/layout.css` or existing hero CSS — remove `max-width` constraint from hero sections
+- Hero template or CSS — apply gradient overlay from `.design/ui-upgrade.md` §2 (Hero Overlay Design)
+- Ensure full-bleed does not affect other sections (only hero)
+
+## Backlog References
+
+Fix-260524-04, Fix-260524-10 (was D3 in old Phase 11)
+
+## Design Reference
+
+`.design/ui-upgrade.md` — Hero Overlay Design section with gradient specifications for both light and dark modes.
+
+## Acceptance Criteria
+
+- [ ] Hero sections extend full width (no max-width constraint)
+- [ ] Text overlay with gradient is applied and readable on all hero images
+- [ ] Dark mode gradient overlay matches `.design/ui-upgrade.md` spec
+- [ ] Non-hero sections remain constrained to `max-width: 1100px` (existing behavior)
+- [ ] Mobile layout tested

--- a/.specs/inbound-sales/README.md
+++ b/.specs/inbound-sales/README.md
@@ -1,0 +1,112 @@
+# Inbound Sales / Visitor Flow — Functional Specification
+
+## Purpose and Scope
+
+Map the visitor journey from first page view to booked conversation and ultimately to paid invoice. Define analytics instrumentation, UTM conventions, funnel definitions, and event tracking so that No Excuse AS can attribute inbound marketing efforts to real outcomes.
+
+This spec covers **C4 — Visitor Flow / Inbound Sales Journey** in the backlog.
+
+## Three-Layer Funnel Architecture
+
+| Layer | Tool | Signal | Status |
+|-------|------|--------|--------|
+| 🟢 Top (awareness) | Simple Analytics | Sidevisninger, UTM-kampanjer, henvisningskilder, scroll-dybde | ✅ Allerede deployet (basisscript) |
+| 🟡 Middle (consideration) | Simple Analytics + Microsoft Bookings | CTA-klikk → bookingside → booket samtale | 🟡 Delvis — auto-events mangler |
+| 🔴 Bottom (conversion) | Fiken (fremtidig) | Booket samtale → betalende kunde (faktura) | 🔴 Fremtidig — krever ekstern tjeneste |
+
+## Requirements
+
+### 1. UTM-sporing
+
+- Alle eksterne kampanjelinker må inneholde `utm_source`, `utm_medium`, `utm_campaign`
+- Simple Analytics fanger disse automatisk via URL-parameterne
+
+**Konvensjon:**
+
+| Parameter | Tillatte verdier | Eksempel |
+|-----------|-----------------|----------|
+| `utm_source` | `linkedin`, `newsletter`, `google`, `referral`, `direct` | `utm_source=linkedin` |
+| `utm_medium` | `social`, `email`, `cpc`, `organic`, `referral` | `utm_medium=social` |
+| `utm_campaign` | kebab-case: `<produkt>-<år>-<mnd>` | `utm_campaign=ledelse-60-2-2026-05` |
+| `utm_content` | `hero`, `cta-primary`, `cta-secondary`, `banner`, `footer` | `utm_content=cta-primary` |
+
+### 2. Simple Analytics Goals (Funnels)
+
+Opprett følgende flertrinns-funnels i Simple Analytics-dashbordet:
+
+| Funnel | Steps | Mål |
+|--------|-------|-----|
+| **Produkt → Booking** | Forsiden → Ledelse 60:2 → Book samtale | Hvor mange når bookingsida? |
+| **Artikkel → Booking** | `/struktur/` eller `/mennesker/` → Ledelse 60:2 → Book samtale | Hvilke artikler driver flest bookinger? |
+| **Kampanje → Booking** | UTM-kampanje → Book samtale | Hvilke kanaler konverterer best? |
+| **Full trakt (fremtidig)** | Book samtale → Betaling | Hvor mange bookinger blir kunder? |
+
+### 3. Automatiske events (auto-events.js)
+
+Legg til `auto-events.js`-scriptet for å fange:
+- **Outbound linker:** Klikk til LinkedIn, andre eksterne sider
+- **E-postklikk:** `mailto:firmapost@noexcuse.no`
+- **Nedlastinger:** PDF-filer (avtale, rapporter)
+
+### 4. Egendefinerte events
+
+Spor følgende interaksjoner som egne events via Simple Analytics Events API:
+
+| Event | Trigger | Metadata |
+|-------|---------|----------|
+| `cta_book_samtale` | Klikk på "Bestill uforpliktende prat" | `page: current path` |
+| `cta_book_60-2` | Klikk på "Bestill Ledelse 60:2" | `page: current path` |
+| `cta_les_mer` | Klikk på "Les mer →" på benefit-kort | `page: current path, card: benefit name` |
+| `profile_expand` | Utvidelse av profil-kort | `profile: name` |
+
+### 5. Microsoft Bookings som konverteringsmål
+
+- Bookings-sidens URL defineres som et funnel-trinn i Simple Analytics Goals
+- Når en besøkende når Bookings-siden telles det som en konvertering (midt i trakten)
+- Bookings-lenker på tvers av nettstedet må ha konsistent `target="_blank"` og kunne spores
+
+### 6. Fiken-integrasjon (fremtidig)
+
+- Når Fiken API v2 er tilgjengelig: opprett en webhook eller periodisk jobb (Zapier / Make / Cloud Function) som:
+  - Fanger nye fakturaer opprettet i Fiken
+  - Matcher fakturaens kundenavn mot bookinger i Bookings
+  - Rapporterer full trakt: besøk → booket samtale → betalende kunde
+- **Designbeslutning:** Jekyll er statisk — Fiken-integrasjonen krever en ekstern tjeneste. Dette er en fremtidig forbedring, ikke en blocker for C4.
+
+## Data Structures
+
+### UTM-konvensjon (kampanje-URL-mal)
+
+```text
+https://noexcuse.no/landing?utm_source={source}&utm_medium={medium}&utm_campaign={campaign}&utm_content={content}
+```
+
+### Simple Analytics Goal-definisjon (JSON)
+
+```json
+{
+  "goal": "Produkt til Booking",
+  "steps": [
+    { "path": "/", "label": "Home" },
+    { "path": "/ledelse-60-2/", "label": "Product page" },
+    { "path": "/booking/", "label": "Booking page" }
+  ],
+  "funnel": true
+}
+```
+
+## Dependencies
+
+- **C1 (Case Planning):** Case-innhold brukes som bakgrunn for traktanalyse — hvilke sider/caser som driver mest trafikk
+- **Simple Analytics:** Allerede installert (`latest.js`). `auto-events.js` må legges til
+- **Microsoft Bookings:** Allerede i bruk — ingen endringer nødvendig på Bookings-siden
+- **Ingen designendringer:** C4 er ren analytics-konfigurasjon, ingen visuelle endringer på nettstedet
+
+## Implementation Order
+
+1. Legg til `auto-events.js` i `_includes/scripts.html`
+2. Opprett UTM-konvensjon-dokument for internt bruk
+3. Definer Simple Analytics Goals i dashbordet (funnels)
+4. Implementer egendefinerte events på CTA-knapper
+5. Dokumentér alle events og målinger i denne spec-fila
+6. (Fremtidig) Koble Fiken API for full trakt-rapportering

--- a/.specs/metode-overhaul/README.md
+++ b/.specs/metode-overhaul/README.md
@@ -1,0 +1,39 @@
+# `/metode/` Overhaul — Fix Specification
+
+## Problem
+
+The `/metode/` page (`_pages/om_metode.md`) has multiple content and layout issues identified during user testing and regression checking. All affect the same file and should be done in a single pass to avoid merge conflicts.
+
+## Scope (Single file: `_pages/om_metode.md`)
+
+| ID | Change |
+|----|--------|
+| Fix-260527-01 | New title, description, and introductory paragraph |
+| Fix-260527-02 | Remove "Vi fremhever fire prinsipper:" line (line ~113) |
+| Fix-260527-03 | Remove ", utvikling" from Mennesker frame-card tag list (line ~62) |
+| Fix-260527-04 | Cut "Symbolsk"-starting sentence from all four frame-card descriptions (lines ~54, 63, 74, 83) |
+| Fix-260527-05 | Fix syntax errors in the file |
+| Fix-260527-06 (R7) | Restore missing `</sup>` tags for footnotes |
+| Fix-260527-07 (R8) | Restore truncated CTA section (missing `</section>`, booking links) |
+
+## Backlog References
+
+Fix-260527-01 through Fix-260527-07 (was D7-D11 + R7-R8 in old Phase 11)
+
+## Dependencies
+
+All items share the same file. Must be done in a single edit pass, ordered:
+1. Fix-260527-01 first (structural: title/description changes)
+2. Remaining edits are independent but on same file — apply together
+
+## Acceptance Criteria
+
+- [ ] `/metode/` has new title, description, and introductory paragraph
+- [ ] "Vi fremhever fire prinsipper:" line removed
+- [ ] "utvikling" tag removed from Mennesker frame-card
+- [ ] "Symbolsk" sentences removed from all four frame-card descriptions
+- [ ] No syntax errors in the file
+- [ ] All `<sup>` tags properly closed
+- [ ] CTA section is complete with `</section>` and booking links
+- [ ] Page renders correctly in both light and dark mode
+- [ ] Mobile layout tested

--- a/.specs/mobile-cta-widths/README.md
+++ b/.specs/mobile-cta-widths/README.md
@@ -1,0 +1,27 @@
+# Mobile CTA Width Consistency — Fix Specification
+
+## Problem
+
+On mobile, "Bestill Ledelse 60:2" and "Book en uforpliktende samtale" CTAs have different widths. This creates visual inconsistency and a less polished appearance on the primary conversion buttons.
+
+## Scope
+
+- `assets/css/products.css` or relevant CTA CSS — ensure all CTAs at mobile breakpoint have consistent width behavior
+- Multiple CTA instances in `_includes/products.html`, `_includes/cta.html` may be affected
+
+## Backlog References
+
+Fix-260524-06 (was 10.10 in old Phase 10)
+
+## Design Constraints
+
+- Mobile (≤599px): all CTAs take `width: 100%` (per `.specs/cta-design/README.md`)
+- Touch targets: minimum 44×44px
+- Padding should be consistent across all CTA types
+
+## Acceptance Criteria
+
+- [ ] All CTAs have the same width at mobile breakpoint
+- [ ] Consistent padding across all CTA types
+- [ ] Text does not overflow or get clipped
+- [ ] Desktop widths remain unchanged (auto width, minimum 200px)

--- a/.specs/profile-card-redesign/README.md
+++ b/.specs/profile-card-redesign/README.md
@@ -1,0 +1,28 @@
+# Profile Card Redesign — Fix Specification
+
+## Problem
+
+Profile card images have incorrect sizing and proportions in both compact and expanded views. Images appear too small in compact mode and proportions are inconsistent when expanded, creating a fragmented visual experience.
+
+## Scope
+
+- `assets/css/profiles.css` — adjust `.profile-image` and `.profile-image-large` dimensions, aspect ratios, and layout spacing
+- Ensure the profile card layout accommodates different image aspect ratios without distortion
+
+## Backlog References
+
+Fix-260524-02 (was 10.5 in old Phase 10)
+
+## Design Constraints
+
+- Touch targets: minimum 44×44px
+- Dark mode: use CSS variables from `colors.css` for all backgrounds and borders
+- Profile images aspect ratio: 1:1 (square) as specified in `.design/graphics.md`
+
+## Acceptance Criteria
+
+- [ ] Profile images display at consistent size in compact view (≥80×80px)
+- [ ] Large profile image in expanded view maintains aspect ratio without distortion
+- [ ] Layout does not jump or shift when expanding/collapsing
+- [ ] Dark mode tested
+- [ ] Mobile layout tested

--- a/.specs/profile-card-test-fixes/README.md
+++ b/.specs/profile-card-test-fixes/README.md
@@ -1,0 +1,51 @@
+# Profile Card User Test Fixes — Fix Specification
+
+## Problem
+
+User testing (P5 brukertest) identified 4 visual issues with profile card behavior. Each has a clear root cause and fix scope.
+
+## Issues
+
+### D12 — Profile image too small in compact view (Fix-260527-08)
+
+- **Problem:** Brukertest funn #4 — profile images are too small in compact card view; difficult to recognize people
+- **Scope:** `assets/css/profiles.css`
+- **Fix:** Increase image size in `.profile-compact` to minimum 80×80px, adjust layout to prevent overlap
+
+### D13 — Profile image jumps on expand (Fix-260527-09)
+
+- **Problem:** Brukertest funn #5 — profile image changes position when card expands, creating a jarring layout shift
+- **Scope:** `assets/css/profiles.css`
+- **Fix:** Use consistent image placement regardless of expanded/compact state; eliminate layout shift
+
+### D14 — Contact link styling inconsistent (Fix-260527-10)
+
+- **Problem:** Brukertest funn #8 — phone/email/linkedin links in profile details have inconsistent styling, lack visual hierarchy
+- **Scope:** `assets/css/profiles.css`
+- **Fix:** Define one link style for all contact points (icon + text, same color, same hover effect)
+
+### D15 — Hero missing rounded bottom corners (Fix-260527-11)
+
+- **Problem:** Brukertest funn #13 — hero banner has sharp bottom edges, breaking the rounded design language used elsewhere
+- **Scope:** CSS — `layout.css` or the relevant hero component
+- **Fix:** Add `border-radius: 0 0 <value> <value>` to hero banner for consistent visual language
+
+## Backlog References
+
+Fix-260527-08 through Fix-260527-11 (was D12-D15 in old Phase 11)
+
+## Design Constraints
+
+- Touch targets: minimum 44×44px
+- Dark mode: all fixes must use CSS variables from `colors.css`
+- Profile card behavior (expand/collapse) must remain functional
+- Ensure `border-radius` does not break gradient overlay or hero image display
+
+## Acceptance Criteria
+
+- [ ] Profile images are ≥80×80px in compact view
+- [ ] No layout shift when expanding/collapsing profile cards
+- [ ] All contact links have consistent styling with clear visual hierarchy
+- [ ] Hero banner has rounded bottom corners matching the site's design language
+- [ ] Dark mode tested for all changes
+- [ ] Mobile layout tested

--- a/.specs/profile-filter/README.md
+++ b/.specs/profile-filter/README.md
@@ -1,0 +1,28 @@
+# Frontpage Profile Filter — Fix Specification
+
+## Problem
+
+The frontpage (`index.md`) shows all team profiles regardless of context. Profiles should be filterable based on page context using a Liquid filter, so relevant profiles appear on relevant pages.
+
+## Scope
+
+- `_includes/profiles.html` — add Liquid context filter logic (e.g., `where` filter or tag-based matching)
+- `index.md` or relevant frontmatter — define which profiles to show per page context
+- `_profiles/*.md` — ensure frontmatter tags are parseable for filtering
+
+## Backlog References
+
+Fix-260524-03 (was 10.6 in old Phase 10)
+
+## Design Constraints
+
+- Vanilla Liquid — no JavaScript for filtering
+- Existing template structure should be preserved
+- Fallback: if no filter context is provided, show all profiles (current behavior)
+
+## Acceptance Criteria
+
+- [ ] Frontpage shows only profiles matching page context
+- [ ] Fallback shows all profiles when no filter is defined
+- [ ] All profiles still render via their dedicated profile pages
+- [ ] Site builds without Liquid errors

--- a/.specs/profile-tag-formatting/README.md
+++ b/.specs/profile-tag-formatting/README.md
@@ -1,0 +1,27 @@
+# Profile Tag Formatting — Fix Specification
+
+## Problem
+
+`{{ profile.tags }}` in the profiles include renders as raw frontmatter text without spacing or formatting. Tags from `_profiles/*.md` frontmatter (e.g., `#struktur #mennesker`) need proper visual rendering.
+
+## Scope
+
+- `_includes/profiles.html` — apply Liquid filters (`split`, `join`, or loop) to render tags with proper spacing
+- CSS in `assets/css/profiles.css` — optional: style tag display (inline-block, badges, etc.)
+
+## Backlog References
+
+Fix-260524-11 (was D4 in old Phase 11)
+
+## Design Constraints
+
+- Tags should be visually scannable
+- No JavaScript for tag rendering — Liquid only
+- Preserve existing tag data structure in frontmatter (`tags: "#tag1 #tag2"`)
+
+## Acceptance Criteria
+
+- [ ] Tags render with proper spacing between each tag
+- [ ] Each tag is visually distinct (not a single blob of text)
+- [ ] Dark mode: tag styling is consistent
+- [ ] Mobile: tags wrap gracefully on small screens

--- a/.specs/regression-fixes-phase6/README.md
+++ b/.specs/regression-fixes-phase6/README.md
@@ -1,0 +1,56 @@
+# Phase 6 Regression Fixes — Fix Specification
+
+## Problem
+
+Content regressions introduced during Phase 7 scroll-animation and SEO work (commit `d1d6ac5`). These are structural HTML issues in the `_pages/ledelse_*.md` content files.
+
+## Issues
+
+### R1 — `_pages/ledelse_forankring.md` trunkert (Fix-260522-01)
+
+- **Problem:** CTA section cut mid-`<h2>` — missing body text, two CTA buttons, closing `</section>`, and 4 footnote references
+- **Cause:** Commit `d1d6ac5` — file went from 315 → 106 lines
+- **Fix:** Restore CTA content from historical commit, add footnotes, close open `<sup>` tags
+
+### R2 — `_pages/ledelse_usikkerhet.md` feil permalink og navn (Fix-260522-02)
+
+- **Note:** This is covered by `.specs/usikkerhet-rename/README.md`. The scope here is the `<sup>` tags only.
+- **Scope:** 12 open `<sup>` tags in addition to the permalink work
+
+### R3 — `_pages/ledelse_tillit.md` nestede `<sup>`-tagger (Fix-260522-03)
+
+- **Problem:** Line 115: 5 `<sup>` tags nested without `</sup>`
+- **Cause:** Commit `90f39cc`
+- **Scope:** `_pages/ledelse_tillit.md`
+- **Fix:** Separate into correct `<sup>...</sup>` per citation, close all 11 open `<sup>` tags
+
+### R4 — `_pages/ledelse_generativ-ki.md` mangler `</sup>` (Fix-260522-04)
+
+- **Problem:** One open `<sup>` on line 90 (Hubbard citation)
+- **Scope:** `_pages/ledelse_generativ-ki.md`
+- **Fix:** Add `</sup>` at the correct position
+
+### R5 — Alle `<sup class="citation">` mangler `</sup>` (Fix-260522-05)
+
+- **Problem:** Systematic issue — no `</sup>` tags found; subsequent text is rendered as superscript
+- **Scope:** All `_pages/ledelse_*.md` files
+- **Fix:** Audit and close all open `<sup class="citation">` tags across all article pages
+
+## Backlog References
+
+Fix-260522-01 through Fix-260522-06 (Phase 6 — R1 through R6)
+
+## Dependencies
+
+- R2 and R6 share scope with `.specs/usikkerhet-rename/README.md` — coordinate or do together
+- R5 is cross-file and should be done last to avoid re-work
+
+## Acceptance Criteria
+
+- [ ] R1: `_pages/ledelse_forankring.md` has complete CTA section, footnotes, and closed tags
+- [ ] R2: `_pages/ledelse_usikkerhet.md` has all `<sup>` tags closed
+- [ ] R3: `_pages/ledelse_tillit.md` has no nested `<sup>` issues
+- [ ] R4: `_pages/ledelse_generativ-ki.md` has closed `<sup>` on line 90
+- [ ] R5: No unclosed `<sup class="citation">` in any `_pages/ledelse_*.md` file
+- [ ] Site builds without HTML/lint errors
+- [ ] Citations render correctly in both light and dark mode

--- a/.specs/security/README.md
+++ b/.specs/security/README.md
@@ -1,0 +1,192 @@
+# Web Application Security Rules
+
+> Status: Ready
+> Created: 2026-05-29
+> Purpose: OWASP-derived, testable security rules for the noexcuse.no static site (vanilla JS, HTML, CSS, Liquid templates, no backend).
+
+## Sources
+
+| Source | URL |
+|--------|-----|
+| OWASP XSS Prevention Cheat Sheet | https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html |
+| OWASP DOM-based XSS Prevention Cheat Sheet | https://cheatsheetseries.owasp.org/cheatsheets/DOM_based_XSS_Prevention_Cheat_Sheet.html |
+| OWASP Content Security Policy Cheat Sheet | https://cheatsheetseries.owasp.org/cheatsheets/Content_Security_Policy_Cheat_Sheet.html |
+| OWASP HTML5 Security Cheat Sheet | https://cheatsheetseries.owasp.org/cheatsheets/HTML5_Security_Cheat_Sheet.html |
+| OWASP Clickjacking Defense Cheat Sheet | https://cheatsheetseries.owasp.org/cheatsheets/Clickjacking_Defense_Cheat_Sheet.html |
+| OWASP HTTP Headers Cheat Sheet | https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html |
+| OWASP Third Party JavaScript Management Cheat Sheet | https://cheatsheetseries.owasp.org/cheatsheets/Third_Party_Javascript_Management_Cheat_Sheet.html |
+| OWASP DOM Clobbering Prevention Cheat Sheet | https://cheatsheetseries.owasp.org/cheatsheets/DOM_Clobbering_Prevention_Cheat_Sheet.html |
+| OWASP Prototype Pollution Prevention Cheat Sheet | https://cheatsheetseries.owasp.org/cheatsheets/Prototype_Pollution_Prevention_Cheat_Sheet.html |
+| OWASP Securing Cascading Style Sheets Cheat Sheet | https://cheatsheetseries.owasp.org/cheatsheets/Securing_Cascading_Style_Sheets_Cheat_Sheet.html |
+| OWASP NPM Security Cheat Sheet | https://cheatsheetseries.owasp.org/cheatsheets/NPM_Security_Cheat_Sheet.html |
+
+## Scope
+
+All HTML, JavaScript, CSS, Liquid template, and configuration files in the repository. Does not cover server-side security (no backend), authentication (no user accounts), or database security (no database).
+
+---
+
+## XSS — Cross-Site Scripting (10 rules)
+
+| ID | Rule | Forbidden | Location | Phase |
+|----|------|-----------|----------|-------|
+| XSS-1 | innerHTML/outerHTML/document.write only with trusted/sanitized strings | Using any untrusted data (URL params, referrer, cookie, postMessage) in innerHTML | `*.js` | lint, commit |
+| XSS-2 | Prefer textContent over innerHTML for plain text | innerHTML where textContent suffices | `*.js` | lint, commit |
+| XSS-3 | Liquid auto-escapes HTML — never use `raw` filter on untrusted data | `{{ var \| raw }}`, `{{ var \| safe }}` | `*.html`, `*.md` | lint, commit |
+| XSS-4 | All HTML attribute values MUST be quoted | `<div class={{ var }}>` unquoted | `*.html`, templates | lint |
+| XSS-5 | Dynamic href/src MUST validate protocol is http/https only | `javascript:` protocol, data URIs in script context | `*.js`, templates | lint, commit |
+| XSS-6 | No eval(), Function(), setTimeout(string), setInterval(string) | All string-to-JS execution | `*.js` | lint, commit |
+| XSS-7 | No `javascript:` URLs in any attribute | `<a href="javascript:...">` etc. | `*.html`, `*.js` | lint |
+| XSS-8 | If innerHTML unavoidable, MUST sanitize via DOMPurify | innerHTML without sanitization on untrusted data | `*.js` | lint, commit |
+| XSS-9 | Event handler attributes (onclick etc.) NEVER set from untrusted data | `setAttribute("onclick", str)` or `el.onclick = str` | `*.js` | lint, commit |
+| XSS-10 | Inline `<script>` blocks with Liquid data MUST JS-encode values | Untrusted data in script without quoting/encoding | `*.html` | build, review |
+
+---
+
+## DOM — DOM-based XSS & Clobbering (11 rules)
+
+| ID | Rule | Forbidden | Location | Phase |
+|----|------|-----------|----------|-------|
+| DOM-1 | Dynamic DOM uses createElement/setAttribute/appendChild | Building HTML strings for innerHTML | `*.js` | lint, commit |
+| DOM-2 | setAttribute only with safe attr names (id, class, href, data-*, aria-*, style) | Event handler names in setAttribute | `*.js` | lint, commit |
+| DOM-3 | postMessage handler MUST check event.origin against allowlist | Processing messages without origin check | `*.js` | lint, commit |
+| DOM-4 | postMessage data used as text only (textContent), never eval'd or set as HTML | innerHTML/eval on event.data | `*.js` | lint, commit |
+| DOM-5 | No implicit eval: setTimeout(string), setInterval(string), new Function(string) | All implicit eval patterns | `*.js` | lint, commit |
+| DOM-6 | URL fragment (location.hash) NEVER written to innerHTML or eval | `innerHTML = location.hash` | `*.js` | lint, commit |
+| DOM-7 | All JS files use `"use strict"` | Implicit globals clobbered by DOM id | `*.js` | lint |
+| DOM-8 | All variables declared with let/const/var | Assignment to undeclared variables | `*.js` | lint |
+| DOM-9 | Store app data in local variables/modules, NOT window/document | `window.X = value` where X could match DOM element id | `*.js` | commit, review |
+| DOM-10 | Check typeof/instanceof before using window/document properties | Using window.config without checking type | `*.js` | lint, commit |
+| DOM-11 | Hash-based navigation values displayed via textContent | `innerHTML = location.hash` | `*.js` | lint, commit |
+
+---
+
+## CSP — Content Security Policy (8 rules)
+
+| ID | Rule | Forbidden | Location | Phase |
+|----|------|-----------|----------|-------|
+| CSP-1 | CSP via HTTP header (not only meta tag) — meta ignores frame-ancestors, sandbox | CSP only in `<meta>` tag | Server config | deploy |
+| CSP-2 | Minimum: `default-src 'self'; frame-ancestors 'none'; form-action 'self'; base-uri 'self'` | Missing or overly permissive CSP | Server config | deploy |
+| CSP-3 | Inline scripts use nonce/hash; no `unsafe-inline` | `script-src 'unsafe-inline'` | Server config | deploy |
+| CSP-4 | No `unsafe-eval` in CSP | `unsafe-eval` keyword | Server config | deploy |
+| CSP-5 | CSP includes `object-src 'none'` and `base-uri 'none'` (or 'self') | Missing object-src, base-uri | Server config | deploy |
+| CSP-6 | CSP includes `frame-ancestors 'none'` (or 'self' if framing needed) | `frame-ancestors *` or missing | Server config | deploy |
+| CSP-7 | HTTPS site: CSP includes `upgrade-insecure-requests` | Mixed content | Server config | deploy |
+| CSP-8 | Production uses enforced CSP, not just Report-Only | Report-Only only | Server config | deploy |
+
+---
+
+## HEADERS — HTTP Security Headers (9 rules)
+
+| ID | Rule | Forbidden | Location | Phase |
+|----|------|-----------|----------|-------|
+| HDR-1 | `Strict-Transport-Security: max-age=63072000; includeSubDomains; preload` | Missing HSTS, short max-age | Server config | deploy |
+| HDR-2 | `X-Content-Type-Options: nosniff` | Missing or wrong value | Server config | deploy |
+| HDR-3 | `X-Frame-Options: DENY` (fallback for CSP frame-ancestors) | ALLOW-FROM (obsolete) | Server config | deploy |
+| HDR-4 | `Referrer-Policy: strict-origin-when-cross-origin` or `no-referrer` | `unsafe-url` | Server config | deploy |
+| HDR-5 | `Permissions-Policy` disables all unneeded features | Missing Permissions-Policy | Server config | deploy |
+| HDR-6 | Remove `Server`, `X-Powered-By` fingerprinting headers | Framework/version exposure | Server config | deploy |
+| HDR-7 | `Cross-Origin-Opener-Policy: same-origin` | `unsafe-none` | Server config | deploy |
+| HDR-8 | `Cross-Origin-Resource-Policy: same-site` | `cross-origin` unnecessarily | Server config | deploy |
+| HDR-9 | Static assets: `Cache-Control: public, max-age=31536000, immutable`. HTML: `no-cache` | Wrong cache policy on assets or HTML | Server config | deploy |
+
+---
+
+## DEPS — Dependencies & Third-Party JS (8 rules)
+
+| ID | Rule | Forbidden | Location | Phase |
+|----|------|-----------|----------|-------|
+| DEP-1 | All external `<script src>` include `integrity` with sha384/sha512 hash | External scripts without SRI | `*.html` | lint, commit |
+| DEP-2 | SRI scripts also set `crossorigin="anonymous"` | SRI without crossorigin | `*.html` | lint, commit |
+| DEP-3 | package-lock.json MUST be committed and not gitignored | Missing lockfile, loose ranges without lock | repo root | commit |
+| DEP-4 | npm audit MUST pass (no critical/high vulns in production deps) | Known vulns in production deps | package.json | build, commit |
+| DEP-5 | Check vendored JS libraries for known CVEs (npx retire) | Known-vulnerable bundled libraries | assets/scripts/ | build |
+| DEP-6 | Third-party scripts in sandboxed iframe or limited DOM access pattern | Third-party scripts with full DOM access | `*.html` | deploy |
+| DEP-7 | All `target="_blank"` links include `rel="noopener noreferrer"` | target=_blank without noopener | `*.html`, templates | lint, commit |
+| DEP-8 | New npm packages verified on official registry with real publisher/history | AI-suggested packages without verification | package.json | commit |
+
+---
+
+## FORMS — Form & Input (3 rules)
+
+| ID | Rule | Forbidden | Location | Phase |
+|----|------|-----------|----------|-------|
+| FRM-1 | CSP includes `form-action 'self'` | `form-action *` or missing | Server config | deploy |
+| FRM-2 | State-changing forms use `method="POST"`, not GET | GET for non-search forms | `*.html` | lint, review |
+| FRM-3 | PII input fields use `autocomplete="off"` | PII fields without autocomplete off | `*.html` | lint |
+
+---
+
+## LINKS — Link & Navigation (3 rules)
+
+| ID | Rule | Forbidden | Location | Phase |
+|----|------|-----------|----------|-------|
+| LNK-1 | target=_blank links MUST have rel="noopener noreferrer" (see DEP-7) | — | `*.html` | lint |
+| LNK-2 | window.location uses hardcoded paths, not URL params/hash | Dynamic redirect via URL params | `*.js` | lint, commit |
+| LNK-3 | Dynamic URLs allow http/https only | `javascript:`, `data:`, `vbscript:` in href/src | `*.js`, `*.html` | lint, commit |
+
+---
+
+## STORAGE — Client-Side Storage (3 rules)
+
+| ID | Rule | Forbidden | Location | Phase |
+|----|------|-----------|----------|-------|
+| STG-1 | localStorage/sessionStorage MUST NOT contain tokens, API keys, or PII | Secrets in localStorage | `*.js` | lint, commit |
+| STG-2 | Use sessionStorage for transient data, not localStorage | localStorage for temporary data | `*.js` | commit, review |
+| STG-3 | localStorage data MUST be validated/encoded before DOM use | Direct innerHTML from localStorage | `*.js` | lint, commit |
+
+---
+
+## SANDBOX — iframe & Embedding (2 rules)
+
+| ID | Rule | Forbidden | Location | Phase |
+|----|------|-----------|----------|-------|
+| SAN-1 | All iframes embedding cross-origin content MUST use sandbox attribute | iframe without sandbox embedding untrusted content | `*.html` | lint |
+| SAN-2 | sandbox permissions minimal: never allow-top-navigation unless required | Overly permissive sandbox | `*.html` | lint |
+
+---
+
+## CSS — CSS Security (3 rules)
+
+| ID | Rule | Forbidden | Location | Phase |
+|----|------|-----------|----------|-------|
+| CSS-1 | CSS class names MUST NOT reveal authorization/role information (adminPanel, deleteUser) | Authorization-level class names in public CSS | `*.css` | commit, review |
+| CSS-2 | CSS MUST NOT contain expression(), javascript:, or behavior: URLs | IE expression(), url(javascript:) | `*.css` | lint |
+| CSS-3 | User-generated CSS (if any) MUST be sanitized or restricted | Arbitrary CSS from user input | `*.css`, `*.js` | lint, commit |
+
+---
+
+## PROTO — Prototype Pollution (3 rules)
+
+| ID | Rule | Forbidden | Location | Phase |
+|----|------|-----------|----------|-------|
+| PROTO-1 | Use Map/Set instead of `{}` for collections where possible | Plain `{}` for associative data | `*.js` | lint, commit |
+| PROTO-2 | Object.create(null) for dictionaries with external keys | `{}` without null prototype for ext-keyed storage | `*.js` | lint, commit |
+| PROTO-3 | Config objects and constants SHOULD be Object.freeze()'d or Object.seal()'d | Mutable config objects | `*.js` | commit, review |
+
+---
+
+## Summary
+
+| Category | Count | Primary Phase | Testable Via |
+|----------|-------|--------------|-------------|
+| XSS | 10 | lint, commit | ESLint, htmlhint, manual review |
+| DOM | 11 | lint, commit | ESLint, manual review |
+| CSP | 8 | deploy | Observatory, curl header check |
+| HEADERS | 9 | deploy | Observatory, curl header check |
+| DEPS | 8 | build, commit | npm audit, npx retire, htmlhint |
+| FORMS | 3 | lint, deploy | htmlhint, CSP check |
+| LINKS | 3 | lint, commit | htmlhint, ESLint |
+| STORAGE | 3 | lint, commit | ESLint, manual review |
+| SANDBOX | 2 | lint, commit | htmlhint |
+| CSS | 3 | lint, commit | stylelint |
+| PROTO | 3 | lint, commit | ESLint |
+| **Total** | **63** | — | — |
+
+## Acceptance Criteria
+
+- [ ] All 63 rules are reviewed for applicability to the project
+- [ ] Each rule with Phase "lint" has a corresponding ESLint/htmlhint/stylelint rule or manual review process documented
+- [ ] Each rule with Phase "commit" is verified before every commit (via pre-commit hooks or manual checklist)
+- [ ] Each rule with Phase "build" is verified during CI
+- [ ] Each rule with Phase "deploy" (CSP, headers) is verified in staging before production deploy

--- a/.specs/usikkerhet-rename/README.md
+++ b/.specs/usikkerhet-rename/README.md
@@ -1,0 +1,25 @@
+# `/organisasjonskultur/` → `/usikkerhet/` — Fix Specification
+
+## Problem
+
+`_pages/ledelse_usikkerhet.md` has `permalink: /organisasjonskultur/` — the permalink does not match the page's actual subject (usikkerhet / uncertainty). The `/organisasjonskultur/` URL is misleading and inconsistent with the navigation structure.
+
+Also: 12 open `<sup>` tags in the same file need closing.
+
+## Scope
+
+- `_pages/ledelse_usikkerhet.md` — change `permalink:` to `/usikkerhet/`, fix frontmatter, JSON-LD, close `<sup>` tags
+- `_pages/ledelse_60-2.md` — update any cross-reference to `/organisasjonskultur/` → `/usikkerhet/`
+- `_products/ledelse-60-2.md` — same cross-reference update
+- No redirect needed — site is small and Google will re-index on next build
+
+## Backlog References
+
+Fix-260524-01, Fix-260522-06 (R6)
+
+## Acceptance Criteria
+
+- [ ] `permalink:` changed to `/usikkerhet/`
+- [ ] All cross-references in `_pages/ledelse_60-2.md` and `_products/ledelse-60-2.md` updated
+- [ ] All 12 open `<sup>` tags closed in `_pages/ledelse_usikkerhet.md`
+- [ ] Site builds and renders `/usikkerhet/` correctly


### PR DESCRIPTION
## Summary

Bonus PR containing pre-existing spec and design documentation files that were untracked in the working directory.

### Commits

1. **docs(design): add information architecture cross-link map** — `.design/information-architecture.md`
2. **docs(specs): add feature specifications across 14 areas** — Specs for: booking-direct-links, brand-trait-reconciliation, hero-layout-fixes, inbound-sales, metode-overhaul, mobile-cta-widths, profile-card-redesign, profile-card-test-fixes, profile-filter, profile-tag-formatting, regression-fixes-phase6, security, usikkerhet-rename, and TEMPLATE.md

No functional changes — documentation only.