### PR TITLE
chore(x2): fix dark mode consistency gaps

### DIFF
--- a/assets/css/article.css
+++ b/assets/css/article.css
@@ -266,20 +266,20 @@
 }
 
 /* Dark mode overrides */
-[data-theme="dark"] .tag-cloud-item {
+.dark-mode .tag-cloud-item {
     background: var(--box-background-dark);
     border-color: var(--surface-tag-bg-dark);
 }
 
-[data-theme="dark"] .tag-name {
+.dark-mode .tag-name {
     color: var(--text-color-dark);
 }
 
-[data-theme="dark"] .tag-badge {
+.dark-mode .tag-badge {
     background: var(--surface-tag-bg-dark);
     color: var(--primary-accent);
 }
 
-[data-theme="dark"] .tag-badge:hover {
+.dark-mode .tag-badge:hover {
     background: var(--surface-hover-dark);
 }

--- a/assets/css/colors.css
+++ b/assets/css/colors.css
@@ -54,6 +54,12 @@
     --footer-text-dark: var(--primary-azure);
 
     /* ========================================
+       Heading Colors
+       ======================================== */
+    --heading-color-light: var(--text-color-light);
+    --heading-color-dark: var(--text-color-dark);
+
+    /* ========================================
        Elevation / Shadows
        ======================================== */
     --shadow-xs: 0 2px 4px rgba(0, 0, 0, 0.08);

--- a/assets/css/styles-dark.css
+++ b/assets/css/styles-dark.css
@@ -189,6 +189,12 @@ a:hover {
     box-shadow: var(--box-shadow-dark);
 }
 
+/* Cases dark mode */
+.case {
+    background-color: var(--box-background-dark);
+    color: var(--text-color-dark);
+}
+
 .value-card:hover {
     box-shadow: var(--box-shadow-hover-dark);
 }


### PR DESCRIPTION
### Changes

Three dark mode fixes:

- **colors.css**: Add missing `--heading-color-light`/`--heading-color-dark` variables — referenced by `card.css` but never defined
- **styles-dark.css**: Add `.case` dark mode overrides for `cases.css` component
- **article.css**: Fix `[data-theme="dark"]` → `.dark-mode` selector mismatch for tag elements — the JS toggle uses class-based dark mode, not data attribute

### Verification
- [x] All changes are CSS-only (no functional changes)
- [x] Variables defined before use
- [x] Selectors match JS toggle mechanism