### PR TITLE
feat(content): add makt article — power vs servant leadership

### DIFF
--- a/_pages/ledelse_makt.md
+++ b/_pages/ledelse_makt.md
@@ -1,0 +1,132 @@
+---
+layout: page
+title: "Makt eller tjeneste — Hvor sitter din ledergruppe på spekteret?"
+description: "Organisasjoner trenger både makt og tjeneste. Lær hvorfor effektive ledelseskulturer bevisst balanserer begge."
+permalink: /makt/
+json_ld:
+  type: "Article"
+  name: "Makt eller tjeneste"
+  description: "Hvor sitter din ledergruppe på spekteret mellom makt og tjeneste?"
+  author:
+    type: "Organization"
+    name: "No Excuse AS"
+  about:
+    - type: "Thing"
+      name: "Maktdynamikk"
+    - type: "Thing"
+      name: "Servant Leadership"
+    - type: "Thing"
+      name: "Organisasjonskultur"
+---
+
+<section class="frame-hero"{% if page.hero_effect %} data-hero-effect="{{ page.hero_effect }}"{% endif %}>
+    <div class="frame-hero-image hero-image">
+        <img src="{{ '/assets/images/banners/hero-makt.webp' | relative_url }}" alt="Makt eller tjeneste — balansen i ledergruppen">
+    </div>
+    <div class="frame-hero-content">
+        <p class="frame-breadcrumb"><a href="{{ '/' | relative_url }}">← No Excuse AS</a></p>
+        <h1 class="hero-title">Makt eller tjeneste?</h1>
+        <p class="frame-intro hero-intro">Organisasjoner trenger både makt og tjeneste. Spørsmålet er ikke hvilken du skal velge — det er om ledergruppen din har en bevisst kultur som balanserer dem.</p>
+    </div>
+</section>
+
+<section class="frame-section animate-on-scroll fade-in-up">
+    <p>To sitater, to verdenssyn. Jeffrey Pfeffer, en av forskningen mest siterte stemmer på maktdynamikk, slår fast: «Power is the ability to get things done.» Uten makt — ingenting skjer. På den andre siden står Ken Blanchard og Colleen Barrett: «Leadership is not about you; it's about the people you serve.» Ledelse som tjeneste.</p>
+    <p>Begge har rett. Og begge tar feil — hvis de står alene.</p>
+    <p>Makt uten tjeneste blir utvinning. Tjeneste uten makt blir martyrdom. Effektive ledelseskulturer vet hvor de sitter på dette spekteret — og hvorfor.</p>
+    <p>Denne artikkelen kartlegger spenningen mellom makt og tjeneste i ledergrupper, med utgangspunkt i Pfeffers forskning på maktens dynamikk og Blanchard & Barretts arbeid med servant leadership. Målet er ikke å kåre en vinner, men å gi deg et verktøy for å diagnostisere din egen ledelseskultur.</p>
+</section>
+
+<section class="frame-section animate-on-scroll fade-in-up">
+    <h2>Den diagnostiske spenningen</h2>
+    <p>Pfeffer og Blanchard representerer ikke personlighetstyper eller ledelsesfilosofier du velger mellom som et par sko. De representerer en strukturell spenning som lever i enhver organisasjon — enten du anerkjenner den eller ikke.</p>
+    <p>På den ene siden: Makt som kapasitet. Evnen til å mobilisere ressurser, ta beslutninger og få ting gjort. Uten denne kapasiteten forblir visjoner drømmer, og organisasjoner mister retning. Pfeffer dokumenterer at makt korrelerer med karrierefremgang, beskyttelse mot organisatorisk kaos, og evnen til å gjennomføre endring.<sup class="citation">[pfeffer2010]</sup></p>
+    <p>På den andre siden: Tjeneste som kulturbygger. Evnen til å sette andre først, bygge tillit og skape psykologisk trygghet. Blanchard og Barrett viser at servant leadership korrelerer med medarbeiderengasjement, lavere turnover og høyere ytelse over tid.<sup class="citation">[blanchard2011]</sup></p>
+    <p>Problemet oppstår når organisasjoner uten bevissthet driver mot den ene polen. Ledergrupper som ikke aktivt reflekterer over denne spenningen, ender ofte opp med en ubalanse som koster mer enn de sparer.</p>
+</section>
+
+<section class="frame-section animate-on-scroll fade-in-up">
+    <h2>Maktsiden — når det å få ting gjort blir alt</h2>
+    <p>La oss starte med makt — ikke fordi den er viktigst, men fordi den ofte er mest usynlig. Makt er infrastrukturen i organisasjonslivet. Den finnes i stillingsbeskrivelser, budsjetter, beslutningsmyndighet og tilgang til informasjon.</p>
+    <p>Pfeffers forskning viser at makt er en forutsetning for organisatorisk effektivitet på flere måter:</p>
+    <ul>
+        <li><strong>Makt gir handlekraft.</strong> Ledere med reell makt kan ta beslutninger raskt, uten å vente på konsensus som aldri kommer.</li>
+        <li><strong>Makt beskytter mot kaos.</strong> I krisesituasjoner er det ledere med makt som kan gjennomføre nødvendige endringer — demokratiske prosesser tar for lang tid.</li>
+        <li><strong>Makt muliggjør strategisk retning.</strong> Uten makt til å prioritere og nedprioritere, blir strategi en ønskeliste uten gjennomføringskraft.</li>
+    </ul>
+    <p>Makt har også en mørk side — og den er ikke bare etisk, den er praktisk. Forskning fra Dacher Keltner ved UC Berkeley viser at makt har en korrumperende effekt på dømmekraften. Personer som får makt, blir mer impulsive, mindre risikovillige på andres vegne, og overvurderer egen kompetanse. De lytter dårligere til råd, og de undervurderer andres bidrag.<sup class="citation">[keltner2007]</sup></p>
+    <p>Pfeffer selv advarer: Makt blir lett selvrettferdiggjørende, der «jeg har makt fordi jeg har rett» forvandles til «jeg har rett fordi jeg har makt.» Dette er mekanismen som gjør at dyktige ledere kan bli isolerte, miste kontakt med virkeligheten og ta stadig dårligere beslutninger.</p>
+    <p>Risikoen er tydelig: En ledergruppe som optimerer for makt, uten korrigerende mekanismer, utvikler seg mot transaksjonelle relasjoner, høy turnover og en kultur der kortsiktige gevinster trumfer langsiktig verdiskaping.</p>
+</section>
+
+<section class="frame-section animate-on-scroll fade-in-up">
+    <h2>Tjenestesiden — når det å tjene andre blir alt</h2>
+    <p>Servant leadership er ikke det samme som å være snill. Blanchard og Barrett er tydelige på at tjenende ledelse er en strategisk posisjonering, ikke en personlighetstype.</p>
+    <p>Servant leadership handler om å bygge organisatorisk kapasitet gjennom å sette medarbeiderne først. Forskningen viser flere konkrete effekter:</p>
+    <ul>
+        <li><strong>Tillit reduserer transaksjonskostnader.</strong> Når ansatte stoler på ledelsen, bruker de mindre tid på ryggdekning og politisk posisjonering — og mer tid på verdiskapende arbeid.</li>
+        <li><strong>Tjeneste skaper engasjement.</strong> Medarbeidere som opplever at lederen genuint bryr seg om deres utvikling, presterer bedre, blir lenger og anbefaler arbeidsgiveren til andre.</li>
+        <li><strong>Tjeneste bygger kulturkapital.</strong> Organisasjoner med en sterk tjenestekultur tiltrekker seg talent som verdsetter samarbeid fremfor konkurranse.</li>
+    </ul>
+    <p>Men også tjenestesiden har en skyggeside. Når «vi setter mennesker først» blir et dekke for manglende beslutningsdyktighet, oppstår et annet problem. Ledere som ikke tør å ta upopulære beslutninger, som utsetter vanskelige samtaler og som lar middelmådighet få fortsette i frykt for å såre noen — de tjener ingen.</p>
+    <p>Risikoen er speilbildet av maktsiden: En ledergruppe som optimerer for tjeneste, uten makt til å gjennomføre, utvikler seg mot en kultur der beslutningsvegring er normen, de flinkeste brenner seg ut på å kompensere for de svakeste, og organisasjonen mister retning og tempo.</p>
+</section>
+
+<section class="frame-section animate-on-scroll fade-in-up">
+    <h2>Prisen du betaler for makt</h2>
+    <p>Det er fristende å konkludere med at svaret er «litt av begge deler». Men det er for enkelt. For å forstå hva en balansert ledelseskultur krever, må vi først se prisene — for begge ytterpunkter.</p>
+    <p>La oss starte med prisen for makt, fordi den oftest er usynlig for dem som sitter i den:</p>
+    <ul>
+        <li><strong>Tid brukt på makt er tid ikke brukt på substans.</strong> Å bygge allianser, sikre budsjetter og posisjonere seg politisk er tid som kunne vært brukt på å forstå markedet, utvikle medarbeidere eller forbedre produktet. Dette er en reell alternativkostnad.</li>
+        <li><strong>Makt korrumperer dømmekraften.</strong> Keltners forskning viser at makthavere systematisk overvurderer egen kompetanse og undervurderer andres. De blir dårligere til å ta imot råd, og mer tilbøyelige til å ta risiko på andres vegne. Effekten er målt både i laboratoriestudier og i reelle organisasjoner.<sup class="citation">[keltner2007]</sup></li>
+        <li><strong>Psykologisk toll.</strong> Makt er ensomt. Når du har makt, endrer andres relasjon til deg seg — selv når du ikke ønsker det. Tillit blir vanskeligere, ærlig tilbakemelding forsvinner, og paranoia kan vokse. «Er de enige med meg fordi jeg har rett, eller fordi jeg er sjefen?»</li>
+        <li><strong>Relasjonskostnader.</strong> Makt endrer hvordan andre forholder seg til deg. Folk sier det du vil høre, holder tilbake dårlige nyheter, og posisjonerer seg heller enn å samarbeide. Dette er ikke vond vilje — det er rasjonell tilpasning til en maktstruktur.</li>
+    </ul>
+    <p>Prisen for ren tjeneste er annerledes, men ikke mindre reell:</p>
+    <ul>
+        <li><strong>Beslutningslammelse.</strong> Når alle skal høres, tar alt lengre tid. I praksis betyr det at organisasjonen reagerer for sent på endringer i markedet.</li>
+        <li><strong>Utbrenthet hos de flinkeste.</strong> Når ledelsen ikke prioriterer, må de ansatte gjøre det selv. De dyktigste ender opp med å bære hele organisasjonen på ryggen.</li>
+        <li><strong>Utnyttelse.</strong> I en kultur som idealiserer tjeneste, er det lett for at de med minst makt blir utnyttet. «Hun stiller alltid opp» blir et tegn på lojalitet, ikke et varsel om overbelastning.</li>
+    </ul>
+</section>
+
+<section class="frame-section animate-on-scroll fade-in-up">
+    <h2>Spekteret — fra utvinning til balanse</h2>
+    <p>Hvis både ren makt og ren tjeneste har kostbare bivirkninger, hva er løsningen? Svaret ligger ikke i et kompromiss på midten, men i å forstå hvor din organisasjon befinner seg på spekteret — og hvorfor.</p>
+    <p>Vi kan grovt sett plassere ledelseskulturer langs et spekter:</p>
+    <ul>
+        <li><strong>Rent maktorientert:</strong> Transaksjonelt, konkurransepreget, høy turnover, kortsiktig fokus. Makt brukes for maktens egen skyld. Ledere belønnes for resultater uansett metode.</li>
+        <li><strong>Makt-tungt med tjeneste-elementer:</strong> Maktstrukturen er tydelig, men det finnes mekanismer som korrigerer de verste utslagene — medarbeiderundersøkelser, varslingskanaler, støttefunksjoner.</li>
+        <li><strong>Balansert:</strong> Bevisst bruk av makt i tjeneste for oppdraget. Ledere har reell myndighet, men er tydelig på at maktens formål er å tjene organisasjonens mål. Korrigerende mekanismer er integrert i kulturen, ikke pålagt utenfra.</li>
+        <li><strong>Tjeneste-tungt med makt-elementer:</strong> Tjenestekulturen dominerer, men det finnes ledere med reell beslutningsmyndighet. Utfordringen er at beslutninger ofte tar for lang tid fordi kulturen idealiserer konsensus.</li>
+        <li><strong>Rent tjenesteorientert:</strong> Samarbeidende, men beslutningsvegrende. Potensial for utnyttelse av de mest lojale. Endringstakten er lav fordi alle skal være enige.</li>
+    </ul>
+    <p>Logans forskning på kulturstadier (Stage 4–5) peker på en interessant syntese: De mest effektive kulturene er «vi»-orienterte kulturer som samtidig distribuerer makt bredt. I Stage 4-kulturer er makt ikke noe enkeltpersoner har — det er noe teamet har sammen. Makt brukes til å tjene felles mål, ikke til å posisjonere seg internt.<sup class="citation">[logan2009]</sup></p>
+    <p>Dette er ikke naiv optimisme. Det er en empirisk observasjon av hva som faktisk fungerer i organisasjoner som presterer over tid. Når makt distribueres og samtidig forankres i et felles oppdrag, reduseres både risikoen for maktmisbruk og risikoen for beslutningsvegring.</p>
+</section>
+
+<section class="frame-section animate-on-scroll fade-in-up">
+    <h2>Spørsmål for selvdiagnose</h2>
+    <p>Hvor sitter din ledergruppe på spekteret? Følgende spørsmål kan hjelpe dere å finne ut:</p>
+    <ul>
+        <li class="animate-on-scroll slide-in-left stagger">Når du tar beslutninger — tenker du først på konsekvensene for oppdraget, eller på hvem som støtter deg?</li>
+        <li class="animate-on-scroll slide-in-left stagger">Hvor mange mennesker ville hjulpet deg hvis du mistet din formelle myndighet i morgen?</li>
+        <li class="animate-on-scroll slide-in-left stagger">Belønner organisasjonen din maktakvisisjon eller tjenesteleveranse? Vær ærlig — ikke svar hva du skulle ønske var sant.</li>
+        <li class="animate-on-scroll slide-in-left stagger">Hva ville endret seg hvis teamet ditt visste dine private motivasjoner?</li>
+        <li class="animate-on-scroll slide-in-left stagger">Når ble siste gang en medarbeider ga deg en ærlig, ubehagelig tilbakemelding — og du tok den imot uten å forsvare deg?</li>
+    </ul>
+</section>
+
+<section class="frame-cta animate-on-scroll fade-in-up">
+    <h2>Få kartlagt ledergruppens makt- og tjenestebalanse</h2>
+    <p>Ledelse 60:2 inneholder spørsmål som kartlegger hvor ledergruppen din sitter på spekteret mellom makt og tjeneste, og gir dere et felles språk for å snakke om dynamikken. Bestill en uforpliktende samtale for å lære mer.</p>
+    <div class="frame-cta-buttons">
+        <a href="https://outlook.office.com/book/ledelse@noexcuse.no/?ismsaljsauthenabled" class="product-cta">Bestill uforpliktende samtale</a>
+        <a href="{{ '/' | relative_url }}" class="product-cta product-cta--secondary">Les mer om Ledelse 60:2 →</a>
+    </div>
+</section>
+
+[^pfeffer2010]: Pfeffer, J. (2010). *Power: Why Some People Have It — and Others Don't*. Harper Business. [Harper Business →](https://www.harpercollins.com/products/power-jeffrey-pfeffer)
+[^blanchard2011]: Blanchard, K. & Barrett, C. (2011). *Lead with LUV: A Different Way to Create Real Success*. FT Press. [Google Scholar →](https://scholar.google.com/scholar?q=blanchard+barrett+lead+with+luv)
+[^keltner2007]: Keltner, D. (2007). "The Power Paradox". *UC Berkeley Greater Good Science Center*. [Greater Good Magazine →](https://greatergood.berkeley.edu/article/item/power_paradox)
+[^logan2009]: Logan, D., King, J., & Fischer-Wright, H. (2009). *Tribal Leadership: Leveraging Natural Groups to Build a Thriving Organization*. Harper Business. [Google Scholar →](https://scholar.google.com/scholar?q=logan+tribal+leadership+stages+culture)


### PR DESCRIPTION
### Changes

New article page at `/makt/` (~1700 words) exploring the tension between power-oriented and service-oriented leadership.

**Structure:**
1. Hero with intro framing the power-service tension
2. The Diagnostic Tension — why both poles matter
3. The Power Side (Pfeffer) — strengths and risks
4. The Service Side (Blanchard & Barrett) — strengths and risks
5. The Price of Power — trade-offs, corruption, psychological toll, relationship costs
6. The Spectrum — mapping real leadership cultures from pure power to pure service
7. Self-diagnosis questions
8. CTA linking to Ledelse 60:2

**Sources cited:** Pfeffer (2010), Blanchard & Barrett (2011), Keltner (2007 — Power Paradox), Logan et al. (2009)

### Notes
- Images not included — placeholder paths use `hero-makt.webp`. F5 (image generation) will produce these later.
- This is the 1st article in the N1–N3 sequence. N1 (triader) and N3 (perspektiv) will follow in separate PRs chained off this branch.

### How to test
Review `_pages/ledelse_makt.md` directly. Content review needed for tone, accuracy, and brand voice.

### Pre-merge notes
Holding for batch merge with remaining Planned BL items.