### PR TITLE
chore(specs): add specs for FF1, FF2, FF5, FF6, P5, X2 and update BACKLOG.md

### DIFF
--- a/.specs/dark-mode-audit/README.md
+++ b/.specs/dark-mode-audit/README.md
@@ -1,0 +1,50 @@
+# Dark Mode Consistency — Feature Specification
+
+> Created: 2026-05-30
+> Status: Ready
+
+## Purpose / Problem
+
+Dark mode was added for core pages but consistency was never verified across every component and page type. Some components may use hardcoded colors instead of CSS variables, or miss explicit dark mode rules entirely.
+
+## Decision
+
+- **Scope:** Full site audit — every component on every page type is reviewed and fixed
+
+## Scope
+
+**Audit checklist (every component):**
+- [ ] Header (logo, navigation links, mobile menu)
+- [ ] Hero sections (headings, text, overlays, CTAs)
+- [ ] Benefit/feature cards
+- [ ] Profile cards
+- [ ] Product cards
+- [ ] Article content (body text, blockquotes, code blocks, tables)
+- [ ] Footer (links, text, dividers)
+- [ ] Forms and buttons
+- [ ] Section backgrounds and borders
+- [ ] Images and SVGs (filter/invert logic)
+
+Files to modify:
+
+- `assets/css/styles-dark.css` — primary dark mode CSS file
+- Any component-specific CSS files that hardcode colors instead of using CSS variables
+- `_includes/` components that need dark mode aware markup
+- HTML templates that may need `data-theme` or class-based dark mode support
+
+## Acceptance Criteria
+
+- [ ] Every page type renders correctly in dark mode
+- [ ] No hardcoded light-mode colors remain in components
+- [ ] All colors use CSS variables from `colors.css`
+- [ ] Dark mode toggle works consistently across all pages
+- [ ] No contrast violations (WCAG AA minimum) in dark mode
+- [ ] Mobile and desktop both tested
+
+## Backlog References
+
+X2
+
+## Dependencies
+
+None. Independent of other features.

--- a/.specs/emne/README.md
+++ b/.specs/emne/README.md
@@ -1,20 +1,40 @@
-# Emne/Tag — Specification (Future Feature)
+# Emne/Tag — Feature Specification
 
-## Purpose and Scope
+> Created: 2026-05-30
+> Status: Ready
 
-A tag lookup page at `/emne/` that allows visitors to browse and filter content by topic/tag across all articles and profiles.
+## Purpose / Problem
 
-## Status
+Visitors need a way to browse content by topic. Currently articles have frontmatter tags but there's no `/emne/` page to discover them — tags are invisible to users and offer no navigation value.
 
-**Future feature — not yet spec'd or scheduled.** This document is a placeholder for when the feature is prioritized.
+## Decision
 
-## Requirements (TBD)
+- **Generation:** Server-generated Jekyll pages (one page per tag)
+- **Tag source:** Free-form — any string in an article's `tags` frontmatter array automatically becomes a page
+- **Scope:** Articles only (not profiles, products, or frame pages)
 
-- URL: `/emne/` with individual tag pages at `/emne/<tag>/`
-- Filter/search across all articles, frames, and products by frontmatter tags
-- Tag cloud or listing view with article counts
-- Clean URL structure compatible with Jekyll collections
+## Scope
+
+Files to create/modify:
+
+- `.specs/emne/README.md` — this spec
+- `_pages/emne.md` — the `/emne/` landing page (list of tags with counts)
+- `_layouts/tag.html` — layout for individual `/emne/<tag>/` pages
+- `_config.yml` — register the tag collection or generator plugin
+
+## Acceptance Criteria
+
+- [ ] `/emne/` shows all unique tags across articles, each with a count of matching articles
+- [ ] Each tag name links to `/emne/<tag>/` showing a list of articles with that tag
+- [ ] Tags with zero articles never appear
+- [ ] Tag pages use the standard site layout (header/footer)
+- [ ] Dark mode tested on both `/emme/` and `/emne/<tag>/` pages
+- [ ] Mobile layout tested — tag cloud and article lists are readable on small screens
+
+## Backlog References
+
+FF1
 
 ## Dependencies
 
-- None. Independent of other features.
+None. Independent of other features.

--- a/.specs/i18n/README.md
+++ b/.specs/i18n/README.md
@@ -1,26 +1,47 @@
-# i18n Multilingual Support — Specification (Future Feature)
+# i18n Multilingual Support — Feature Specification
 
-## Purpose and Scope
+> Created: 2026-05-30
+> Status: Ready
 
