### PR TITLE
docs(a1): update design docs and spec to enforce new patterns

### DIFF
--- a/.design/architecture.md
+++ b/.design/architecture.md
@@ -5,80 +5,119 @@
 ```
 www-public/
 ├── _pages/              # Standalone content pages
-├── _layouts/           # Page templates
-├── _includes/           # Reusable HTML partials
-├── _products/           # Product data
-├── _profiles/          # Team member profiles
-├── _cases/             # Case studies
-├── _partners/          # Partner organizations
-├── _data/              # Site-wide data
+├── _layouts/            # Page templates (default, perspektiv, tag)
+├── _includes/           # Reusable HTML partials (hero, card, header, footer, profiles, styles, scripts, metadata)
+├── _products/           # Product frontmatter data
+├── _profiles/           # Team member profiles
+├── _topics/             # Topic content — frames, benefits, process steps (output: false)
+├── _tags/               # Tag landing pages (one per tag, output: page)
+├── _data/               # Site-wide data (metadata.yml)
 ├── assets/
-│   ├── css/            # Modular stylesheets
-│   ├── images/         # Graphics (icons, banners, heroes)
-│   └── scripts/        # JavaScript
-├── .specs/             # Functional specifications
-├── .design/            # Design documentation
-└── tests/              # Test files
+│   ├── css/             # Modular stylesheets
+│   │   └── components/  # Component-specific CSS (hero.css, card.css)
+│   ├── images/          # Graphics (spot illustrations, banners, heroes)
+│   └── scripts/         # JavaScript (vanilla, no frameworks)
+├── .specs/              # Functional specifications
+├── .design/             # Design documentation
+└── tests/               # Test files
 ```
 
-## Pages/Collections
+## Collections
 
 | Directory | Purpose | Output |
 |-----------|---------|--------|
-| `_pages/` | Content pages (ledelse-60-2, om-oss, vitenskapelig-grunnlag) | Static HTML |
-| `_products/` | Product frontmatter data | Used by includes |
-| `_profiles/` | Team member profiles | Static HTML |
-| `_cases/` | Case study content | Static HTML |
-| `_partners/` | Partner organizations | Static HTML |
+| `_pages/` | Content pages (ledelse-60-2, om-oss, frame articles, etc.) | Static HTML at `/:permalink/` |
+| `_products/` | Product frontmatter data (used by includes) | None (data only) |
+| `_profiles/` | Team member profiles | Static HTML at `/profiles/:name/` |
+| `_topics/` | Topic cards — frames (4), benefits (4), process steps (3) | None (data only) |
+| `_tags/` | Tag landing pages | Static HTML at `/emne/:tag/` |
+
+### `_topics/` — Unified topic collection
+
+Replaced the old `_frames/` collection. Each topic has a `category` field (`frame`, `benefit`, or `step`). Steps also carry a `step_number` (1–3) for ordering.
+
+Used by `_includes/card.html` via `site.topics | where: "category", "<type>"` filtering and by `_layouts/perspektiv.html` for hero data.
+
+### `_tags/` — Tag index pages
+
+Created for the emne (topic/tag) landing system. Each file in `_tags/` generates a page at `/emne/:tag/` listing all articles with that tag.
+
+## Pages
+
+| URL | File | Layout | Purpose |
+|-----|------|--------|---------|
+| `/` | `index.md` | default | Frontpage |
+| `/ledelse-60-2/` | `_pages/ledelse_60-2.md` | default | Product landing |
+| `/om-oss/` | `_pages/om_oss.md` | default | About us |
+| `/om-metode/` | `_pages/om_metode.md` | default | Method overview with frame/benefit/step cards |
+| `/perspektiv/` | `_pages/ledelse_perspektiv.md` | perspektiv | Scientific background |
+| `/triader/` | `_pages/ledelse_triader.md` | perspektiv | Triads concept article |
+| `/struktur/` | `_pages/struktur.md` | perspektiv | Frame: Structure |
+| `/mennesker/` | `_pages/mennesker.md` | perspektiv | Frame: People |
+| `/identitet/` | `_pages/identitet.md` | perspektiv | Frame: Identity |
+| `/pavirkning/` | `_pages/pavirkning.md` | perspektiv | Frame: Influence |
+| `/forankring/` | `_pages/ledelse_forankring.md` | perspektiv | Benefit: Anchoring |
+| `/tillit/` | `_pages/ledelse_tillit.md` | perspektiv | Benefit: Trust |
+| `/makt/` | `_pages/ledelse_makt.md` | perspektiv | Benefit: Control/Power |
+| `/generativ-ki/` | `_pages/ledelse_generativ-ki.md` | perspektiv | Benefit: Generative AI |
+| `/usikkerhet/` | `_pages/ledelse_usikkerhet.md` | perspektiv | Benefit: Uncertainty |
+| `/emne/:tag/` | `_tags/:tag.md` | tag | Tag landing page |
 
 ## URL Conventions
 
 | Pattern | Example |
 |---------|---------|
-| Pages: `/:filename/` | `/ledelse-60-2/` |
-| Products: `/products/:name/` | `/products/ledelse-60-2/` |
-| Profiles: `/profiles/:name/` | `/profiles/dagfinn/` |
+| Pages: `/:permalink/` | `/ledelse-60-2/`, `/struktur/` |
+| Products: `/produkt/:name/` | `/produkt/ledelse-60-2/` |
+| Profiles: `/profiler/:name/` | `/profiler/dagfinn/` |
+| Tags: `/emne/:tag/` | `/emne/tillit/` |
 
 ## Layouts
 
-| Layout | Use For |
-|--------|---------|
-| `default` | Standard pages with products, profiles, cases sections |
-| `landing` | Product/company landing pages (hero + content) |
+| Layout | Use For | Key Features |
+|--------|---------|--------------|
+| `default` | Standard pages | Header, navbar, profiles, products, footer sections |
+| `perspektiv` | Frame/benefit articles | Hero from topic data, article content, question sections, CTA |
+| `tag` | Tag landing pages | Tag cloud, filtered article list |
 
-## Modules
+The `perspektiv` layout sources its hero from `page.topic_hero` frontmatter referencing `site.topics`, and wraps content in `.perspektiv-section` / `.perspektiv-element` classes for article styling.
 
-### CSS
+## CSS Architecture
 
-13 modular stylesheets organized by category:
-- **Base:** colors, typography, layout
-- **Components:** profiles, products, cases, podcast
-- **Layout:** header, footer, navbar
-- **Themes:** styles-light, styles-dark
-- **Utilities:** utilities
+See `.design/css-architecture.md` for the full breakdown. Key patterns:
 
-Always use CSS custom properties (variables) for colors.
+- **Component CSS** in `assets/css/components/` — `hero.css`, `card.css`
+- **Theme via variables** — `--*-light` / `--*-dark` pairs in `colors.css`, no component re-selection
+- **Zero hardcoded colors** — all visual color values use `var(--variable)` from `colors.css`
 
