### PR TITLE
feat(content): B0-B4 benefit article frame argument integration

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -26,11 +26,7 @@ Completed items belong in `CHANGELOG.md` only.
 | N5 | Struktur: layout wiring + content refinement (method-benefit integration) + 4 spot illustrations (roller, mål, prosesser, lederverdi) | Planned | — |
 | N6 | Mennesker: layout wiring + content refinement (method-benefit integration) + 4 spot illustrations (tilhørighet, mestring, autonomi, lederverdi) | Planned | — |
 | N7 | Påvirkning: layout wiring + content refinement (method-benefit integration) + 4 spot illustrations (makt, nettverk, interesser, lederverdi) | Planned | — |
-| B0 | Benefit layout fix: center `.frame-section` content | Planned | — |
-| B1 | Tillit: add autonomy pillar + compliance clarity (from Mennesker/Struktur frames) | Planned | — |
-| B2 | GenKI: add cultural maturity + power dynamics (from Identitet/Påvirkning frames) | Planned | — |
-| B3 | Usikkerhet: add theater metaphor + power vacuum (from Identitet/Påvirkning frames) | Planned | — |
-| B4 | Forankring: add interests + trust + ownership (from Påvirkning/Mennesker/Struktur frames) | Planned | — |
+
 | A1 | Architecture cleanup: CSS reorganization, topic consolidation, hero/card unification | Planned | — |
 | N2 | Makt article (order: 1st) | Planned | — |
 | N1 | Triader article (order: 2nd) | Planned | N2 |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **B0–B4 — Benefit article improvements + frame argument integration**: `.specs/benefit-frame-integration/README.md` — spec for weaving frame perspective arguments into the four benefit articles (tillit, GenKI, usikkerhet, forankring) plus CSS layout fix for left-aligned content. BACKLOG updated with B0–B4 as Planned.
+- **B0–B4 — Benefit article improvements + frame argument integration**:
+  - B0: `.frame-section` centered with `margin-inline: auto` in `typography.css`
+  - B1: Tillit — autonomy added as fourth pillar, compliance≠byråkrati in system pillar
+  - B2: GenKI — cultural maturity (Logan stages) and power dynamics sections added
+  - B3: Usikkerhet — theater metaphor, power vacuum paragraph, structural uncertainty challenge
+  - B4: Forankring — interests mapping as new dimension, psychological safety in intro, ownership in dimension 1
 - **10.3-10.4 — Hero animation system + parallax-fade**: Frontmatter-driven hero effect framework with `HeroEffects` dispatcher in `animations.js`. First effect: parallax-fade — image translates up 40px on scroll (0–300px), title/intro fade out with translateY. Enabled on `/ledelse-60-2/`, `/om-oss/`, `/metode/` via `hero_effect: parallax-fade` frontmatter. `.specs/hero-animation-system/README.md` spec created
 - **A1 — Architecture cleanup spec**: `.specs/architecture-cleanup/README.md` — full spec for CSS reorganization, topic consolidation, hero/card unification, color hygiene, inline CSS removal, and file restructuring across all layers
 - **N4–N7 — Frame perspective article content spec**: `.specs/frame-article-content/README.md` — spec for writing body content on the four empty perspective pages (identitet, struktur, mennesker, påvirkning). BACKLOG updated with N4–N7 as Planned

--- a/_pages/ledelse_forankring.md
+++ b/_pages/ledelse_forankring.md
@@ -35,6 +35,7 @@ json_ld:
     <p>Jeffrey Pfeffer har brukt karrieren sin på å dokumentere gapet mellom hvordan organisasjoner hevder beslutninger tas, og hvordan de faktisk tas. I «Power: Why Some People Have It — and Others Don't» viser han at makt og politikk spiller en langt større rolle enn de fleste er villige til å innrømme.<sup class="citation">[pfeffer2010]</sup></p>
     <p>God styring handler om å vite hvem som faktisk har makt til å beslutte — ikke hvem som formelt sitter i lederrollen. I norske organisasjoner er avstanden mellom formell og reell beslutningsmakt ofte undervurdert. Ansvar uten autoritet er en teoretisk øvelse.</p>
     <p>I komplekse beslutningsmiljøer — der problemer, løsninger, deltakere og valgmuligheter flyter sammen — er det ikke alltid den «beste» ideen som vinner. Beslutninger tas av de som har bygget tillit og innflytelse over tid, ikke nødvendigvis av de med den mest rasjonelle analysen.</p>