-Add multilingual support to the site, allowing visitors to view content in their preferred language.
+## Purpose / Problem
 
-## Status
+The site is currently Norwegian-only. To reach non-Norwegian-speaking visitors (international clients, partners), we need multilingual support with a clear, maintainable content structure.
 
-**Future feature — not yet spec'd or scheduled.** This document is a placeholder for when the feature is prioritized.
+## Decision
 
-## Approach (Decided)
+- **Content structure:** Separate files per language — e.g. `_pages/en/ledelse-60-2.md`, `_pages/no/ledelse-60-2.md`
+- **Language detection:** Browser `Accept-Language` header
+- **Fallback:** Norwegian Bokmål
+- **Language switcher:** UI component for manual override
 
-- Language selection by browser `Accept-Language` header
-- Fallback language: Norwegian Bokmål
-- Logic handled in code (not webserver), per Jekyll best practices
-- Content structure TBD (separate files per language vs. frontmatter-based)
+## Scope
 
-## Requirements (TBD)
+Files to create/modify:
 
-- Language switcher UI component
-- SEO handling (hreflang tags)
-- Content management strategy for translations
+- Language-specific page directories (e.g. `_pages/no/`, `_pages/en/`)
+- `_data/languages.yml` — language configuration
+- Language detector logic (Jekyll plugin or include)
+- Language switcher component (`_includes/language-switcher.html`)
+- SEO hreflang tags in `<head>`
+- Existing `_pages/*.md` files — migrate to language subdirectories
+
+Open questions:
+
+- Which pages get translation first? (TBD — likely landing pages and product pages)
+- Who provides translations? (TBD — client, partner, or AI-assisted)
+
+## Acceptance Criteria
+
+- [ ] Visitors are redirected to their preferred language based on `Accept-Language`
+- [ ] All pages have a fallback to Norwegian Bokmål when translation is missing
+- [ ] Language switcher allows manual override and persists the choice
+- [ ] hreflang tags are present on every page
+- [ ] SEO impact is neutral or positive (no duplicate content penalties)
+
+## Backlog References
+
+FF2
 
 ## Dependencies
 
-- None. Independent of other features.
+None. Independent of other features.

--- a/.specs/layout-migration/README.md
+++ b/.specs/layout-migration/README.md
@@ -1,0 +1,38 @@
+# Layout Migration — Chore Specification
+
+> Created: 2026-05-30
+> Status: Ready
+
+## Purpose / Problem
+
+The article pages under `_pages/ledelse_*.md` currently use inline HTML and arbitrary class combinations rather than the project's layout system (`.container`, `.section`, `.grid`, `.flex-*`). This makes them inconsistent and harder to maintain.
+
+## Decision
+
+- **Approach:** Full redesign pass — convert all article pages at once, not incrementally
+
+## Scope
+
+Files to modify:
+
+- All `_pages/ledelse_*.md` files — rewrite markup to use layout system classes
+- CSS — verify all layout classes used are defined; add missing ones if needed
+- `_layouts/page.html` or `_layouts/article.html` — ensure layout templates support the classes
+
+Existing design reference: `.design/layouts.md`
+
+## Acceptance Criteria
+
+- [ ] All `_pages/ledelse_*.md` files use `.container`, `.section`, `.grid`, and `.flex-*` classes consistently
+- [ ] Visual appearance is preserved (no regressions in spacing, alignment, or proportions)
+- [ ] Dark mode works on every converted page
+- [ ] Mobile layout works on every converted page
+- [ ] Diff shows only structural class changes — content text is unchanged
+
+## Backlog References
+
+P5
+
+## Dependencies
+
+None. Independent of other features.

--- a/.specs/multi-product/README.md
+++ b/.specs/multi-product/README.md
@@ -1,0 +1,43 @@
+# Multi-Product — Architecture Specification
+
+> Created: 2026-05-30
+> Status: Ready
+
+## Purpose / Problem
+
+The site currently only sells Ledelse 60:2. Adding more products (e.g. Katalysator) requires a flexible product data model and page architecture that doesn't hardcode assumptions about a single product.
+
+## Decision
+
+- **Architecture:** Design for generic multi-product *now*, not later
+- Products defined as collection entries with frontmatter-driven content
+- Shared layouts, includes, and CTAs that work for any product
+
+## Scope
+
+Files to create/modify:
+
+- `_products/` — Jekyll collection for product entries
+- `_layouts/product.html` — generic product page layout
+- `_includes/product-card.html` — reusable product card component
+- `_includes/product-cta.html` — configurable CTA component
+- `_data/products.yml` — product metadata (names, slugs, descriptions)
+- `_config.yml` — register `_products` collection
+- Existing `_pages/ledelse-60-2.*` — refactor to use the collection-driven layout
+
+## Acceptance Criteria
+
+- [ ] Adding a new product requires only adding a file to `_products/` and an entry in `_data/products.yml`
+- [ ] Product pages use a shared layout — no per-product page templates
+- [ ] Header/footer navigation picks up new products automatically
+- [ ] Product cards render correctly with varying content length
+- [ ] Dark mode tested on product pages
+- [ ] Mobile layout tested
+
+## Backlog References
+
+FF6
+
+## Dependencies
+
+- Q7 (Katalysator) — not required for architecture design, but the first candidate after Ledelse 60:2