-### JavaScript
+## Includes
+
+| Include | Purpose | Source Pattern |
+|---------|---------|----------------|
+| `hero.html` | Page hero with image, title, breadcrumb | Dual-source: page frontmatter OR include params |
+| `card.html` | Topic card with image, title, description | Iterates `site.topics` with `include.category` filter |
+| `header.html` | Site header with logo + navbar | — |
+| `profiles.html` | Team profile cards | Iterates `site.profiles` |
+| `styles.html` | CSS link tags | Lists all stylesheets including `components/` |
+| `scripts.html` | JavaScript includes | — |
+| `metadata.html` | SEO meta tags | Reads `_data/metadata.yml` |
+
+## JavaScript
 
 Vanilla JS only, no frameworks:
-- `dark-mode-toggle.js` — Theme switching
-- `profile-card.js` — Profile expansion
+- `dark-mode-toggle.js` — Theme switching via `[data-theme="dark"]` attribute
+- `profile-card.js` — Profile expansion modal
+- `animations.js` — Scroll-triggered animations (Intersection Observer)
 
 ## Navigation
 
 - Header banner with logo and navbar
-- Links to main pages (Ledelse 60:2, Om oss)
-- Dark mode toggle
-
-## Response Flow
-
-```
-User → Landing Page → Booking URL (Microsoft Bookings)
-```
+- Links to main pages (Ledelse 60:2, Om oss, Metode)
+- Dark mode toggle in header
+- Frame/benefit articles linked from method page and cross-references
 
 ## Build & Deploy
 
-- **Build:** GitHub Pages (automatic)
+- **Build:** GitHub Pages (automatic Jekyll build)
 - **Host:** noexcuse.no
-- **CMS:** Jekyll (static)
+- **CMS:** Jekyll (static site generator)

--- a/.design/colors.md
+++ b/.design/colors.md
@@ -1,4 +1,4 @@
-# Color Palette - No Excuse AS
+# Color Palette — No Excuse AS
 
 ## Twin Primary Colors
 
@@ -29,23 +29,38 @@ CTAs always carry a 2px solid border of the opposite twin primary for guaranteed
 | CTA-1 (primary) | `#F0FFFF` (azure) | `#003060` (navy) | `#003060` |
 | CTA-2 (secondary) | `#003060` (navy) | `#F0FFFF` (azure) | `#F0FFFF` |
 
+### CTA Variables
+
+| Variable | Value |
+|----------|-------|
+| `--cta-primary-bg` | `var(--primary-azure)` |
+| `--cta-primary-text` | `var(--primary-navy)` |
+| `--cta-primary-border` | `var(--primary-navy)` |
+| `--cta-secondary-bg` | `var(--primary-navy)` |
+| `--cta-secondary-text` | `var(--primary-azure)` |
+| `--cta-secondary-border` | `var(--primary-azure)` |
+
 ---
+
+## Theme Color Convention
+
+All theme-aware variables use a `-light` / `-dark` suffix pair. Light mode values have the `-light` suffix, dark mode values have the `-dark` suffix. Components reference variables without the suffix ambiguity — `styles-dark.css` overrides swap which value is active.
 
 ## Light Mode
 
 | Element | Variable | Value |
 |---------|----------|-------|
 | Page Background | `--background-color-light` | `#c0d4e8` |
-| Stashed (old bg) | `--bg-neutral-light` | `#e2e8f0` |
+| Neutral Background | `--bg-neutral-light` | `#e2e8f0` |
 | Text | `--text-color-light` | `#37474F` |
-| Header/Banner Background | `--banner-background-light` | `var(--primary-navy)` -> `#003060` |
-| Header/Banner Text | `--banner-text-light` | `var(--primary-azure)` -> `#F0FFFF` |
+| Header/Banner Background | `--banner-background-light` | `var(--primary-navy)` → `#003060` |
+| Header/Banner Text | `--banner-text-light` | `var(--primary-azure)` → `#F0FFFF` |
 | Card/Box | `--box-background-light` | `#FFFFFF` |
-| Page Link | `--link-color-light` | `#000A14` |
+| Page Link | `--link-color-light` | `var(--primary-navy)` → `#003060` |
 | Page Link Hover | `--link-hover-light` | `#000A1F` |
-| Nav Link | `--nav-link-color-light` | `var(--primary-azure)` -> `#F0FFFF` |
-| Footer Background | `--footer-background-light` | `#FFFFFF` |
-| Footer Text | `--footer-text-light` | `#000A14` |
+| Nav Link | `--nav-link-color-light` | `var(--primary-azure)` → `#F0FFFF` |
+| Footer Background | `--footer-background-light` | `var(--primary-azure)` → `#F0FFFF` |
+| Footer Text | `--footer-text-light` | `var(--primary-navy)` → `#003060` |
 
 ## Dark Mode
 
@@ -53,38 +68,82 @@ CTAs always carry a 2px solid border of the opposite twin primary for guaranteed
 |---------|----------|-------|
 | Page Background | `--background-color-dark` | `#121212` |
 | Text | `--text-color-dark` | `#FFFFFF` |
-| Header/Banner Background | `--banner-background-dark` | `var(--primary-azure)` -> `#F0FFFF` |
-| Header/Banner Text | `--banner-text-dark` | `var(--primary-navy)` -> `#003060` |
+| Header/Banner Background | `--banner-background-dark` | `var(--primary-azure)` → `#F0FFFF` |
+| Header/Banner Text | `--banner-text-dark` | `var(--primary-navy)` → `#003060` |
 | Card/Box | `--box-background-dark` | `#333333` |
-| Page Link | `--link-color-dark` | `#F0FFFF` |
+| Page Link | `--link-color-dark` | `var(--primary-azure)` → `#F0FFFF` |
 | Page Link Hover | `--link-hover-dark` | `#8AB4F8` |
-| Nav Link | `--nav-link-color-dark` | `var(--primary-navy)` -> `#003060` |
-| Footer Background | `--footer-background-dark` | `#222222` |
-| Footer Text | `--footer-text-dark` | `#F0FFFF` |
+| Nav Link | `--nav-link-color-dark` | `var(--primary-navy)` → `#003060` |
+| Footer Background | `--footer-background-dark` | `var(--primary-navy)` → `#003060` |
+| Footer Text | `--footer-text-dark` | `var(--primary-azure)` → `#F0FFFF` |
 
-## CSS Variables Added
+## Surface Colors (Subtle Backgrounds)
 