+    <p>Forankring uten relasjonell tillit er seremoniell. Folk nikker i møter og gjør noe annet etterpå. Grunnmuren i all forankring er psykologisk trygghet — tilliten til at man kan si hva man faktisk mener uten negative konsekvenser.</p>
     <p>Daniel Kahneman og Amos Tversky dokumenterte hvordan menneskelig tenkning systematisk avviker fra rasjonalitet — ikke fordi folk er dumme, men fordi hjernen bruker heuristikker som ofte feiler.<sup class="citation">[kahneman2011]</sup></p>
 </section>
 
@@ -43,27 +44,35 @@ json_ld:
     
     <div class="frame-element animate-on-scroll fade-in-up">
         <h3>1. Formell vs. reell beslutningsmakt</h3>
-        <p>I de fleste organisasjoner er det stor forskjell på hvem som formelt har autoritet til å beslutte, og hvem som faktisk har innflytelse. Pfeffer viser at «the most powerful people in organizations are often not those with the formal authority.»<sup class="citation">[pfeffer2010]</sup></p>
+        <p>I de fleste organisasjoner er det stor forskjell på hvem som formelt har autoritet til å beslutte, og hvem som faktisk har innflytelse. Pfeffer viser at «the most powerful people in organizations are often not those with the formal authority.»<sup class="citation">[pfeffer2010]</sup> Et initiativ uten tydelig eierskap er ikke forankret — det er bare kommunisert. Når roller er uklare, oppstår ansvarsskyvning, og forankringen blir illusorisk.</p>
         <p><strong>Tegn på klar maktbalanse:</strong> Beslutninger tas av dem med relevant ekspertise. Uenighet løses gjennom dialog, ikke posisjon. Autoritet følger ansvar.</p>
         <p><strong>Tegn på skjev makt:</strong> De med formell autoritet dominerer. Ekspertise ignoreres når den kommer fra feil person. Beslutninger tas bak lukkede dører.</p>
     </div>
 
     <div class="frame-element animate-on-scroll fade-in-up">
-        <h3>2. Kognitiv bias som påvirker valg</h3>
+        <h3>2. Interesser som forankringens byggesteiner</h3>
+        <p>Hver leder og hver avdeling har sine interesser. Ikke nødvendigvis egoistiske — de kan være faglige, strategiske eller personlige. Forankring handler først og fremst om å forstå disse interessene og hvordan de samhandler.</p>
+        <p>En initiativtaker som kartlegger interesser før hun presenterer løsningen, har langt større gjennomføringskraft enn den som antar at alle ser saken fra samme ståsted.</p>
+        <p><strong>Tegn på god interessekartlegging:</strong> Ulike standpunkter er kjent og anerkjent. Forhandling handler om å forene interesser, ikke om å vinne en argumentasjon.</p>
+        <p><strong>Tegn på manglende interessekartlegging:</strong> Initiativer presenteres som «åpenbart riktige» — og møtes med taus motstand.</p>
+    </div>
+
+    <div class="frame-element animate-on-scroll fade-in-up">
+        <h3>3. Kognitiv bias som påvirker valg</h3>
         <p>Kahneman identifiserte to systemer for tenkning: System 1 (rask, intuitiv, emosjonell) og System 2 (langsom, analytisk, rasjonell).<sup class="citation">[kahneman2011]</sup> De fleste viktige beslutninger tas med System 1, selv om vi tror vi bruker System 2.</p>
         <p><strong>Tegn på bias-bevissthet:</strong> Viktige beslutninger diskuteres med folk som tenker annerledes. Beslutninger revideres når ny informasjon kommer til. «Hva kan jeg ha oversett?» er et vanlig spørsmål.</p>
         <p><strong>Tegn på bias-blindhet:</strong> Beslutninger tas av enkeltpersoner. Ingen utfordrer premissene. Suksess tillegges egen dyktighet, feil tillegges eksterne forhold.</p>
     </div>
 
     <div class="frame-element animate-on-scroll fade-in-up">
