### PR TITLE
docs(specs): update P5 dependency chain and BL ordering

### DIFF
--- a/.specs/layout-migration/README.md
+++ b/.specs/layout-migration/README.md
@@ -35,4 +35,9 @@ P5
 
 ## Dependencies
 
-None. Independent of other features.
+- **A1 (Architecture cleanup) — prerequisite**: A1 stabilizes the CSS class system (hero unification, card extraction, color variables, file reorganization). P5 converts article pages to use these classes — doing P5 before A1 would target a moving class system.
+- **N1–N3, N4–N7, B0–B4 — recommended sequencing**: P5 rewrites markup in all `_pages/ledelse_*.md` files. N1–N3 create new articles, N4–N7 add new perspective pages, B0–B4 edit existing benefit articles. Running P5 after all content changes are settled means one migration pass across the complete file set rather than returning for stragglers.
+
+## Implementation Order
+
+After A1 completes. Prefer running after N1–N7 content and B0–B4 edits are finalized.

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -32,11 +32,11 @@ Completed items belong in `CHANGELOG.md` only.
 | B3 | Usikkerhet: add theater metaphor + power vacuum (from Identitet/Påvirkning frames) | Planned | — |
 | B4 | Forankring: add interests + trust + ownership (from Påvirkning/Mennesker/Struktur frames) | Planned | — |
 | A1 | Architecture cleanup: CSS reorganization, topic consolidation, hero/card unification | Planned | — |
+| N2 | Makt article (order: 1st) | Planned | — |
+| N1 | Triader article (order: 2nd) | Planned | N2 |
+| N3 | Perspektiv article (order: 3rd) | Planned | N1, N2 |
 | P5 | Migrate `_pages/ledelse_*.md` to layout system | Planned | A1 |
 | X2 | Dark mode consistency pass | Planned | — |
-| N1 | Triader article (order: 2nd) | Planned | N2 |
-| N2 | Makt article (order: 1st) | Planned | — |
-| N3 | Perspektiv article (order: 3rd) | Planned | N1, N2 |
 | F5 | Image generation for N1-N3 | Blocked | N1, N2, N3 |
 | C1 | Customer case planning & discovery | Blocked | Brainstorming session |
 | C2 | Customer case intake form | Blocked | C1 |


### PR DESCRIPTION
### Changes

- **P5 spec**: Fixed stale `Dependencies: None` — replaced with A1 as prerequisite (CSS must stabilize before P5 targets the class system) and N1–N7 / B0–B4 as recommended sequencing (all content settled before one migration pass)
- **BACKLOG**: Reordered rows so P5 sits at the end of the article content chain — N4–N7 → B0–B4 → A1 → N1–N3 → P5. This visually communicates that P5 is the final pass over all `_pages/ledelse_*.md` files

### How to test
No code changes — review spec and BL directly.

### Pre-merge notes
None.