-| Variable | Value | Purpose |
-|----------|-------|---------|
-| `--primary-navy` | `#003060` | Twin primary dark |
-| `--primary-azure` | `#F0FFFF` | Twin primary light |
-| `--logo-fill` | `var(--primary-azure)` | Logo color (overridden on `.header` in dark mode) |
-| `--nav-link-color-light` | `var(--primary-azure)` | Nav link on navy header (light mode) |
-| `--nav-link-color-dark` | `var(--primary-navy)` | Nav link on azure header (dark mode) |
-| `--cta-primary-bg` | `var(--primary-azure)` | CTA-1 background |
-| `--cta-primary-text` | `var(--primary-navy)` | CTA-1 text |
-| `--cta-primary-border` | `var(--primary-navy)` | CTA-1 border (2px solid) |
-| `--cta-secondary-bg` | `var(--primary-navy)` | CTA-2 background |
-| `--cta-secondary-text` | `var(--primary-azure)` | CTA-2 text |
-| `--cta-secondary-border` | `var(--primary-azure)` | CTA-2 border (2px solid) |
-| `--bg-neutral-light` | `#e2e8f0` | Stashed old light page bg |
+Used for tag badges, profile contact items, hover states, and other secondary surface treatments.
+
+| Variable | Light | Dark |
+|----------|-------|------|
+| `--surface-subtle-*` | `rgba(0,0,0,0.04)` | `rgba(255,255,255,0.06)` |
+| `--surface-hover-*` | `rgba(0,0,0,0.08)` | `rgba(255,255,255,0.12)` |
+| `--surface-raised-*` | `rgba(0,0,0,0.03)` | `rgba(255,255,255,0.05)` |
+| `--surface-raised-hover-*` | `rgba(0,0,0,0.06)` | `rgba(255,255,255,0.10)` |
+| `--surface-tag-bg-dark` | — | `rgba(255,255,255,0.08)` |
+
+## Border Colors
+
+Color-only variables (not `border` shorthand — use with `border-*-color` properties).
+
+| Variable | Light | Dark |
+|----------|-------|------|
+| `--border-color-*` | `rgba(0,0,0,0.1)` | `rgba(255,255,255,0.1)` |
+| `--border-color-subtle-light` | `rgba(0,0,0,0.08)` | — |
+
+Shorthand border variables: `--border-light`, `--border-medium`, `--border-dark` in `colors.css`.
+
+## Overlays & Modals
+
+| Variable | Value | Usage |
+|----------|-------|-------|
+| `--overlay-light` | `rgba(0,0,0,0.6)` | Profile expanded backdrop |
+| `--overlay-dark` | `rgba(0,0,0,0.8)` | Booking overlay |
+| `--close-bg-light` | `rgba(255,255,255,0.95)` | Profile close button |
+| `--close-bg-hover-light` | `#ffffff` | Profile close button hover |
+| `--close-bg-dark` | `rgba(255,255,255,0.9)` | Close buttons in dark mode |
+
+## Profile Card Components
+
+| Variable | Light | Dark |
+|----------|-------|------|
+| `--profile-gradient-start-*` | `rgba(58,78,88,0.06)` | `rgba(255,255,255,0.05)` |
+| `--profile-gradient-end-*` | `rgba(58,78,88,0.02)` | `rgba(255,255,255,0.02)` |
+| `--profile-image-border-*` | `rgba(58,78,88,0.12)` | `rgba(255,255,255,0.1)` |
+
+## Nav Hover
+
+| Variable | Value |
+|----------|-------|
+| `--nav-hover-bg-light` | `rgba(255,255,255,0.15)` |
+| `--nav-hover-bg-dark` | `rgba(0,0,0,0.1)` |
+
+## Component Aliases
+
+These exist so component CSS references semantic names instead of direct variable names, making it possible to swap the underlying variable without touching component CSS.
+
+| Alias | Maps To |
+|-------|---------|
+| `--navbar-background-light` | `var(--box-background-light)` |
+| `--navbar-background-dark` | `var(--box-background-dark)` |
+| `--button-background-light` | `var(--primary-accent)` |
+| `--button-background-dark` | `var(--box-background-dark)` |
+| `--button-text-color-light` | `var(--primary-accent-contrast)` |
+| `--button-text-color-dark` | `var(--text-color-light)` |
 
 ## Legacy Aliases (backward compatibility)
 
-| Alias | Maps to | Old value |
-|-------|---------|-----------|
-| `--primary-accent` | `var(--primary-azure)` | `azure` |
-| `--primary-accent-contrast` | `var(--primary-navy)` | `#000A14` |
+| Alias | Maps to |
+|-------|---------|
+| `--primary-accent` | `var(--primary-azure)` |
+| `--primary-accent-contrast` | `var(--primary-navy)` |
 
 These aliases ensure components using the old variable names still work.
 
@@ -102,6 +161,7 @@ These aliases ensure components using the old variable names still work.
 - Nav links use the inverted twin primary to contrast with the header background
 - Logo fill swaps via `--logo-fill` CSS variable — controlled by mode stylesheets on `.header`
 - Page link colors (`--link-color-light`/`--link-color-dark`) are for content links only; nav links use `--nav-link-*` variables
+- Surface colors are for secondary interactive backgrounds only — use `--box-background-*` for card-level surfaces
 
 ### Color Intensity Levels
 

--- a/.design/components.md
+++ b/.design/components.md
@@ -1,80 +1,183 @@
-# Reusable Components - No Excuse AS
+# Reusable Components — No Excuse AS
 
-## Buttons
+## Hero Component
+
+The hero is rendered via `_includes/hero.html` and styled by `assets/css/components/hero.css`.
+
+### Dual-Source Data Pattern
+
+The hero accepts data from two sources, with include params taking priority:
+
+1. **Page frontmatter** — `page.hero.image`, `page.hero.title`, `page.hero.breadcrumb`, `page.hero_effect`
+2. **Include parameters** — `{% include hero.html image="..." title="..." %}`
+
+This enables the `perspektiv` layout to pass frame topic data without duplicating it in each article's frontmatter:
+```liquid
+{% include hero.html image=frame.hero.image title=frame.title breadcrumb="Perspektiv" %}
+```
+
+### CSS
+
+Single `.hero` class set in `assets/css/components/hero.css`. Replaces 4 old hero implementations:
+- `.landing-hero` (was in `products.css`)
+- `.science-hero` (was in `products.css`)
+- `.about-hero` (was in `about.css`)
+- `.frame-hero` / `.perspektiv-hero` (was in `article.css`)
+
+### Markup Structure
+
+```html
+<div class="hero">
+  <div class="hero-image" role="img" aria-label="...">
+    <div class="hero-overlay"></div>
+  </div>
+  <div class="hero-content">
+    <nav class="hero-breadcrumb">...</nav>
+    <h1 class="hero-title">...</h1>
+    <p class="hero-intro">...</p>
+  </div>
+</div>
+```
+
+### Dark Mode
+
+Controlled entirely via CSS variables — `.hero` uses `var(--banner-background-*)`, `var(--banner-text-*)`, `var(--primary-*)` from `colors.css`.
+
+### Hero Effects
+
+Optional scroll-driven effects activated by `hero_effect` frontmatter field:
+- `parallax-fade` — image translates up 40px on scroll (0–300px), title/intro fade out with translateY
+
+Handled by `HeroEffects` dispatcher in `animations.js`. The JS selector `.hero-image` drives the parallax.
+
+---
+
+## Card Component
+
+Cards are rendered via `_includes/card.html` and styled by `assets/css/components/card.css`.
+
+### Data Source
+
+Cards iterate `site.topics` filtered by category:
+```liquid
+{% assign frame_topics = site.topics | where: "category", "frame" | sort: "weight" %}
+{% for topic in frame_topics %}
+  {% include card.html topic=topic %}
+{% endfor %}
+```
+
+### Card Variants
+
+Controlled by CSS modifier classes (not separate includes):
+
+| Class | Usage | Features |
+|-------|-------|----------|
+| `.card--frame` | Frame perspective cards | Accent border, hover lift |
+| `.card--benefit` | Benefit cards | Icon/illustration + description |
+| `.card--numbered` | Process step cards | Step number badge, ordered layout |
+
+### Per-Topic Accent
+
+Each topic card gets a `data-topic-id` attribute matching the topic's slug. The `--card-accent` custom property enables per-topic accent colors via CSS:
+```css
+.card[data-topic-id="struktur"] { --card-accent: #...; }
+```
+
+### CSS Structure
+
+```css
+.card-grid          — Grid container (2/3 col, responsive)
+.card               — Base card component
+.card--frame        — Frame variant
+.card--benefit      — Benefit variant  
+.card--numbered     — Numbered step variant
+.card-image         — Card illustration
+.card-content       — Text container
+.card-step-badge    — Step number display
+.card-subtitle      — Subtitle text
+.card-detail        — Detail/description text
+.card-link          — CTA link within card
+.card-link--cta     — Primary CTA link variant
+```
+
+---
+
+## Buttons / CTAs
 
 ### Primary CTA Button
 - **Height:** 44px minimum
