### PR TITLE
10.6: Frontpage profile filter

### DIFF
--- a/_includes/profiles.html
+++ b/_includes/profiles.html
@@ -1,5 +1,18 @@
 <section id="profiles" class="profiles section container">
     {% for profile in site.profiles %}
+    {% if include.tags %}
+        {% assign filter_tags = include.tags | split: "," %}
+        {% assign matches = false %}
+        {% for filter_tag in filter_tags %}
+            {% assign ft = filter_tag | strip | downcase %}
+            {% assign pt = profile.tags | downcase %}
+            {% if pt contains ft %}
+                {% assign matches = true %}
+                {% break %}
+            {% endif %}
+        {% endfor %}
+        {% unless matches %}{% continue %}{% endunless %}
+    {% endif %}
     <div class="profile">
         <div class="profile-compact">
             <img class="profile-image" src="{{ profile.image | relative_url }}" alt="{{ profile.name }}s profilbilde">

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -4,7 +4,7 @@ breadcrumb: false
 ---
 {{ content }}
 {% include products.html %}
-{% include profiles.html %}
+{% include profiles.html tags="ledelse" %}
 {% include podcast.html %}
 {% include cases.html %}
 {% include partners.html %}


### PR DESCRIPTION
## What
Adds a Liquid tag-based filter to `_includes/profiles.html` so pages can show only profiles matching specific tags.

## How it works
- `{% include profiles.html tags=ledelse %}` — shows only profiles whose tags contain 'ledelse'
- `{% include profiles.html %}` (no parameter) — shows all profiles (existing behavior)

## Changes
- `_includes/profiles.html` — added filter logic with {% continue %} skip for non-matching profiles
- `_layouts/home.html` — filters frontpage profiles to 'ledelse'

## Spec
`.specs/profile-filter/README.md` — Fix-260524-03