-        <h3>3. Konflikt og forhandling</h3>
+        <h3>4. Konflikt og forhandling</h3>
         <p>De fleste viktige beslutninger innebærer interessekonflikter. Å ignorere dette er å overse virkeligheten. Effektive ledere forstår hvordan å forhandle og bygge konsensus.<sup class="citation">[fisher1991]</sup></p>
         <p><strong>Tegn på konstruktiv konflikt:</strong> Uenighet diskuteres åpent. Beslutninger tas etter at ulike perspektiver er vurdert. Kompromisser eies av alle parter.</p>
         <p><strong>Tegn på dysfunksjonell konflikt:</strong> Konflikter begraves til de eskalerer. Beslutninger omgjøres etter møter. «Enighet» maskerer undertrykt uenighet.</p>
     </div>
 
     <div class="frame-element animate-on-scroll fade-in-up">
-        <h3>4. Beslutningskultur</h3>
+        <h3>5. Beslutningskultur</h3>
         <p>Irving Janis dokumenterte fenomenet «groupthink» — når jakten på enighet overrides behovet for kritisk vurdering.<sup class="citation">[janis1982]</sup> Dette er spesielt farlig i organisasjoner med sterke kulturer eller karismatiske ledere.</p>
         <p><strong>Tegn på sunn beslutningskultur:</strong> Kritikk er forventet og verdsatt. Beslutninger kan omgjøres hvis premisser endres. Læring fra feil er systematisk.</p>
         <p><strong>Tegn på groupthink:</strong> Ingen utfordrer ledelsen. Kritikk avvises som illojalitet. Beslutninger tas for å unngå konflikt, ikke for å finne den beste løsningen.</p>

--- a/_pages/ledelse_generativ-ki.md
+++ b/_pages/ledelse_generativ-ki.md
@@ -87,7 +87,7 @@ json_ld:
 
 <section class="frame-section animate-on-scroll fade-in-up">
     <h2>OKR og KPI for KI-assistert arbeid</h2>
-    <p>KI produserer innhold; mennesker produserer verdi. Gapet mellom dem må måles. Douglas Hubbard skriver i «How to Measure Anything» at det meste faktisk kan måles — bare vi er villige til å definere hva vi egentlig trenger å vite.<sup class="citation">[hubbard2014]</sup></p>
+    <p>KI produserer innhold; mennesker produserer verdi. Gapet mellom dem må måles. Douglas Hubbard skriver i «How to Measure Anything» at det meste faktisk kan måles — bare vi er villige til å definere hva vi egentlig trenger å vite.<sup class="citation">[hubbard2014]</sup> Hubbard viser at all måling reduserer usikkerhet — den eliminerer den ikke. Formålet med å måle KI-output er ikke perfeksjon, men å vite om man beveger seg i riktig retning.</p>
     
     <p><strong>KPI-er for KI-assisterte prosesser:</strong></p>
     <ul>
@@ -104,6 +104,14 @@ json_ld:
     <h2>Organisasjonens rolle</h2>
     <p>Å trene ansatte i prompting er ikke nok — man må utvikle dømmekraft. Ledelsens oppgave er å skape forutsetninger for effektiv KI-bruk, ikke å bestemme hvilke verktøy som skal brukes.</p>
     <p>Risikoen er at KI blir en unnskyldning for å fjerne menneskelig dømmekraft fra beslutninger. Når «effektivitet» overstyres av «automasjon», taper organisasjonen på kvalitet.</p>
+
+    <h3>Kultur som forutsetning for KI-adopsjon</h3>
+    <p>Dave Logan beskriver fem kulturstadier — fra «livet suger» til «livet er fantastisk.» De fleste organisasjoner befinner seg på stadium 3: «Jeg er flink» (individualisme). På dette stadiet hamstres kunnskap i stedet for å deles. KI-adopsjon som krever samarbeid på tvers, forutsetter minimum stadium 4: «Vi er flinke.»</p>
+    <p>Spørsmålet er ikke om organisasjonen har KI-verktøy — det er om kulturen er moden for å bruke dem.</p>
+
+    <h3>KI som maktspørsmål</h3>
+    <p>KI-verktøy kontrolleres sjelden av alle. Én avdeling eller enkeltpersoner kan få uforholdsmessig innflytelse ved å eie KI-budsjettet eller KI-kompetansen. Uten åpen diskusjon om hvem som styrer KI, risikerer organisasjonen at teknologiens gevinster konsentreres hos få.</p>
+    <p>Den som kontrollerer KI, former retningen. Det er et spørsmål om makt, ikke bare om teknologi.</p>
 </section>
 
 <section class="frame-section animate-on-scroll fade-in-up">