-- **Background:** Azure (`--primary-accent`)
-- **Text:** Dark (`--primary-accent-contrast`)
-- **Border-radius:** 4px
-- **States:** Default, Hover, Active, Disabled
+- **Background:** `var(--cta-primary-bg)` (azure)
+- **Text:** `var(--cta-primary-text)` (navy)
+- **Border:** 2px solid `var(--cta-primary-border)` (navy)
+- **States:** Default, Hover (translateY lift), Active, Disabled
 
 ### Secondary Button
-- **Style:** Outlined or text-only
-- **Purpose:** Secondary actions
+- **Background:** `var(--cta-secondary-bg)` (navy)
+- **Text:** `var(--cta-secondary-text)` (azure)
+- **Border:** 2px solid `var(--cta-secondary-border)` (azure)
 
-## Cards
+---
 
-### Service Card
-- Icon (service representation)
-- Title (service name)
-- Description (brief)
-- CTA button
-- Background: `--box-background-light/dark`
+## Profile Card
 
-### Profile Card
-- Photo (rounded or square)
+- Photo (rounded, 120×120px)
 - Name
-- Title/role
-- Tags (expertise)
-- Contact links
+- Contact links (phone, email) — pill-style with subtle background
+- Expand button → modal with biography, tags, booking CTA
+- Background: `var(--box-background-light/dark)`
+- Modal backdrop: `var(--overlay-light)`
+
+Styled by `assets/css/profiles.css`.
+
+---
 
 ## Navigation
 
 ### Header
-- Logo
-- Navigation links (if needed)
+- Logo (inline SVG with `--logo-fill`)
+- Navigation links
 - Dark mode toggle
 
-### Footer
-- Contact information
-- Social links
-- Copyright
+### Navbar
+- Horizontal flex layout, centered
+- Links use `--nav-link-color-light` (azure on navy bg in light mode) / `--nav-link-color-dark` (navy on azure bg in dark mode)
+- Hover: `background: var(--nav-hover-bg-light/dark)`
+
+Styled by `assets/css/header.css` and `assets/css/navbar.css`.
+
+---
+
+## Tags / Emne System
+
+### Tag Cloud
+Displayed on tag landing pages (`/emne/:tag/`):
+- `.tag-cloud` — flex-wrap container of `.tag-cloud-item` links
+- `.tag-name` — tag display name
+- `.tag-count` — pill badge with accent background and `--primary-accent-contrast` text
+- `.tag-badge` — inline tag badges on article list pages
+
+Styled in `assets/css/article.css`.
+
+---
 
 ## Form Elements
 - Input fields (44px height minimum)
 - Date picker (Microsoft Bookings)
 - Submit buttons
 
+---
+
 ## Theme Support
-- Light mode stylesheet
-- Dark mode stylesheet
-- Toggle mechanism
 
-## Accessibility Requirements
+Light and dark mode are handled through CSS variable pairs. All components reference `var(--*-light)` / `var(--*-dark)` from `colors.css`. The active value is determined by `styles-dark.css` being enabled and the `[data-theme="dark"]` attribute on `<html>`.
 
-- WCAG AA compliant colors
-- Keyboard navigable
-- Screen reader friendly
-- Focus indicators
+**Never** use `.dark-mode` class selectors — the project migrated from that pattern to `[data-theme="dark"]` and `styles-dark.css`.
 
-## Dark Mode Support
+### Required Dark Mode Variables
 
-All components **must** have both light and dark mode variants.
+Each component must use these variables for theme-aware styling:
 
-### Requirement
-
-When adding new components or modifying existing ones:
-1. Define CSS variables for colors (do not hardcode colors)
-2. Provide light mode styles in base CSS
-3. Provide dark mode styles in `styles-dark.css` or via `.dark-mode` class override
-4. Test all sections with dark mode toggled on before submitting PR
-
-### Required Dark Mode Elements
-
-Each section type must handle:
-
-| Element | Light Variable | Dark Variable |
+| Purpose | Light Variable | Dark Variable |
 |---------|---------------|---------------|
 | Background | `--background-color-light` | `--background-color-dark` |
 | Text | `--text-color-light` | `--text-color-dark` |
@@ -82,11 +185,17 @@ Each section type must handle:
 | Box shadow | `--box-shadow-light` | `--box-shadow-dark` |
 | Link | `--link-color-light` | `--link-color-dark` |
 | Link hover | `--link-hover-light` | `--link-hover-dark` |
+| Surface (subtle) | `--surface-subtle-light` | `--surface-subtle-dark` |
+| Surface (hover) | `--surface-hover-light` | `--surface-hover-dark` |
+| Border color | `--border-color-light` | `--border-color-dark` |
 
 ### New Components Checklist
 
-Before merging any PR, verify:
+Before merging any PR with new components, verify:
 - [ ] All colors use CSS variables, not hardcoded values
-- [ ] `.dark-mode` variant exists for the component
-- [ ] Dark mode tested on all page sections (landing, products, benefits, etc.)
+- [ ] Light/dark variable pairs exist in `colors.css`
+- [ ] Component uses `var(--property)` referencing `colors.css` — no `[data-theme="dark"]` overrides in component CSS
+- [ ] Dark mode tested on all page sections
 - [ ] No color contrast violations (WCAG AA minimum 4.5:1 for text)
+- [ ] Touch targets minimum 44×44px
+- [ ] Component CSS added via `_includes/styles.html` if new file

--- a/.design/css-architecture.md
+++ b/.design/css-architecture.md
@@ -1,68 +1,163 @@
 # CSS Architecture — No Excuse AS
 
-## Module Structure (21 files, ~2100 lines)
+## Module Structure (21 files, ~2572 total lines)
 
 | Category | Files |
 |----------|-------|
