### PR TITLE
fix(css): CTA hover color-swap per Type A/B spec

### DIFF
--- a/assets/css/products.css
+++ b/assets/css/products.css
@@ -38,22 +38,26 @@
 }
 
 .product-cta {
-    display: inline-block;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 44px;
     padding: 14px 32px;
     background-color: var(--cta-primary-bg);
     color: var(--cta-primary-text);
     text-decoration: none;
-    border-radius: var(--radius-md);
+    border-radius: 4px;
     font-weight: 600;
     font-size: 1.05em;
     border: 2px solid var(--cta-primary-border);
     cursor: pointer;
-    transition: opacity 0.2s, transform 0.2s;
+    transition: background-color 0.2s ease, color 0.2s ease;
 }
 
 .product-cta:hover {
-    opacity: 0.9;
-    transform: translateY(-2px);
+    background-color: var(--cta-primary-text);
+    color: var(--cta-primary-bg);
+    border-color: var(--cta-primary-bg);
 }
 
 .product-cta--spaced {
@@ -67,8 +71,9 @@
 }
 
 .product-cta--secondary:hover {
-    opacity: 0.9;
-    transform: translateY(-2px);
+    background-color: var(--cta-secondary-text);
+    color: var(--cta-secondary-bg);
+    border-color: var(--cta-secondary-bg);
 }
 
 .product-link {
@@ -420,10 +425,6 @@
 }
 
 .benefit-card .product-cta {
-    margin: 0 var(--space-lg) var(--space-lg);
-    align-self: flex-start;
-}
-efit-card .product-cta {
     margin: 0 var(--space-lg) var(--space-lg);
     align-self: flex-start;
 }


### PR DESCRIPTION
## Summary

Implements D2 from BACKLOG — replaces opacity/translateY hover effects on CTA buttons with proper color-swap transitions per `.specs/cta-design/README.md`.

### Changes

**Type A (.product-cta):**
- `display: inline-block` → `inline-flex` with `align-items/justify-content: center`
- Added `min-height: 44px` for touch targets
- `border-radius: var(--radius-md)` → `4px` (per spec)
- `transition: opacity 0.2s, transform 0.2s` → `background-color 0.2s ease, color 0.2s ease`
- Hover: `opacity: 0.9 + translateY(-2px)` → `bg: navy, text: azure, border: azure`

**Type B (.product-cta--secondary):**
- Hover: `opacity: 0.9 + translateY(-2px)` → `bg: azure, text: navy, border: navy`

**Bonus fix:** Removed duplicate broken CSS selector `efit-card .product-cta` (was missing leading dot — lines 431-434).

### Files
`assets/css/products.css` — 12 insertions, 11 deletions

Closes: D2