### PR TITLE
chore(rules): fire git discipline rules on reading planning files

### DIFF
--- a/.omo/rules/task-management.md
+++ b/.omo/rules/task-management.md
@@ -1,6 +1,6 @@
 ---
 description: Branch naming, commits, PR workflow, changelog management, and version bumping
-globs: ["BACKLOG.md", "CHANGELOG.md", "VERSION"]
+globs: ["BACKLOG.md", "CHANGELOG.md", "VERSION", ".omo/plans/**", ".omo/todos/**"]
 ---
 
 # Task Management & Development Workflow


### PR DESCRIPTION
## Change

Added ``.omo/plans/**`` and ``.omo/todos/**`` to `task-management.md` globs so the full git branch/commit/PR discipline context is injected when planning or todo files are read.

Previously only fired on BACKLOG.md, CHANGELOG.md, VERSION.