-| **Base** | `colors.css` (78), `typography.css` (72), `layout.css` (25) |
-| **Utilities** | `utilities.css` (49), `animations.css` (64) |
-| **Components** | `article.css` (290), `about.css` (129), `avtale.css` (107), `cases.css` (17), `partners.css` (44), `podcast.css` (13), `products.css` (426), `profiles.css` (260) |
-| **Layout** | `header.css` (43), `navbar.css` (38), `footer.css` (6) |
-| **Themes** | `styles-light.css` (49), `styles-dark.css` (315) |
-| **Overrides** | `perspektiv-styles.css` (79) — unique overrides only |
+| **Base** | `colors.css` (166), `typography.css` (73), `layout.css` (133) |
+| **Utilities** | `utilities.css` (49), `animations.css` (151) |
+| **Components** | `assets/css/components/hero.css` (91), `assets/css/components/card.css` (164) |
+| **Pages** | `article.css` (285), `about.css` (122), `products.css` (356), `profiles.css` (280), `avtale.css` (107), `perspektiv-styles.css` (118), `cases.css` (16), `partners.css` (45), `podcast.css` (13) |
+| **Layout** | `header.css` (46), `navbar.css` (38), `footer.css` (6) |
+| **Themes** | `styles-light.css` (50), `styles-dark.css` (263) |
+
+Component-specific CSS lives in `assets/css/components/`. Page-level CSS lives in the root `assets/css/` directory. This separation prevents component styles from being mixed with page layout rules.
 
 ## Design Tokens
 
-All defined in `colors.css`:
+All design tokens defined in `colors.css`:
+
+### Core Colors
 
 ```
---primary-accent: azure;
---primary-accent-contrast: #000a14;
+--primary-navy:   #003060    Twin primary dark
+--primary-azure:  #F0FFFF    Twin primary light
+```
 
-/* Shadow elevation scale */
---shadow-sm      0 2px 8px  rgba(0,0,0,0.08)   — cards, small surfaces
---shadow-md      0 8px 20px rgba(0,0,0,0.12)   — hover states
---shadow-lg      0 12px 24px rgba(0,0,0,0.12)  — modals, overlays
---shadow-xl      0 20px 60px rgba(0,0,0,0.15)  — large overlays
---shadow-*-dark                                   — dark variants
+### Background / Surface Colors
 
-/* Spacing scale (4px base) */
---space-xs   4px     --space-sm   8px
---space-md   16px    --space-lg   24px
---space-xl   32px    --space-2xl  40px    --space-3xl  48px
+```
+--background-color-light: #c0d4e8    Dark mode: --background-color-dark: #121212
+--box-background-light:   #ffffff    Dark mode: --box-background-dark:   #333333
+--surface-subtle-light:   rgba(0,0,0,0.04)   Dark mode: --surface-subtle-dark:   rgba(255,255,255,0.06)
+--surface-raised-light:   rgba(0,0,0,0.03)   Dark mode: --surface-raised-dark:   rgba(255,255,255,0.05)
+--surface-raised-hover-light: rgba(0,0,0,0.06)  Dark mode: --surface-raised-hover-dark: rgba(255,255,255,0.10)
+--surface-hover-light:    rgba(0,0,0,0.08)   Dark mode: --surface-hover-dark:    rgba(255,255,255,0.12)
+--surface-tag-bg-dark:    rgba(255,255,255,0.08)
+```
 
-/* Border radius */
---radius-sm  4px     --radius-md  8px     --radius-lg  12px    --radius-xl  16px
+### Text Colors
 
-/* Content widths */
---content-max: 1100px;   --content-narrow: 65ch;   --content-wide: 800px;
+```
+--text-color-light: #37474f    Dark mode: --text-color-dark: #ffffff
+--link-color-light: var(--primary-navy)   Dark mode: --link-color-dark: var(--primary-azure)
+--link-hover-light: #000a1f     Dark mode: --link-hover-dark: #8ab4f8
+```
 
-/* Legacy aliases */
---box-shadow-light: var(--shadow-sm);
---box-shadow-hover-light: var(--shadow-md);
+### Border Colors (color-only, not shorthand)
+
+```
+--border-color-light:         rgba(0,0,0,0.1)    Dark mode: --border-color-dark: rgba(255,255,255,0.1)
+--border-color-subtle-light:  rgba(0,0,0,0.08)
+```
+
+### Border Shorthand
+
+```
+--border-light:   1px solid rgba(0,0,0,0.08)
+--border-medium:  1px solid rgba(0,0,0,0.1)
+--border-dark:    1px solid rgba(255,255,255,0.1)
+```
+
+### Shadow Elevation Scale
+
+```
+--shadow-xs      0 2px 4px   rgba(0,0,0,0.08)   — cards, small surfaces
+--shadow-sm      0 2px 8px   rgba(0,0,0,0.08)   — hover states (light)
+--shadow-md      0 8px 20px  rgba(0,0,0,0.12)   — hover states (medium)
+--shadow-lg      0 12px 24px rgba(0,0,0,0.12)   — modals, overlays
+--shadow-xl      0 20px 60px rgba(0,0,0,0.15)   — large overlays
+--shadow-*-dark                                   — dark variants (deeper opacity)
+```
+
+### Spacing Scale (4px base)
+
+```
+--space-xs   4px    --space-sm   8px    --space-md   16px
+--space-lg   24px   --space-xl   32px   --space-2xl  40px
+--space-3xl  48px   --space-4xl  64px   --space-5xl  80px
+```
+
+### Border Radius
+
+```
+--radius-sm  4px    --radius-md  8px    --radius-lg  12px    --radius-xl  16px
+```
+
+### Content Widths
+
+```
+--content-max: 1100px    --content-narrow: 65ch    --content-wide: 800px
+```
+
+### Overlays & Modals
+
+```
+--overlay-light:      rgba(0,0,0,0.6)   — profile modal backdrop
+--overlay-dark:       rgba(0,0,0,0.8)   — booking overlay
+--close-bg-light:     rgba(255,255,255,0.95)   Dark mode: --close-bg-dark: rgba(255,255,255,0.9)
+--close-bg-hover-light: #ffffff
+```
+
+### Profile Card Components
+
+```
+--profile-gradient-start-light: rgba(58,78,88,0.06)   Dark mode: ...-dark: rgba(255,255,255,0.05)
+--profile-gradient-end-light:   rgba(58,78,88,0.02)   Dark mode: ...-dark: rgba(255,255,255,0.02)
+--profile-image-border-light:   rgba(58,78,88,0.12)   Dark mode: ...-dark: rgba(255,255,255,0.1)
+```
+
+### Component Aliases
+
+```
+--navbar-background-light:  var(--box-background-light)   Dark mode: ...-dark
+--button-background-light:  var(--primary-accent)          Dark mode: ...-dark
+--button-text-color-light:  var(--primary-accent-contrast) Dark mode: ...-dark
+--nav-hover-bg-light:       rgba(255,255,255,0.15)         Dark mode: --nav-hover-bg-dark: rgba(0,0,0,0.1)
+```
+
+### Legacy Aliases
+
+```
+--primary-accent:             var(--primary-azure)
+--primary-accent-contrast:    var(--primary-navy)
+--box-shadow-light:           var(--shadow-sm)
+--box-shadow-hover-light:     var(--shadow-md)
+--box-shadow-dark:            var(--shadow-sm-dark)
+--box-shadow-hover-dark:      var(--shadow-md-dark)
 ```
 
 ## Theme Support (Dark Mode)
 