--- a/_pages/ledelse_tillit.md
+++ b/_pages/ledelse_tillit.md
@@ -37,7 +37,7 @@ json_ld:
 </section>
 
 <section class="frame-section animate-on-scroll fade-in-up">
-    <h2>De tre pilarene for tillitsbasert ledelse</h2>
+    <h2>De fire pilarene for tillitsbasert ledelse</h2>
     
     <div class="frame-element animate-on-scroll fade-in-up">
         <h3>1. Psykologisk trygghet</h3>
@@ -55,9 +55,17 @@ json_ld:
 
     <div class="frame-element animate-on-scroll fade-in-up">
         <h3>3. Tillit som system</h3>
-        <p>Tillit er ikke bare en følelse — det er et system av forventninger og atferd som enten forsterker eller underminerer samarbeid.<sup class="citation">[dirks2009]</sup> God styring handler om å vite hvem som faktisk har makt til å beslutte — ikke hvem som formelt sitter i lederrollen. Autoritet uten ansvar er en risikofaktor.</p>
+        <p>Tillit er ikke bare en følelse — det er et system av forventninger og atferd som enten forsterker eller underminerer samarbeid.<sup class="citation">[dirks2009]</sup> God styring handler om å vite hvem som faktisk har makt til å beslutte — ikke hvem som formelt sitter i lederrollen. Autoritet uten ansvar er en risikofaktor. Compliance er ikke byråkrati — det er tydelighet. Når roller er definerte og ansvar er dokumentert, unngår man den typen uklarhet som fører til at oppgaver faller mellom stoler og tillit blir satt på prøve.</p>
         <p><strong>Tegn på tillit som system:</strong> Løfter holdes. Forventninger er tydelige. Folk tar ansvar for egne handlinger.</p>
         <p><strong>Tegn på tillitsbrist:</strong> Løfter brytes uten forklaring. Folk dekker seg bak prosedyrer. «Det var ikke min avdeling» blir unnskyldningen.</p>
+    </div>
+
+    <div class="frame-element animate-on-scroll fade-in-up">
+        <h3>4. Autonomi som tillitsdriver</h3>
+        <p>Mennesker er motiverte når de opplever mestring, tilhørighet og mening. Ytre motivatorer (bonus, straff) kan drive kortvarig atferd, men varig engasjement krever indre motivasjon: autonomi, mestring og tilhørighet. Når ledere stoler på at ansatte kan bruke sunn fornuft, blir kontroll unødvendig — og byråkratiet mister sin begrunnelse.</p>
+        <p>Autonomi er ikke frihet fra struktur — det er frihet <em>innenfor</em> struktur. Tydelige roller og forventninger muliggjør tillit, de svekker den ikke.</p>
+        <p><strong>Tegn på autonomi som tillitsdriver:</strong> Ansatte tar initiativ uten å vente på godkjenning. Ledere delegerer både ansvar og autoritet. Feil analyseres for læring, ikke for straff.</p>
+        <p><strong>Tegn på kontrollkultur:</strong> Alle beslutninger må oppover i systemet. Detaljerte prosedyrer erstatter skjønn. Ledere sjekker opp på detaljer heller enn å stole på fagfolk.</p>
     </div>
 </section>
 

--- a/_pages/ledelse_usikkerhet.md
+++ b/_pages/ledelse_usikkerhet.md
@@ -44,6 +44,10 @@ json_ld:
         <li class="animate-on-scroll slide-in-left stagger"><strong>Grunnleggende antakelser:</strong> Det vi tar for gitt — ubevisste, tatt-for-gitt sannheter</li>
     </ul>
     <p>Problemet: de fleste prøver å endre kultur ved å endre artefakter og verdier, mens de grunnleggende antakelsene forblir uendret. Det er som å behandle symptomene i stedet for årsaken.</p>
