### PR TITLE
docs(backlog): mark N2 and N3 as Done

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -30,8 +30,8 @@ Completed items belong in `CHANGELOG.md` only.
 | N7 | Påvirkning: layout wiring + content refinement (method-benefit integration) + 4 spot illustrations (makt, nettverk, interesser, lederverdi) | Planned | — |
 | N1 | Triader article (order: 2nd) | Done | — |
 | A1 | Architecture cleanup: CSS reorganization, topic consolidation, hero/card unification | Done | — |
-| N2 | Makt article (order: 1st) | Planned | — |
-| N3 | Perspektiv article (order: 3rd) | Planned | N1, N2 |
+| N2 | Makt article (order: 1st) | Done | — |
+| N3 | Perspektiv article (order: 3rd) | Done | N1, N2 |
 | P5 | Migrate `_pages/ledelse_*.md` to layout system | Planned | A1 |
 | X2 | Dark mode consistency pass | Planned | — |
 | F5 | Image generation for N1-N3 | Blocked | N1, N2, N3 |


### PR DESCRIPTION
- N2 (Makt): _pages/ledelse_makt.md exists with full content (156 lines)
- N3 (Perspektiv): _pages/ledelse_perspektiv.md exists with full content (261 lines)


o inline styles remain across _pages/
- A1.7: Shrink styles-dark.css 267→38 lines; distribute 229 lines of component dark mode overrides to respective files
- A1.8: Verify CSS brace matching, hardcoded color absence, styles.html load order
- Backlog: Remove B0-B4 (already done), add N1 as Done, mark A1 as Done

Refs: A1


d JSON-LD citation arrays.


ded modal)
- .specs/benefit-article-illustrations/: R4 spec (4 spot illustrations)
- .specs/values-illustrations/: R15 spec (3 value card illustrations)


odified:   CHANGELOG.md
#
# Untracked files:
#	.specs/inbound-sales/
#