-Consolidated pattern: ALL dark mode styles live in `styles-dark.css` with plain selectors (no `.dark-mode` prefix). Zero `.dark-mode` selectors remain in any component CSS file.
+Dark mode is implemented entirely through CSS variable overrides — no component re-selection.
 
-JavaScript toggles both the stylesheet `disabled` attribute and `document.body.classList` synchronously.
+- Light mode variables use `--*-light` suffix
+- Dark mode variables use `--*-dark` suffix
+- JavaScript toggles `[data-theme="dark"]` on `<html>`
+- `styles-dark.css` contains dark mode overrides that are enabled/disabled via stylesheet `disabled` attribute
 
-## Component Alias Pattern
+New components must follow this pattern: define all themed values as `var(--property)` referencing `colors.css`, which already has both `-light` and `-dark` variants.
 
-Shared component patterns use comma-separated selectors:
+## Variable Naming Convention
 
-```css
-.perspektiv-hero,
-.frame-hero { ... }
+```
+--{purpose}-{modifier}-{light|dark}
 ```
 
-The `perspektiv-styles.css` file contains only genuinely unique overrides (markers, decorations, extended hover effects) — slimmed from 303→79 lines.
+Examples:
+- `--surface-subtle-light` / `--surface-subtle-dark`
+- `--border-color-light` / `--border-color-dark`
+- `--box-background-light` / `--box-background-dark`
+
+Constants (no theme pair): omit the suffix.
+- `--primary-navy`, `--space-md`, `--radius-lg`
 
 ## Conventions
 
-- **Colors**: Always `var(--text-color-*)` / `var(--box-background-*)` — never `#333` or raw hex
+- **Colors**: Always `var(--variable)` — never `#333` or raw hex or rgba
 - **Shadows**: Use `var(--shadow-*)` — never raw values
+- **Component CSS**: Lives in `assets/css/components/` — `hero.css`, `card.css`
 - **Breakpoints**: 599px (mobile), 1024px (tablet). Never `768px`.
-- **Touch targets**: Minimum 44x44px for interactive elements
-- **Font sizes**: Use heading elements (h1-h3) or the typography scale
+- **Touch targets**: Minimum 44×44px for interactive elements
+- **Font sizes**: Use heading elements (h1–h3) or the typography scale
+- **Dark mode**: Variables only — no `[data-theme="dark"]` selector overrides in component CSS; those belong in `styles-dark.css`

--- a/.design/html-templates.md
+++ b/.design/html-templates.md
@@ -6,14 +6,91 @@
 {% include metadata.html %}
 {% include styles.html %}
 {% include header.html %}
-{% for profile in site.profiles %}
-  {% include profiles.html %}
+{% include hero.html %}
+{% include card.html topic=site.topic %}
+{% include profiles.html %}
+{% include scripts.html %}
+```
+
+## Core Includes
+
+### `hero.html` — Page Hero
+
+Two invocation patterns:
+
+**1. From page frontmatter (standard pages):**
+```liquid
+{% include hero.html %}
+```
+Renders from `page.hero.image`, `page.hero.title`, `page.hero.breadcrumb`, `page.hero_effect`.
+
+**2. With parameters (layout-driven):**
+```liquid
+{% include hero.html image=frame.hero.image title=frame.title breadcrumb="Perspektiv" %}
+```
+Parameters override frontmatter values. Used by `_layouts/perspektiv.html` to pass topic data.
+
+### `card.html` — Topic Card
+
+Renders a single topic item:
+```liquid
+{% assign topics = site.topics | where: "category", "frame" | sort: "weight" %}
+{% for topic in topics %}
+  {% include card.html topic=topic %}
 {% endfor %}
 ```
 
-## Metadata
+Uses `topic.image`, `topic.title`, `topic.description`, `topic.cta` from the topic's frontmatter. Styled via CSS classes on `.card` (`.card--frame`, `.card--benefit`, `.card--numbered`).
 
-All SEO/social meta tags in `_includes/metadata.html`, populated from `_data/metadata.yml`.
+### `profiles.html` — Team Profiles
+
+Iterates `site.profiles`:
+```liquid
+{% include profiles.html %}
+```
+Optional `tags` parameter for filtering:
+```liquid
+{% include profiles.html tags="ledelse" %}
+```
+
+### `styles.html` — CSS Includes
+
+Lists all stylesheets in order:
+```
+colors.css → typography.css → layout.css → utilities.css → animations.css
+components/hero.css → components/card.css
+article.css → about.css → products.css → profiles.css → avtale.css ...
+header.css → navbar.css → footer.css
+styles-light.css → styles-dark.css
+perspektiv-styles.css → cases.css → partners.css → podcast.css
+```
+
+### `scripts.html` — JavaScript Includes
+
+Lists all scripts. Currently: `dark-mode-toggle.js`, `profile-card.js`, `animations.js`.
+
+### `metadata.html` — SEO Meta Tags
+
+Populated from `_data/metadata.yml`. Includes:
+- Dynamic `og:title`, `og:description`, `og:url` per page
+- Canonical URL
+- BreadcrumbList JSON-LD
+- FAQPage schema (where applicable)
+
+## HTML Structure Pattern
+
+```html
+<body>
+  {% include header.html %}
+  <main>
+    {% include hero.html %}
+    {{ content }}
+    {% include profiles.html %}
+  </main>
+  {% include footer.html %}
+  {% include scripts.html %}
+</body>
+```
 
 ## Prohibited Patterns
 
@@ -22,3 +99,4 @@ All SEO/social meta tags in `_includes/metadata.html`, populated from `_data/met
 | `style="..."` on HTML elements | Breaks CSP, mixes concerns, hard to maintain | CSS classes in proper files under `assets/css/` |
 | `onclick="..."`, `onsubmit="..."`, etc. | Inline event handlers are CSP violations, hard to debug | External JS files in `assets/scripts/` with `addEventListener` |
 | `<script>...</script>` inside HTML bodies | Blocks rendering, mixes concerns, no caching | External JS files loaded via `_includes/scripts.html` |
+| `<style>...</style>` in pages | Same as inline styles — CSP + maintainability | Page-specific CSS goes in a dedicated file or utility classes |

--- a/.design/information-architecture.md
+++ b/.design/information-architecture.md
@@ -4,20 +4,47 @@
 
 Documents all cross-references between content pages on noexcuse.no. When adding or modifying pages, update this map to keep cross-links consistent.
 