--- a/.specs/three-step-pages/README.md
+++ b/.specs/three-step-pages/README.md
@@ -1,0 +1,41 @@
+# Three-Step Pages — Feature Specification
+
+> Created: 2026-05-30
+> Status: Ready
+
+## Purpose / Problem
+
+The Ledelse 60:2 product page describes a three-step process (kartlegging → analyse → tilbakemelding) but all content for all three steps lives on a single page. To better communicate each phase and allow targeted CTAs, each step should have its own sub-page.
+
+## Decision
+
+- **URL structure:** Sub-pages under `/ledelse-60-2/` — e.g. `/ledelse-60-2/kartlegging/`, `/ledelse-60-2/analyse/`, `/ledelse-60-2/tilbakemelding/`
+- **CTA per step:** Each step page has its own call-to-action appropriate for that phase
+- Content split from the main product page into the three sub-pages
+
+## Scope
+
+Files to create/modify:
+
+- `_pages/ledelse-60-2/` — new directory with per-step page files
+- `_pages/ledelse-60-2.md` — main product page (trimmed — overview + links to steps)
+- `_data/ledelse-60-2.yml` — step data (descriptions, CTAs, icons)
+- `_includes/ledelse-60-2-steps.html` — step navigation/card component
+- CSS for step navigation component
+
+## Acceptance Criteria
+
+- [ ] Each step has its own URL under `/ledelse-60-2/<step>/`
+- [ ] Main product page links to all three steps with clear navigation
+- [ ] Each step page has a distinct CTA (e.g. "Book kartlegging →", "Se analyseprøve →", "Bestill tilbakemelding →")
+- [ ] Breadcrumb or step indicator shows position in the three-step flow
+- [ ] Dark mode tested on step pages
+- [ ] Mobile layout tested — step navigation works on small screens
+
+## Backlog References
+
+FF5
+
+## Dependencies
+
+- FF6 (multi-product) should be designed first to ensure step-page architecture works generically

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -20,11 +20,10 @@ Completed items belong in `CHANGELOG.md` only.
 | FF4 | Citation Enhancement (kramdown footnotes + JSON-LD + JS enhancer) | Planned | — |
 | FF1 | Tag lookup page `/emne/` | Planned | — |
 | FF2 | i18n multilingual support | Planned | — |
-| FF5 | Three-step pages for Ledelse 60:2 | Planned | — |
+| FF5 | Three-step pages for Ledelse 60:2 | Planned | FF6 |
 | FF6 | Multi-product support | Planned | Q7 |
-| FF7 | JSON Schema validation | Planned | — |
-| P5 | Migrate `_pages/ledelse_*.md` to layout system | Blocked | Architecture decision |
-| X2 | Dark mode consistency pass | Blocked | Spec refinement |
+| P5 | Migrate `_pages/ledelse_*.md` to layout system | Planned | — |
+| X2 | Dark mode consistency pass | Planned | — |
 | N1 | Triader article | Blocked | User content |
 | N2 | Makt article | Blocked | User content |
 | N3 | Perspektiv article | Blocked | User content |


### PR DESCRIPTION
## Changes

Added specs and unblocked 6 backlog items based on user decisions:

| Item | What changed |
|------|-------------|
| **FF1** (Tag lookup) |  — server-generated, free-form, articles only |
| **FF2** (i18n) |  — separate files per language |
| **FF5** (Three-step pages) |  — sub-pages with per-step CTAs |
| **FF6** (Multi-product) |  — generic architecture now |
| **P5** (Layout migration) |  — full redesign pass, unblocked |
| **X2** (Dark mode) |  — full site audit, unblocked |
| **FF7** (JSON Schema) | Removed from BACKLOG — not a priority |
| **BL updates** | P5, X2 moved from Blocked → Planned; FF5 depends on FF6 |

## How to test

No behavior change — all changes are documentation only.