+
+    <h3>Teateret i usikkerhet</h3>
+    <p>En organisasjonskultur er ikke bare noe man <em>har</em> — det er noe man <em>fremfører</em>. I usikre tider sprekker fasaden: det som var «hvordan vi gjør ting her» avsløres som overflate når presset kommer. Ritualer og historier som fungerte i stabile perioder, mister sin kraft når ingen lenger tror på dem.</p>
+    <p>Spørsmålet ledergrupper bør stille seg i usikre tider er ikke «hva er kulturen vår?» — det er «hvilken kultur kommer til syne når vi ikke lenger har kontroll?»</p>
 </section>
 
 <section class="frame-section animate-on-scroll fade-in-up">
@@ -86,6 +90,9 @@ json_ld:
         <li class="animate-on-scroll slide-in-left stagger">Kortsiktig tenkning — endring tar tid, de fleste gir opp for tidlig</li>
     </ul>
     <p>En moden ledelse forstår at risiko ikke er noe man setter på lista en gang i året — det er en daglig holdning. Organisasjoner som leser signalene tidlig, justerer kurs før krisen er et faktum. Muligheter og risikoer hører sammen. De som bare ser risiko, misser mulighetene. De som bare ser muligheter, ender i brann.</p>
+
+    <h3>Usikkerhet skaper maktvakuum</h3>
+    <p>Når usikkerhet oppstår, oppstår også maktkamper. De som griper muligheten i uklare situasjoner, former retningen — uavhengig av om de har formell autoritet. Ledergrupper som ikke er bevisst på dette, oppdager for sent at veivalg er tatt av dem som handlet raskest, ikke av dem som hadde best innsikt.</p>
 </section>
 
 <section class="frame-section animate-on-scroll fade-in-up">
@@ -207,6 +214,10 @@ json_ld:
         <div class="frame-challenge animate-on-scroll fade-in-up stagger">
             <h4>«Alltid sånn her»-mentalitet</h4>
             <p>Historisk suksess blir institusjonlisert. «Vi har alltid gjort det sånn» blir argumentet mot fornyelse.</p>
+        </div>
+        <div class="frame-challenge animate-on-scroll fade-in-up stagger">
+            <h4>Strukturell usikkerhet</h4>
+            <p>Mål i ulike avdelinger som motvirker hverandre. Koordinering som skulle vært automatisk, krever stadige møter. Det oppleves som kulturproblem, men er egentlig strukturproblem — målene er ikke samordnet, og ingen har sett på om de henger sammen.</p>
         </div>
     </div>
 </section>

--- a/assets/css/typography.css
+++ b/assets/css/typography.css
@@ -50,6 +50,7 @@ small {
 .frame-section,
 .perspektiv-section {
     max-width: 65ch;
+    margin-inline: auto;
 }
 
 /* Mobile Scale */


### PR DESCRIPTION
## What

Implements B0-B4: weaves frame perspective arguments into all four benefit articles and fixes the  centering bug.

### Changes

| ID | File | Change |
|----|------|--------|
| B0 | `assets/css/typography.css` | Add `margin-inline: auto` to `.frame-section` |
| B1 | `_pages/ledelse_tillit.md` | Renamed to «Fire pilarene», added autonomy pillar + compliance clarity |
| B2 | `_pages/ledelse_generativ-ki.md` | Added cultural maturity (Logan) + power dynamics sections, strengthened Hubbard ref |
| B3 | `_pages/ledelse_usikkerhet.md` | Added theater metaphor, power vacuum, structural uncertainty challenge |
| B4 | `_pages/ledelse_forankring.md` | Added interests dimension, psychological safety in intro, ownership in dim 1 |

### How to test

1. Visit /tillit/, /generativ-ki/, /usikkerhet/, /forankring/ — verify content is centered
2. Check that new paragraphs render correctly in each article
3. Verify dark mode and mobile layout unaffected

Co-authored-by: Rasmus S. Olsen <rasmus@noexcuse.no>