### PR TITLE
docs(specs): unblock N1-N3 with implementation order

### DIFF
--- a/.specs/makt/README.md
+++ b/.specs/makt/README.md
@@ -167,6 +167,10 @@ json_ld:
 ---
 ```
 
+## Implementation Order
+
+**1st** in the N1–N3 sequence (strongest hook — opens with the central leadership tension). Written first to provide referenceable context for triader and perspektiv.
+
 ## Dependencies
 
 - 4 images (1 hero, 3 section illustrations)

--- a/.specs/perspektiv/README.md
+++ b/.specs/perspektiv/README.md
@@ -174,11 +174,17 @@ json_ld:
 ---
 ```
 
+## Implementation Order
+
+**3rd** in the N1–N3 sequence (capstone — synthesized after makt and triader are written). Must be written last as it references both `/makt/` and `/triader/` as supporting articles.
+
 ## Dependencies
 
 - 2-3 images (1 hero, 1-2 section illustrations)
 - Cross-links from all four perspektiv articles
-- Link from `/makt/` and potentially `/triader/`
+- Link from `/makt/` (multiframe thinking as resolution of power-service tension)
+- Link from `/triader/` (structural tool that serves multiple frames)
+- Both `/makt/` and `/triader/` must exist before cross-links are valid
 
 ## Acceptance Criteria
 

--- a/.specs/triader/README.md
+++ b/.specs/triader/README.md
@@ -162,10 +162,15 @@ json_ld:
 ---
 ```
 
+## Implementation Order
+
+**2nd** in the N1–N3 sequence (after makt, before perspektiv). Should be written after `/makt/` is complete so cross-links to power-service tension are accurate.
+
 ## Dependencies
 
 - 3 images (1 hero, 2 section illustrations)
 - Cross-links from existing articles
+- Cross-link from `/makt/` (power-service tension as context for triad formation)
 
 ## Acceptance Criteria
 

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -34,9 +34,9 @@ Completed items belong in `CHANGELOG.md` only.
 | A1 | Architecture cleanup: CSS reorganization, topic consolidation, hero/card unification | Planned | — |
 | P5 | Migrate `_pages/ledelse_*.md` to layout system | Planned | A1 |
 | X2 | Dark mode consistency pass | Planned | — |
-| N1 | Triader article | Blocked | User content |
-| N2 | Makt article | Blocked | User content |
-| N3 | Perspektiv article | Blocked | User content |
+| N1 | Triader article (order: 2nd) | Planned | N2 |
+| N2 | Makt article (order: 1st) | Planned | — |
+| N3 | Perspektiv article (order: 3rd) | Planned | N1, N2 |
 | F5 | Image generation for N1-N3 | Blocked | N1, N2, N3 |
 | C1 | Customer case planning & discovery | Blocked | Brainstorming session |
 | C2 | Customer case intake form | Blocked | C1 |


### PR DESCRIPTION
### Changes

- **BACKLOG.md**: Changed N1 (Triader), N2 (Makt), N3 (Perspektiv) from `Blocked` to `Planned` with dependency links
- **N2 Makt spec**: Added `Implementation Order: 1st` section (strongest hook — opens with central leadership tension)
- **N1 Triader spec**: Added `Implementation Order: 2nd` section (written after makt for accurate cross-links)
- **N3 Perspektiv spec**: Added `Implementation Order: 3rd` section (capstone, references both makt and triader)

### How to test
No code changes — review markdown files directly.

### Pre-merge notes
None.