+## Content Pages
+
+| URL | File | Topic |
+|-----|------|-------|
+| `/` | `index.md` | Frontpage |
+| `/ledelse-60-2/` | `_pages/ledelse_60-2.md` | Product landing — Ledelse 60:2 |
+| `/om-oss/` | `_pages/om_oss.md` | About the company |
+| `/om-metode/` | `_pages/om_metode.md` | Method overview with 4 frames, 4 benefits, 3 steps |
+| `/perspektiv/` | `_pages/ledelse_perspektiv.md` | Scientific background: multiframe thinking |
+| `/triader/` | `_pages/ledelse_triader.md` | Triads concept |
+| `/struktur/` | `_pages/struktur.md` | Frame: Structure (roller, mål, prosesser) |
+| `/mennesker/` | `_pages/mennesker.md` | Frame: People (tilhørighet, mestring, autonomi) |
+| `/identitet/` | `_pages/identitet.md` | Frame: Identity (verdier, ritualer, fortelling) |
+| `/pavirkning/` | `_pages/pavirkning.md` | Frame: Influence (makt, nettverk, interesser) |
+| `/forankring/` | `_pages/ledelse_forankring.md` | Benefit: Anchoring |
+| `/tillit/` | `_pages/ledelse_tillit.md` | Benefit: Trust |
+| `/makt/` | `_pages/ledelse_makt.md` | Benefit: Power dynamics |
+| `/generativ-ki/` | `_pages/ledelse_generativ-ki.md` | Benefit: Generative AI |
+| `/usikkerhet/` | `_pages/ledelse_usikkerhet.md` | Benefit: Uncertainty |
+
+## Tag Pages
+
+Generated from `_tags/` collection at `/emne/:tag/`. Current tags: `beslutningstaking`, `digital-transformasjon`, `endringsledelse`, `forankring`, `kunstig-intelligens`, `ledelse`, `makt`, `organisasjonskultur`, `psykologisk-trygghet`, `servant-leadership`, `tillit`, `usikkerhet`.
+
 ## Cross-Reference Map
 
 | From | To | Link Text |
 |------|----|-----------|
-| `/påvirkning/` → "Maktens kostnader" brief paragraph | `/makt/` | "Les om maktens kostnader →" |
+| `/pavirkning/` → "Maktens kostnader" brief paragraph | `/makt/` | "Les om maktens kostnader →" |
 | `/struktur/` → "Det vitenskapelige grunnlaget" | `/perspektiv/` | "Les om multiframe-tenkning →" |
 | `/mennesker/` → "Verdier og mening" (Noble Cause → servant leadership) | `/makt/` | Noble cause connects to servant leadership |
 | `/identitet/` → tribal stages (Logan) | `/triader/` | "Hvordan bygge triader →" |
 | `/usikkerhet/` → Kotter section | `/triader/` | "Verktøy for kulturendring: triader →" |
 | All 4 frame articles → "Det vitenskapelige grunnlaget" | `/perspektiv/` | "Les om hvorfor vi ikke scorer →" |
+| `/om-metode/` → frame/benefit/step cards | Each content page | Card CTAs link to respective pages |
+| Tag cloud on `/emne/:tag/` | Tagged articles | Article links from tag landing |
 
 ## Rules
 
-1. Every cross-link must be bidirectional — if page A links to page B, verify B has a relevant context or return link.
+1. Every cross-link should be bidirectional — if page A links to page B, verify B has a relevant context or return link.
 2. Link text should be action-oriented ("Les om ..."), not generic ("Klikk her").
 3. When a page is renamed or removed, update all incoming cross-links.
 4. This map lives in `.design/` as reference for content work — the actual links are hardcoded in `_pages/*.md`.
+5. Topic card CTAs in `_includes/card.html` are driven by topic frontmatter — update the topic file, not the include.

