### PR TITLE
fix: Profile card improvements — image size, layout shift, contact links (D12-D14)

### DIFF
--- a/assets/css/layout.css
+++ b/assets/css/layout.css
@@ -1,4 +1,8 @@
 /* Layout.css */
+html {
+    scrollbar-gutter: stable;
+}
+
 html, body {
     display: flex;
     flex-direction: column;

--- a/assets/css/profiles.css
+++ b/assets/css/profiles.css
@@ -28,11 +28,11 @@
 }
 
 .profile-image {
-    width: 100px;
-    height: 100px;
+    width: 120px;
+    height: 120px;
     border-radius: 50%;
     object-fit: cover;
-    margin-bottom: 16px;
+    margin-bottom: 20px;
 }
 
 .profile-name {
@@ -43,9 +43,28 @@
 .profile-contact {
     display: flex;
     flex-direction: column;
-    gap: 4px;
+    gap: 6px;
     margin-bottom: 16px;
     font-size: 0.9em;
+}
+
+.profile-phone,
+.profile-email {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 6px 14px;
+    border-radius: var(--radius-md);
+    background: rgba(0, 0, 0, 0.03);
+    color: var(--link-color-light);
+    text-decoration: none;
+    transition: background 0.2s ease;
+    word-break: break-all;
+}
+
+.profile-phone:hover,
+.profile-email:hover {
+    background: rgba(0, 0, 0, 0.06);
 }
 
 .profile-expand-btn {

--- a/assets/css/styles-dark.css
+++ b/assets/css/styles-dark.css
@@ -133,6 +133,17 @@ a:hover {
     color: var(--text-color-dark);
 }
 
+.profile-phone,
+.profile-email {
+    color: var(--link-color-dark);
+    background: rgba(255, 255, 255, 0.06);
+}
+
+.profile-phone:hover,
+.profile-email:hover {
+    background: rgba(255, 255, 255, 0.12);
+}
+
 .profile-expanded {
     background: rgba(0, 0, 0, 0.8);
 }


### PR DESCRIPTION
## Summary

Three profile card fixes based on `.specs/profile-card-redesign/README.md`.

### D12 — Profile image too small in compact view
- `.profile-image` increased from 100×100px → 120×120px
- Bottom margin increased from 16px → 20px for better spacing

### D13 — Image "jumps" when profile modal opens
- Added `scrollbar-gutter: stable` to `html` — prevents the page from shifting right when `overflow: hidden` removes the scrollbar on modal open
- This is a common UX fix: the scrollbar space is always reserved, so toggling overflow: hidden no longer causes layout shift

### D14 — Contact links inconsistent styling in compact view
- Added pill-style styling to `.profile-phone` and `.profile-email` in the compact card: background chip, border-radius, hover state
- Matches the visual style of `.profile-contact-item` in the expanded view
- Dark mode variants included (white overlay background)

### Files
| File | Changes |
|------|---------|
| `assets/css/profiles.css` | +27/-4: larger image, contact link styling |
| `assets/css/layout.css` | +4: scrollbar-gutter on html |
| `assets/css/styles-dark.css` | +11: dark mode for new contact link styles |

### Verification
- Zero new stylelint errors (3 pre-existing duplicates unchanged)
- Phone/email links in compact view now have consistent visual treatment
- No layout shift when opening/closing profile modal

Closes: D12, D13, D14