### PR TITLE
10.7: Full-width hero sections

### DIFF
--- a/assets/css/about.css
+++ b/assets/css/about.css
@@ -1,7 +1,5 @@
 .about-hero {
     display: grid;
-    max-width: 1100px;
-    margin: 0 auto;
     padding: 0;
 }
 

--- a/assets/css/article.css
+++ b/assets/css/article.css
@@ -1,8 +1,6 @@
 .perspektiv-hero,
 .frame-hero {
     display: grid;
-    max-width: 1100px;
-    margin: 0 auto;
     padding: 0;
 }
 

--- a/assets/css/products.css
+++ b/assets/css/products.css
@@ -143,8 +143,6 @@
 
 .landing-hero {
     display: grid;
-    max-width: 1100px;
-    margin: 0 auto;
     padding: 0;
 }
 
@@ -205,8 +203,6 @@
 
 .science-hero {
     display: grid;
-    max-width: 1100px;
-    margin: 0 auto;
     padding: 0;
 }
 


### PR DESCRIPTION
## What
Removes `max-width: 1100px; margin: 0 auto;` from all hero sections so they extend edge-to-edge.

## Changed files
- `assets/css/products.css` — `.landing-hero` + `.science-hero`
- `assets/css/article.css` — `.perspektiv-hero, .frame-hero`
- `assets/css/about.css` — `.about-hero`

## Spec
`.specs/hero-layout-fixes/README.md` — Fix-260524-04

## Verification
- Hero images fill full viewport width
- Non-hero sections remain at `max-width: 1100px` (unchanged)
- Mobile breakpoints unaffected (no width changes on hero content padding)