--- a/.specs/architecture-cleanup/README.md
+++ b/.specs/architecture-cleanup/README.md
@@ -24,44 +24,44 @@ Consolidate all five layers — CSS, HTML templates, content model (Markdown col
 
 ## Acceptance Criteria (Checklist)
 
-### A1.1 — Topic consolidation (`_topics/` collection)
+### A1.1 — Topic consolidation (`_topics/` collection) ✅
 
-- [ ] `_config.yml` registers `_topics/` collection with `output: false`
-- [ ] All `_frames/*.md` files are copied to `_topics/` with frontmatter amended to include `category: frame`
-- [ ] `_topics/` items in `_config.yml` defaults have `category` field, image path, and layout reference
-- [ ] Benefit cards and process step data from `_products/ledelse-60-2.md` frontmatter are migrated to `_topics/` with appropriate categories (`benefit`, `step`)
-- [ ] `_frames/` directory is removed after migration
-- [ ] Frame article pages (`_pages/struktur.md` etc.) continue to render correctly — their topic content is sourced from `site.topics` where `category == "frame"`, and the article page links remain `/struktur/` etc. (unchanged permalinks)
-- [ ] Every card on `om_metode.md` (frame grid) and `ledelse_60-2.md` (benefit grid, process steps) is rendered via `_includes/card.html` iterating `site.topics`, not hardcoded HTML
+- [x] `_config.yml` registers `_topics/` collection with `output: false`
+- [x] All `_frames/*.md` files are copied to `_topics/` with frontmatter amended to include `category: frame`
+- [x] `_topics/` items in `_config.yml` defaults have `category` field, image path, and layout reference
+- [x] Benefit cards and process step data from `_products/ledelse-60-2.md` frontmatter are migrated to `_topics/` with appropriate categories (`benefit`, `step`)
+- [x] `_frames/` directory is removed after migration
+- [x] Frame article pages (`_pages/struktur.md` etc.) continue to render correctly — their topic content is sourced from `site.topics` where `category == "frame"`, and the article page links remain `/struktur/` etc. (unchanged permalinks)
+- [x] Every card on `om_metode.md` (frame grid) and `ledelse_60-2.md` (benefit grid, process steps) is rendered via `_includes/card.html` iterating `site.topics`, not hardcoded HTML
 
-### A1.2 — Hero unification
+### A1.2 — Hero unification ✅
 
-- [ ] `_includes/hero.html` is created — renders from page frontmatter fields: `hero.image`, `hero.title`, `hero.breadcrumb`, `hero_effect`
-- [ ] `assets/css/components/hero.css` contains a single `.hero` class set that handles all hero variants (landing, science, about, frame/perspektiv)
-- [ ] The 4 existing hero implementations (`.frame-hero` in `article.css`, `.about-hero` in `about.css`, `.landing-hero`/`.science-hero` in `products.css`) are removed — replaced by the shared `.hero` component
-- [ ] All 12 pages with heroes (`ledelse_60-2.md`, `om_oss.md`, `om_metode.md`, `struktur.md`, `identitet.md`, `mennesker.md`, `pavirkning.md`, `forankring.md`, `generativ-ki.md`, `tillit.md`, `usikkerhet.md`, `vitenskapelig-grunnlag.md`) use the same `_includes/hero.html` include
-- [ ] Hero frontmatter is added to pages missing it; redundant frontmatter is removed
+- [x] `_includes/hero.html` is created — renders from page frontmatter fields: `hero.image`, `hero.title`, `hero.breadcrumb`, `hero_effect`
+- [x] `assets/css/components/hero.css` contains a single `.hero` class set that handles all hero variants (landing, science, about, frame/perspektiv)
+- [x] The 4 existing hero implementations (`.frame-hero` in `article.css`, `.about-hero` in `about.css`, `.landing-hero`/`.science-hero` in `products.css`) are removed — replaced by the shared `.hero` component
+- [x] All 12 pages with heroes (`ledelse_60-2.md`, `om_oss.md`, `om_metode.md`, `struktur.md`, `identitet.md`, `mennesker.md`, `pavirkning.md`, `forankring.md`, `generativ-ki.md`, `tillit.md`, `usikkerhet.md`, `vitenskapelig-grunnlag.md`) use the same `_includes/hero.html` include
+- [x] Hero frontmatter is added to pages missing it; redundant frontmatter is removed
 
-### A1.3 — Card partial
+### A1.3 — Card partial ✅
 
-- [ ] `_includes/card.html` renders one topic item from a given category — uses `topic.image`, `topic.title`, `topic.description`, `topic.cta` where applicable
-- [ ] Card styling lives entirely in `assets/css/components/card.css`
-- [ ] Pages pass `include.category` to iterate and render the relevant subset of topics
-- [ ] Cards respect dark mode via CSS variables only (same as A1.4)
-- [ ] Card layout variants (grid vs. row, icon vs. banner image) are controlled by CSS classes, not separate HTML includes
+- [x] `_includes/card.html` renders one topic item from a given category — uses `topic.image`, `topic.title`, `topic.description`, `topic.cta` where applicable
+- [x] Card styling lives entirely in `assets/css/components/card.css`
+- [x] Pages pass `include.category` to iterate and render the relevant subset of topics
+- [x] Cards respect dark mode via CSS variables only (same as A1.4)
+- [x] Card layout variants (grid vs. row, icon vs. banner image) are controlled by CSS classes, not separate HTML includes
 
-### A1.4 — CSS color hygiene
+### A1.4 — CSS color hygiene ✅
 
-- [ ] `grep -n '#fff\|#ffffff\|#000\|#000000\|color: rgba\|background: rgba\|background-color: rgba' assets/css/*.css` returns zero matches in `article.css`, `about.css`, `products.css`, `header.css`, `navbar.css`, `footer.css`, `profiles.css`
-- [ ] All visual color values use `var(--variable)` referencing `colors.css`
-- [ ] `colors.css` has sufficient variable coverage for every component — no component falls back to a hardcoded color
-- [ ] `styles-dark.css` is reduced from 283 lines to approximately 30 lines — only variable flips and aesthetic tweaks (gradient intensity, shadow depth) that cannot be expressed as pure variable swaps
+- [x] `grep -n '#fff\|#ffffff\|#000\|#000000\|color: rgba\|background: rgba\|background-color: rgba' assets/css/*.css` returns zero matches in `article.css`, `about.css`, `products.css`, `header.css`, `navbar.css`, `footer.css`, `profiles.css`
+- [x] All visual color values use `var(--variable)` referencing `colors.css`
+- [x] `colors.css` has sufficient variable coverage for every component — no component falls back to a hardcoded color
+- [ ] `styles-dark.css` is reduced from 283 lines to approximately 30 lines — only variable flips and aesthetic tweaks (gradient intensity, shadow depth) that cannot be expressed as pure variable swaps (A1.7)
 
 ### A1.5 — CSS file reorganization
 
 - [ ] `assets/css/components/` directory exists with files:
-  - `hero.css` — all hero layout, overlay, responsive styles
-  - `card.css` — all card layout, hover, responsive styles
+  - `hero.css` — all hero layout, overlay, responsive styles ⚡ exists
+  - `card.css` — all card layout, hover, responsive styles ⚡ exists
   - `buttons.css` — all button / CTA styles (extracted from `products.css`)
   - `header.css` — stays as-is
   - `navbar.css` — stays as-is
@@ -84,7 +84,11 @@ Consolidate all five layers — CSS, HTML templates, content model (Markdown col
 - [ ] `_pages/om_metode.md` has no `<style>` block — any remaining inline styles are moved to appropriate CSS files
 - [ ] No page carries page-specific CSS in a `<style>` tag — page-specific overrides go to a dedicated CSS file or use existing utility classes
 
-### A1.7 — No regressions
+### A1.7 — `styles-dark.css` shrink
+
+- [ ] `styles-dark.css` is reduced from 263 lines to approximately 30 lines — only variable flips and aesthetic tweaks that cannot be expressed as pure variable swaps
+
+### A1.8 — No regressions
 
 - [ ] `bundle exec jekyll build` exits 0
 - [ ] All pages render heroes correctly (check top 3 pages: `/ledelse-60-2/`, `/om-oss/`, `/om-metode/`)
@@ -95,16 +99,16 @@ Consolidate all five layers — CSS, HTML templates, content model (Markdown col
 
 ## Implementation Order
 
-| Step | What | Why |
-|------|------|-----|
-| 1 | Topic content migration | Foundation — everything depends on the unified collection |
-| 2 | Hero include + CSS | Next — every page uses it, so it's a big diff to review early |
-| 3 | Card include + CSS | Needs topic collection in place (step 1) |
-| 4 | CSS color purge | Low risk, mechanical — can be done after structural changes settle |
-| 5 | CSS file split + cleanup | Reorganize after all CSS changes are done |
-| 6 | Inline CSS removal | Final cleanup |
-| 7 | `styles-dark.css` shrink | Last — depends on all other CSS being clean |
-| 8 | Full regression pass | Verify build, render, animations, dark mode |
+| Step | Status | What | Why |
+|------|--------|------|-----|
+| 1 | ✅ Merged | Topic content migration | Foundation — everything depends on the unified collection |
+| 2 | ✅ Merged | Hero include + CSS | Next — every page uses it, so it's a big diff to review early |
+| 3 | ✅ Merged | Card include + CSS | Needs topic collection in place (step 1) |
+| 4 | ✅ Merged | CSS color purge | Low risk, mechanical — can be done after structural changes settle |
+| 5 | ⬜ Pending | CSS file split + cleanup | Reorganize after all CSS changes are done |
+| 6 | ⬜ Pending | Inline CSS removal | Final cleanup |
+| 7 | ⬜ Pending | `styles-dark.css` shrink | Last — depends on all other CSS being clean |
+| 8 | ⬜ Pending | Full regression pass | Verify build, render, animations, dark mode |
 
 ## Design References
 


### PR DESCRIPTION
Update all 6 .design/ docs and the A1 spec to reflect patterns established in A1.1-A1.4: topic/_topics collection, hero/card includes, CSS components/ directory, color variable system, 24 new variable categories, and the -light/-dark naming convention.

Mark A1.1-A1.4 acceptance criteria as completed in spec.


m .frame-hero/
  .about-hero/.landing-hero/.science-hero to hero include; old hero CSS removed
  from article.css, about.css, products.css, styles-dark.css; parallax effect
  JS remains compatible (.hero-image, .hero-title, .hero-intro selectors)


sjonskultur


ored-by: Sisyphus <clio-agent@sisyphuslabs.ai>
t/README.md
#	modified:   .specs/ui-upgrade/README.md
#	modified:   BACKLOG.md
#	modified:   CHANGELOG.md
#
# Untracked files:
#	.specs/inbound-sales/
#