### PR TITLE
refactor(p5): migrate article pages to layout system classes

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -32,7 +32,7 @@ Completed items belong in `CHANGELOG.md` only.
 | A1 | Architecture cleanup: CSS reorganization, topic consolidation, hero/card unification | Done | — |
 | N2 | Makt article (order: 1st) | Done | — |
 | N3 | Perspektiv article (order: 3rd) | Done | N1, N2 |
-| P5 | Migrate `_pages/ledelse_*.md` to layout system | Planned | A1 |
+| P5 | Migrate `_pages/ledelse_*.md` to layout system | Done | A1 |
 | X2 | Dark mode consistency pass | Planned | — |
 | F5 | Image generation for N1-N3 | Blocked | N1, N2, N3 |
 | C1 | Customer case planning & discovery | Blocked | Brainstorming session |

--- a/_pages/ledelse_forankring.md
+++ b/_pages/ledelse_forankring.md
@@ -52,7 +52,7 @@ json_ld:
 
 {% include hero.html %}
 
-<section class="frame-section animate-on-scroll fade-in-up">
+<section class="section container--wide animate-on-scroll fade-in-up">
     <h2>Hvorfor ledere ofte tar dårlige beslutninger</h2>
     <p>Jeffrey Pfeffer har brukt karrieren sin på å dokumentere gapet mellom hvordan organisasjoner hevder beslutninger tas, og hvordan de faktisk tas. I «Power: Why Some People Have It — and Others Don't» viser han at makt og politikk spiller en langt større rolle enn de fleste er villige til å innrømme.[^pfeffer2010]</p>
     <p>God styring handler om å vite hvem som faktisk har makt til å beslutte — ikke hvem som formelt sitter i lederrollen. I norske organisasjoner er avstanden mellom formell og reell beslutningsmakt ofte undervurdert. Ansvar uten autoritet er en teoretisk øvelse.</p>
@@ -61,17 +61,17 @@ json_ld:
     <p>Daniel Kahneman og Amos Tversky dokumenterte hvordan menneskelig tenkning systematisk avviker fra rasjonalitet — ikke fordi folk er dumme, men fordi hjernen bruker heuristikker som ofte feiler.[^kahneman2011]</p>
 </section>
 
-<section class="frame-section animate-on-scroll fade-in-up">
+<section class="section container--wide animate-on-scroll fade-in-up">
     <h2>De fire dimensjonene av beslutningstaking</h2>
     
-    <div class="frame-element animate-on-scroll fade-in-up">
+    <div class="info-box animate-on-scroll fade-in-up">
         <h3>1. Formell vs. reell beslutningsmakt</h3>
         <p>I de fleste organisasjoner er det stor forskjell på hvem som formelt har autoritet til å beslutte, og hvem som faktisk har innflytelse. Pfeffer viser at «the most powerful people in organizations are often not those with the formal authority.»[^pfeffer2010] Et initiativ uten tydelig eierskap er ikke forankret — det er bare kommunisert. Når roller er uklare, oppstår ansvarsskyvning, og forankringen blir illusorisk.</p>
         <p><strong>Tegn på klar maktbalanse:</strong> Beslutninger tas av dem med relevant ekspertise. Uenighet løses gjennom dialog, ikke posisjon. Autoritet følger ansvar.</p>
         <p><strong>Tegn på skjev makt:</strong> De med formell autoritet dominerer. Ekspertise ignoreres når den kommer fra feil person. Beslutninger tas bak lukkede dører.</p>
     </div>
 
-    <div class="frame-element animate-on-scroll fade-in-up">
+    <div class="info-box animate-on-scroll fade-in-up">
         <h3>2. Interesser som forankringens byggesteiner</h3>
         <p>Hver leder og hver avdeling har sine interesser. Ikke nødvendigvis egoistiske — de kan være faglige, strategiske eller personlige. Forankring handler først og fremst om å forstå disse interessene og hvordan de samhandler.</p>
         <p>En initiativtaker som kartlegger interesser før hun presenterer løsningen, har langt større gjennomføringskraft enn den som antar at alle ser saken fra samme ståsted.</p>
@@ -79,21 +79,21 @@ json_ld:
         <p><strong>Tegn på manglende interessekartlegging:</strong> Initiativer presenteres som «åpenbart riktige» — og møtes med taus motstand.</p>
     </div>
 
-    <div class="frame-element animate-on-scroll fade-in-up">
+    <div class="info-box animate-on-scroll fade-in-up">
         <h3>3. Kognitiv bias som påvirker valg</h3>
         <p>Kahneman identifiserte to systemer for tenkning: System 1 (rask, intuitiv, emosjonell) og System 2 (langsom, analytisk, rasjonell).[^kahneman2011] De fleste viktige beslutninger tas med System 1, selv om vi tror vi bruker System 2.</p>
         <p><strong>Tegn på bias-bevissthet:</strong> Viktige beslutninger diskuteres med folk som tenker annerledes. Beslutninger revideres når ny informasjon kommer til. «Hva kan jeg ha oversett?» er et vanlig spørsmål.</p>
         <p><strong>Tegn på bias-blindhet:</strong> Beslutninger tas av enkeltpersoner. Ingen utfordrer premissene. Suksess tillegges egen dyktighet, feil tillegges eksterne forhold.</p>
     </div>
 
-    <div class="frame-element animate-on-scroll fade-in-up">
+    <div class="info-box animate-on-scroll fade-in-up">
         <h3>4. Konflikt og forhandling</h3>
         <p>De fleste viktige beslutninger innebærer interessekonflikter. Å ignorere dette er å overse virkeligheten. Effektive ledere forstår hvordan å forhandle og bygge konsensus.[^fisher1991]</p>
         <p><strong>Tegn på konstruktiv konflikt:</strong> Uenighet diskuteres åpent. Beslutninger tas etter at ulike perspektiver er vurdert. Kompromisser eies av alle parter.</p>
         <p><strong>Tegn på dysfunksjonell konflikt:</strong> Konflikter begraves til de eskalerer. Beslutninger omgjøres etter møter. «Enighet» maskerer undertrykt uenighet.</p>
     </div>
 
-    <div class="frame-element animate-on-scroll fade-in-up">
+    <div class="info-box animate-on-scroll fade-in-up">
         <h3>5. Beslutningskultur</h3>
         <p>Irving Janis dokumenterte fenomenet «groupthink» — når jakten på enighet overrides behovet for kritisk vurdering.[^janis1982] Dette er spesielt farlig i organisasjoner med sterke kulturer eller karismatiske ledere.</p>
         <p><strong>Tegn på sunn beslutningskultur:</strong> Kritikk er forventet og verdsatt. Beslutninger kan omgjøres hvis premisser endres. Læring fra feil er systematisk.</p>
@@ -101,32 +101,32 @@ json_ld:
     </div>
 </section>
 
-<section class="frame-section animate-on-scroll fade-in-up">
+<section class="section container--wide animate-on-scroll fade-in-up">
     <h2>Vanlige beslutningsfallgruber</h2>
     
-    <div class="frame-challenges stagger-parent">
-        <div class="frame-challenge animate-on-scroll fade-in-up stagger">
+    <div class="grid grid--2 challenges-grid stagger-parent">
+        <div class="challenge-card animate-on-scroll fade-in-up stagger">
             <h4>Bekreftelsesbias</h4>
             <p>Vi søker informasjon som støtter det vi allerede tror, og ignorerer det som utfordrer det. Beslutninger tas basert på ønsketenkning.</p>
         </div>
-        <div class="frame-challenge animate-on-scroll fade-in-up stagger">
+        <div class="challenge-card animate-on-scroll fade-in-up stagger">
             <h4>Ankerfeste</h4>
             <p>Det første tallet eller forslaget som presenteres får uforholdsmessig stor innflytelse. «Vi har alltid gjort det sånn» blir argumentet.</p>
         </div>
-        <div class="frame-challenge animate-on-scroll fade-in-up stagger">
+        <div class="challenge-card animate-on-scroll fade-in-up stagger">
             <h4>Sunk cost-fallacy</h4>
             <p>Vi fortsetter med feil investeringer fordi vi allerede har brukt så mye. Å kutte tap oppfattes som å innrømme feil.</p>
         </div>
-        <div class="frame-challenge animate-on-scroll fade-in-up stagger">
+        <div class="challenge-card animate-on-scroll fade-in-up stagger">
             <h4>Overdreven selvtillit</h4>
             <p>Vi tror vi forstår mer enn vi faktisk gjør. «This time is different» blir gjentatt til tross for klare bevis på motsatt.</p>
         </div>
     </div>
 </section>
 
-<section class="frame-section animate-on-scroll fade-in-up">
+<section class="section container--wide animate-on-scroll fade-in-up">
     <h2>Spørsmål for å forbedre beslutningstaking</h2>
-    <ul class="frame-questions stagger-parent" style="--stagger-delay: 80ms;">
+    <ul class="question-list stagger-parent" style="--stagger-delay: 80ms;">
         <li class="animate-on-scroll slide-in-left stagger">Hvem hadde reell innflytelse på de siste tre viktige beslutningene — og var det de som burde hatt det?</li>
         <li class="animate-on-scroll slide-in-left stagger">Når ble en beslutning tatt mot bedre vitende — og hvorfor?</li>
         <li class="animate-on-scroll slide-in-left stagger">Hvordan håndterer vi uenighet når den oppstår?</li>
@@ -135,10 +135,10 @@ json_ld:
     </ul>
 </section>
 
-<section class="frame-cta animate-on-scroll fade-in-up">
+<section class="section section--spacious container--narrow cta-section animate-on-scroll fade-in-up">
     <h2>Få kartlagt ledergruppens beslutningsprosesser</h2>
     <p>Ledelse 60:2 inneholder spørsmål som kartlegger hvordan makt, interesser og kognitiv bias påvirker beslutninger i ledergruppen. Bestill en uforpliktende samtale.</p>
-    <div class="frame-cta-buttons">
+    <div class="cta-buttons">
         <a href="https://outlook.office.com/book/ledelse@noexcuse.no/?ismsaljsauthenabled" class="product-cta">Bestill uforpliktende samtale</a>
         <a href="{{ '/' | relative_url }}" class="product-cta product-cta--secondary">Les mer om Ledelse 60:2 →</a>
     </div>

--- a/_pages/ledelse_generativ-ki.md
+++ b/_pages/ledelse_generativ-ki.md
@@ -34,62 +34,62 @@ json_ld:
 
 {% include hero.html %}
 
-<section class="frame-section animate-on-scroll fade-in-up">
+<section class="section container--wide animate-on-scroll fade-in-up">
     <h2>Lederbristen i KI-æraen</h2>
     <p>KI-adopsjonen går raskere enn KI-ledelseskompetansen. Overalt hører vi om nye verktøy — ChatGPT, Midjourney, Claude — men nesten ingen snakker om hvordan lede menneskene som bruker dem. Spørsmålet er ikke lenger «skal vi bruke KI?» — det er «hvordan leder vi folk som styrer KI-modeller?»</p>
     <p>Den som kan formulere gode spørsmål, vurdere svar kritisk, og integrere KI i menneskelige arbeidsprosesser, vil erstatte den som ikke kan. Ferdigheten er ikke prompting — det er dømmekraft.</p>
 </section>
 
-<section class="frame-section animate-on-scroll fade-in-up">
+<section class="section container--wide animate-on-scroll fade-in-up">
     <h2>Hva KI-ledelse faktisk betyr</h2>
     <p>Å lede noen som bruker KI handler ikke om teknisk kompetanse. Det handler om å sikre at mennesket forblir i kontroll når modellen produserer.</p>
     
-    <div class="frame-element animate-on-scroll fade-in-up">
+    <div class="info-box animate-on-scroll fade-in-up">
         <h3>1. Formulere gode spørsmål</h3>
         <p>Vage spørsmål gir vage svar. En leder som mestrer KI, lærer seg å presisere intensjon — ikke bare skrive «skriv en e-post». Den som kan definere hva som faktisk trengs, får resultater den andre ikke engang ser.</p>
     </div>
     
-    <div class="frame-element animate-on-scroll fade-in-up">
+    <div class="info-box animate-on-scroll fade-in-up">
         <h3>2. Vurdere utdata kritisk</h3>
         <p>KI hallusinerer, kopierer bias, og opererer uten kontekst. En god KI-leder antar aldri at svaret er riktig — den tester det mot virkeligheten. Kalibrering er kontinuerlig: stemmer modellens selvtillit med faktisk kvalitet?</p>
     </div>
     
-    <div class="frame-element animate-on-scroll fade-in-up">
+    <div class="info-box animate-on-scroll fade-in-up">
         <h3>3. Integrere KI i menneskelige prosesser</h3>
         <p>KI produserer innhold; mennesker produserer verdi. Gapet mellom dem må lukkes med menneskelig dømmekraft. Ledere må bygge arbeidsflyter der KI-assistert arbeid alltid passerer gjennom menneskelig evaluering før det når kunden.</p>
     </div>
     
-    <div class="frame-element animate-on-scroll fade-in-up">
+    <div class="info-box animate-on-scroll fade-in-up">
         <h3>4. Opprettholde ansvarlighet</h3>
         <p>Når KI er involvert i en beslutning, blir ansvarlighet uklar. God KI-ledelse betyr at det alltid er et menneske som signerer under — ikke en modell. «KI sa det» er aldri en gyldig begrunnelse.</p>
     </div>
 </section>
 
-<section class="frame-section animate-on-scroll fade-in-up">
+<section class="section container--wide animate-on-scroll fade-in-up">
     <h2>Tenkeevner som skiller effektive KI-brukere fra passive</h2>
     
-    <div class="frame-element animate-on-scroll fade-in-up">
+    <div class="info-box animate-on-scroll fade-in-up">
         <h3>Epistemisk ydmykhet</h3>
         <p>Vite hva du ikke vet. KI kan få deg til å føle deg smartere enn du er. Den som tror modellen vet mer enn den faktisk gjør, tar dårlige beslutninger.</p>
     </div>
     
-    <div class="frame-element animate-on-scroll fade-in-up">
+    <div class="info-box animate-on-scroll fade-in-up">
         <h3>Presisjon av intensjon</h3>
         <p>Vage spørsmål gir vage svar. KI-ledere må lære seg å presisere hva de faktisk trenger, ikke bare beskrive det de tror de vil ha.</p>
     </div>
     
-    <div class="frame-element animate-on-scroll fade-in-up">
+    <div class="info-box animate-on-scroll fade-in-up">
         <h3>Iterativ forbedring</h3>
         <p>KI-interaksjon er dialog, ikke én-klikk. De beste resultatene kommer fra å stille oppfølgingsspørsmål, utfordre premisser, og gradvis presisere fram mot det som faktisk trengs.</p>
     </div>
     
-    <div class="frame-element animate-on-scroll fade-in-up">
+    <div class="info-box animate-on-scroll fade-in-up">
         <h3>Kalibrering</h3>
         <p>Konstant teste om modellens selvtillit stemmer med virkeligheten. Når KI er sikker — er den faktisk riktig? Når den er usikker — er den faktisk feil?</p>
     </div>
 </section>
 
-<section class="frame-section animate-on-scroll fade-in-up">
+<section class="section container--wide animate-on-scroll fade-in-up">
     <h2>OKR og KPI for KI-assistert arbeid</h2>
     <p>KI produserer innhold; mennesker produserer verdi. Gapet mellom dem må måles. Douglas Hubbard skriver i «How to Measure Anything» at det meste faktisk kan måles — bare vi er villige til å definere hva vi egentlig trenger å vite.[^hubbard2014] Hubbard viser at all måling reduserer usikkerhet — den eliminerer den ikke. Formålet med å måle KI-output er ikke perfeksjon, men å vite om man beveger seg i riktig retning.</p>
     
@@ -104,7 +104,7 @@ json_ld:
     <p>Målstyring holder mennesker ansvarlige for KI-output — ikke KI-input. Det handler ikke om å evaluere modellen, men om å sikre at mennesket som bruker den, leverer verdi.</p>
 </section>
 
-<section class="frame-section animate-on-scroll fade-in-up">
+<section class="section container--wide animate-on-scroll fade-in-up">
     <h2>Organisasjonens rolle</h2>
     <p>Å trene ansatte i prompting er ikke nok — man må utvikle dømmekraft. Ledelsens oppgave er å skape forutsetninger for effektiv KI-bruk, ikke å bestemme hvilke verktøy som skal brukes.</p>
     <p>Risikoen er at KI blir en unnskyldning for å fjerne menneskelig dømmekraft fra beslutninger. Når «effektivitet» overstyres av «automasjon», taper organisasjonen på kvalitet.</p>
@@ -118,32 +118,32 @@ json_ld:
     <p>Den som kontrollerer KI, former retningen. Det er et spørsmål om makt, ikke bare om teknologi.</p>
 </section>
 
-<section class="frame-section animate-on-scroll fade-in-up">
+<section class="section container--wide animate-on-scroll fade-in-up">
     <h2>Røde flagg</h2>
     
-    <div class="frame-challenges stagger-parent">
-        <div class="frame-challenge animate-on-scroll fade-in-up stagger">
+    <div class="grid grid--2 challenges-grid stagger-parent">
+        <div class="challenge-card animate-on-scroll fade-in-up stagger">
             <h4>KI-implementert uten menneskelig review</h4>
             <p>Output fra modellen går direkte til kunde eller beslutning uten at et menneske har sett på det.</p>
         </div>
-        <div class="frame-challenge animate-on-scroll fade-in-up stagger">
+        <div class="challenge-card animate-on-scroll fade-in-up stagger">
             <h4>«KI sa det»</h4>
             <p>Brukt som begrunnelse for beslutninger. Modellen blir autoritet, ikke verktøy.</p>
         </div>
-        <div class="frame-challenge animate-on-scroll fade-in-up stagger">
+        <div class="challenge-card animate-on-scroll fade-in-up stagger">
             <h4>Kvantitet over kvalitet</h4>
             <p>Organisasjonen måler hvor mye KI som brukes, ikke om det faktisk fungerer. Høyere volum maskerer lavere verdi.</p>
         </div>
-        <div class="frame-challenge animate-on-scroll fade-in-up stagger">
+        <div class="challenge-card animate-on-scroll fade-in-up stagger">
             <h4>Raskere, men mindre nøyaktig</h4>
             <p>Team produserer mer output med KI, men feilraten øker. Ingen har lagt merke til det fordi ingen måler det.</p>
         </div>
     </div>
 </section>
 
-<section class="frame-section animate-on-scroll fade-in-up">
+<section class="section container--wide animate-on-scroll fade-in-up">
     <h2>Spørsmål for å evaluere KI-ledelsen</h2>
-    <ul class="frame-questions stagger-parent" style="--stagger-delay: 80ms;">
+    <ul class="question-list stagger-parent" style="--stagger-delay: 80ms;">
         <li class="animate-on-scroll slide-in-left stagger">Hvem i organisasjonen har ansvaret for kvaliteten på KI-output — og vet de det?</li>
         <li class="animate-on-scroll slide-in-left stagger">Hvordan vet du at KI-svar faktisk er riktige, ikke bare overbevisende?</li>
         <li class="animate-on-scroll slide-in-left stagger">Finnes det beslutninger som nå tas av KI uten at et menneske ser på dem?</li>
@@ -152,10 +152,10 @@ json_ld:
     </ul>
 </section>
 
-<section class="frame-cta animate-on-scroll fade-in-up">
+<section class="section section--spacious container--narrow cta-section animate-on-scroll fade-in-up">
     <h2>Få kartlagt ledergruppens KI-modenhet</h2>
     <p>Ledelse 60:2 inneholder spørsmål som kartlegger hvordan ledergruppen forholder seg til teknologi, endring og menneskelig dømmekraft. Bestill en uforpliktende samtale for å lære mer.</p>
-    <div class="frame-cta-buttons">
+    <div class="cta-buttons">
         <a href="https://outlook.office.com/book/ledelse@noexcuse.no/?ismsaljsauthenabled" class="product-cta">Bestill uforpliktende samtale</a>
         <a href="{{ '/' | relative_url }}" class="product-cta product-cta--secondary">Les mer om Ledelse 60:2 →</a>
     </div>

--- a/_pages/ledelse_makt.md
+++ b/_pages/ledelse_makt.md
@@ -54,14 +54,14 @@ json_ld:
 
 {% include hero.html %}
 
-<section class="frame-section animate-on-scroll fade-in-up">
+<section class="section container--wide animate-on-scroll fade-in-up">
     <p>To sitater, to verdenssyn. Jeffrey Pfeffer, en av forskningen mest siterte stemmer på maktdynamikk, slår fast: «Power is the ability to get things done.» Uten makt — ingenting skjer. På den andre siden står Ken Blanchard og Colleen Barrett: «Leadership is not about you; it's about the people you serve.» Ledelse som tjeneste.</p>
     <p>Begge har rett. Og begge tar feil — hvis de står alene.</p>
     <p>Makt uten tjeneste blir utvinning. Tjeneste uten makt blir martyrdom. Effektive ledelseskulturer vet hvor de sitter på dette spekteret — og hvorfor.</p>
     <p>Denne artikkelen kartlegger spenningen mellom makt og tjeneste i ledergrupper, med utgangspunkt i Pfeffers forskning på maktens dynamikk og Blanchard & Barretts arbeid med servant leadership. Målet er ikke å kåre en vinner, men å gi deg et verktøy for å diagnostisere din egen ledelseskultur.</p>
 </section>
 
-<section class="frame-section animate-on-scroll fade-in-up">
+<section class="section container--wide animate-on-scroll fade-in-up">
     <h2>Den diagnostiske spenningen</h2>
     <p>Pfeffer og Blanchard representerer ikke personlighetstyper eller ledelsesfilosofier du velger mellom som et par sko. De representerer en strukturell spenning som lever i enhver organisasjon — enten du anerkjenner den eller ikke.</p>
     <p>På den ene siden: Makt som kapasitet. Evnen til å mobilisere ressurser, ta beslutninger og få ting gjort. Uten denne kapasiteten forblir visjoner drømmer, og organisasjoner mister retning. Pfeffer dokumenterer at makt korrelerer med karrierefremgang, beskyttelse mot organisatorisk kaos, og evnen til å gjennomføre endring.[^pfeffer2010]</p>
@@ -69,7 +69,7 @@ json_ld:
     <p>Problemet oppstår når organisasjoner uten bevissthet driver mot den ene polen. Ledergrupper som ikke aktivt reflekterer over denne spenningen, ender ofte opp med en ubalanse som koster mer enn de sparer.</p>
 </section>
 
-<section class="frame-section animate-on-scroll fade-in-up">
+<section class="section container--wide animate-on-scroll fade-in-up">
     <h2>Maktsiden — når det å få ting gjort blir alt</h2>
     <p>La oss starte med makt — ikke fordi den er viktigst, men fordi den ofte er mest usynlig. Makt er infrastrukturen i organisasjonslivet. Den finnes i stillingsbeskrivelser, budsjetter, beslutningsmyndighet og tilgang til informasjon.</p>
     <p>Pfeffers forskning viser at makt er en forutsetning for organisatorisk effektivitet på flere måter:</p>
@@ -83,7 +83,7 @@ json_ld:
     <p>Risikoen er tydelig: En ledergruppe som optimerer for makt, uten korrigerende mekanismer, utvikler seg mot transaksjonelle relasjoner, høy turnover og en kultur der kortsiktige gevinster trumfer langsiktig verdiskaping.</p>
 </section>
 
-<section class="frame-section animate-on-scroll fade-in-up">
+<section class="section container--wide animate-on-scroll fade-in-up">
     <h2>Tjenestesiden — når det å tjene andre blir alt</h2>
     <p>Servant leadership er ikke det samme som å være snill. Blanchard og Barrett er tydelige på at tjenende ledelse er en strategisk posisjonering, ikke en personlighetstype.</p>
     <p>Servant leadership handler om å bygge organisatorisk kapasitet gjennom å sette medarbeiderne først. Forskningen viser flere konkrete effekter:</p>
@@ -96,7 +96,7 @@ json_ld:
     <p>Risikoen er speilbildet av maktsiden: En ledergruppe som optimerer for tjeneste, uten makt til å gjennomføre, utvikler seg mot en kultur der beslutningsvegring er normen, de flinkeste brenner seg ut på å kompensere for de svakeste, og organisasjonen mister retning og tempo.</p>
 </section>
 
-<section class="frame-section animate-on-scroll fade-in-up">
+<section class="section container--wide animate-on-scroll fade-in-up">
     <h2>Prisen du betaler for makt</h2>
     <p>Det er fristende å konkludere med at svaret er «litt av begge deler». Men det er for enkelt. For å forstå hva en balansert ledelseskultur krever, må vi først se prisene — for begge ytterpunkter.</p>
     <p>La oss starte med prisen for makt, fordi den oftest er usynlig for dem som sitter i den:</p>
@@ -114,7 +114,7 @@ json_ld:
     </ul>
 </section>
 
-<section class="frame-section animate-on-scroll fade-in-up">
+<section class="section container--wide animate-on-scroll fade-in-up">
     <h2>Spekteret — fra utvinning til balanse</h2>
     <p>Hvis både ren makt og ren tjeneste har kostbare bivirkninger, hva er løsningen? Svaret ligger ikke i et kompromiss på midten, men i å forstå hvor din organisasjon befinner seg på spekteret — og hvorfor.</p>
     <p>Vi kan grovt sett plassere ledelseskulturer langs et spekter:</p>
@@ -129,7 +129,7 @@ json_ld:
     <p>Dette er ikke naiv optimisme. Det er en empirisk observasjon av hva som faktisk fungerer i organisasjoner som presterer over tid. Når makt distribueres og samtidig forankres i et felles oppdrag, reduseres både risikoen for maktmisbruk og risikoen for beslutningsvegring.</p>
 </section>
 
-<section class="frame-section animate-on-scroll fade-in-up">
+<section class="section container--wide animate-on-scroll fade-in-up">
     <h2>Spørsmål for selvdiagnose</h2>
     <p>Hvor sitter din ledergruppe på spekteret? Følgende spørsmål kan hjelpe dere å finne ut:</p>
     <ul>
@@ -141,10 +141,10 @@ json_ld:
     </ul>
 </section>
 
-<section class="frame-cta animate-on-scroll fade-in-up">
+<section class="section section--spacious container--narrow cta-section animate-on-scroll fade-in-up">
     <h2>Få kartlagt ledergruppens makt- og tjenestebalanse</h2>
     <p>Ledelse 60:2 inneholder spørsmål som kartlegger hvor ledergruppen din sitter på spekteret mellom makt og tjeneste, og gir dere et felles språk for å snakke om dynamikken. Bestill en uforpliktende samtale for å lære mer.</p>
-    <div class="frame-cta-buttons">
+    <div class="cta-buttons">
         <a href="https://outlook.office.com/book/ledelse@noexcuse.no/?ismsaljsauthenabled" class="product-cta">Bestill uforpliktende samtale</a>
         <a href="{{ '/' | relative_url }}" class="product-cta product-cta--secondary">Les mer om Ledelse 60:2 →</a>
     </div>

--- a/_pages/ledelse_perspektiv.md
+++ b/_pages/ledelse_perspektiv.md
@@ -46,44 +46,44 @@ json_ld:
       name: "Ledelsesdiagnostikk"
 ---
 
-<section class="frame-hero"{% if page.hero_effect %} data-hero-effect="{{ page.hero_effect }}"{% endif %}>
-    <div class="frame-hero-image hero-image">
+<section class="hero"{% if page.hero_effect %} data-hero-effect="{{ page.hero_effect }}"{% endif %}>
+    <div class="hero-image">
         <img src="{{ '/assets/images/banners/hero-perspektiv.webp' | relative_url }}" alt="Abstrakt illustrasjon av fire overlappende linser — et prisme som splitter lys">
     </div>
-    <div class="frame-hero-content">
-        <p class="frame-breadcrumb"><a href="{{ '/' | relative_url }}">← No Excuse AS</a></p>
+    <div class="hero-content">
+        <p class="hero-breadcrumb"><a href="{{ '/' | relative_url }}">← No Excuse AS</a></p>
         <h1 class="hero-title">Fire perspektiver — se mer enn du ser</h1>
-        <p class="frame-intro hero-intro">De fleste ledere ser verden gjennom ett filter. De beste ser gjennom fire — og vet hvilket som passer når. Multiframe thinking er ikke teori, det er en ferdighet.</p>
+        <p class="hero-intro">De fleste ledere ser verden gjennom ett filter. De beste ser gjennom fire — og vet hvilket som passer når. Multiframe thinking er ikke teori, det er en ferdighet.</p>
     </div>
 </section>
 
-<section class="frame-section animate-on-scroll fade-in-up">
+<section class="section container--wide animate-on-scroll fade-in-up">
     <p>En ingeniør som blir leder ser strukturelle problemer: uklare roller, manglende prosesser, feil rapporteringslinjer. En HR-sjef ser menneskelige problemer: motivasjon, trivsel, relasjoner. En politisk aktør ser maktdynamikk: allianser, agendaer, budsjettkamper. En markedsfører ser symboler: historier, identitet, mening.</p>
     <p>Alle har rett. Og alle tar feil — fordi de ser bare én side.</p>
     <p>Bolman og Deal (2017) kaller dette for enrammetenking — «the tendency to see only what our training and experience have taught us to see.»[^bolman2017] De fleste ledere har ett dominerende perspektiv, ett filter de bruker på alle situasjoner. Problemet er at organisasjonslivet ikke er enkelt nok til å forstås gjennom ett filter.</p>
     <p>Denne artikkelen handler ikke om de fire rammeverkene — hvert av dem har sin egen artikkel (<a href="{{ '/struktur/' | relative_url }}">struktur</a>, <a href="{{ '/mennesker/' | relative_url }}">mennesker</a>, <a href="{{ '/påvirkning/' | relative_url }}">påvirkning</a>, <a href="{{ '/identitet/' | relative_url }}">identitet</a>). Den handler om ferdigheten å bevege seg mellom dem — multiframe thinking — og hvorfor dette er den faktiske kjernekompetansen i ledelse.</p>
 </section>
 
-<section class="frame-section animate-on-scroll fade-in-up">
+<section class="section container--wide animate-on-scroll fade-in-up">
     <h2>Enrammefellen — når ett filter blir hele bildet</h2>
     <p>Enrammefellen er ikke at du har et favorittperspektiv. Det har alle. Fellen er at du bruker det samme perspektivet på alle problemer, uavhengig av hva situasjonen krever.</p>
 
-    <div class="frame-element animate-on-scroll fade-in-up">
+    <div class="info-box animate-on-scroll fade-in-up">
         <h3>Når struktur blir tvangstrøye</h3>
         <p>En leder som alltid starter med omorganisering, nye prosesser og rapporteringslinjer, kan skape kaos i en organisasjon som egentlig trenger kulturell trygghet. Strukturelle løsninger på menneskelige problemer skaper mer byråkrati uten å løse grunnårsaken.</p>
     </div>
 
-    <div class="frame-element animate-on-scroll fade-in-up">
+    <div class="info-box animate-on-scroll fade-in-up">
         <h3>Når mennesker blir overfladisk</h3>
         <p>En leder som alltid spør «hvordan har du det?» og aldri tar upopulære beslutninger, kan skape en hyggelig kultur som ikke presterer. Menneskerettede løsninger på strukturelle problemer gir gode samtaler, men ingen endring.</p>
     </div>
 
-    <div class="frame-element animate-on-scroll fade-in-up">
+    <div class="info-box animate-on-scroll fade-in-up">
         <h3>Når politikk blir kynisme</h3>
         <p>En leder som alltid analyserer maktforhold og aldri handler, kan lamme organisasjonen. Politisk analyse uten strukturell gjennomføring blir spill og posisjonering — ikke ledelse.</p>
     </div>
 
-    <div class="frame-element animate-on-scroll fade-in-up">
+    <div class="info-box animate-on-scroll fade-in-up">
         <h3>Når symbolikk blir tom</h3>
         <p>En leder som alltid snakker om verdier og kultur og aldri tar strukturelle grep, mister troverdighet. Symbolsk ledelse uten innhold blir PR — ikke ledelse.</p>
     </div>
@@ -91,21 +91,21 @@ json_ld:
     <p>Konsekvensen er ikke bare at du tar feil avgjørelser. Konsekvensen er at du ikke ser at du ser for snevert. Du forklarer dårlige resultater med at verden er kaotisk, i stedet for å innse at verktøykassen din er for liten.</p>
 </section>
 
-<section class="frame-section animate-on-scroll fade-in-up">
+<section class="section container--wide animate-on-scroll fade-in-up">
     <h2>Hva multiframe thinking faktisk er</h2>
     <p>Multiframe thinking er ikke å kjenne til fire teorier. Det er å ha fire mentale linser du kan skifte mellom, ofte i løpet av minutter. Det er en ferdighet, ikke kunnskap.</p>
 
-    <div class="frame-element animate-on-scroll fade-in-up">
+    <div class="info-box animate-on-scroll fade-in-up">
         <h3>Samtidighet, ikke sekvens</h3>
         <p>Multiframe thinking handler ikke om å analysere ett perspektiv av gangen. Det handler om å holde alle fire i hodet samtidig og spørre: «Hvilket perspektiv forklarer mest av det jeg ser akkurat nå?» Bolman og Deal sammenligner det med en jazzmusiker som må holde melodi, harmoni, rytme og samspill i hodet samtidig — ikke sekvensielt.[^bolman2017]</p>
     </div>
 
-    <div class="frame-element animate-on-scroll fade-in-up">
+    <div class="info-box animate-on-scroll fade-in-up">
         <h3>Diagnostisk disiplin, ikke ideologi</h3>
         <p>Forskjellen mellom en ideologisk leder og en diagnostisk leder er enkel: Ideologen har én forklaring på alt. Diagnostikeren har fire og velger den som passer situasjonen. Den diagnostiske disiplinen er å spørre: «Hvilket rammeverk gir mest innsikt her — og hva ville de andre avslørt som jeg ikke ser?»</p>
     </div>
 
-    <div class="frame-element animate-on-scroll fade-in-up">
+    <div class="info-box animate-on-scroll fade-in-up">
         <h3>Praktisk, ikke akademisk</h3>
         <p>Å reframe en situasjon tar to minutter. Effekten kan vare i måneder. Når en leder i en vanskelig samtale stopper opp og sier: «La oss se på dette fra et annet perspektiv,» er det multiframe thinking i praksis. Når et team som sitter fast i en konflikt, blir enige om å analysere problemet gjennom en annen linse, er det multiframe thinking i praksis.</p>
     </div>
@@ -113,54 +113,54 @@ json_ld:
     <p>Ingeniøren som lærer å se maktspill. HR-sjefen som lærer å se strukturelle feil. Gründeren som lærer å se symbolske behov i organisasjonen. Det er dette som skiller gode ledere fra effektive ledere.</p>
 </section>
 
-<section class="frame-section animate-on-scroll fade-in-up">
+<section class="section container--wide animate-on-scroll fade-in-up">
     <h2>«No scoring» — det filosofiske argumentet</h2>
     <p>Hvorfor har Ledelse 60:2 ingen poengsum, ingen karakter, ingen rangering? Er ikke det mindre presist?</p>
     <p>Kort svar: Nei. Det er mer presist. Her er hvorfor.</p>
 
-    <div class="frame-element animate-on-scroll fade-in-up">
+    <div class="info-box animate-on-scroll fade-in-up">
         <h3>Hubbard: Det viktigste er å vite hva du ikke vet</h3>
         <p>Douglas Hubbard, forfatteren av <em>How to Measure Anything</em>, argumenterer for at den største feilen i måling er å tro at du måler presist når du ikke gjør det. «The most important measurement is knowing what you don't know — and quantifying that uncertainty.»[^hubbard2014]</p>
         <p>En poengsum på 67 av 100 på «tillit» er presis i tall, upresis i mening. Betyr det at 67% av ansatte stoler på lederen? At lederen skårer 67% av maksimal tillit? At organisasjonen er 67% av veien til en tillitskultur? Uten kontekst og uten å vite hva 67 faktisk innebærer, er talltrygghet en illusjon.</p>
     </div>
 
-    <div class="frame-element animate-on-scroll fade-in-up">
+    <div class="info-box animate-on-scroll fade-in-up">
         <h3>Logan: Beskrivende, ikke evaluerende</h3>
         <p>Logans kulturstadier i <em>Tribal Leadership</em> er et beskrivende rammeverk. «Kulturen din viser Stage 3-mønstre» er en observasjon, ikke en karakter. Poenget er ikke å fastslå at Stage 3 er dårlig — det er å gi ledergruppen et språk for å gjenkjenne hvor de er og hvor de kan gå.[^logan2011]</p>
         <p>Ledelse 60:2 følger samme logikk. Intervjuet avdekker mønstre i hvordan ledergruppen tenker om makt, struktur, mennesker og identitet. Det gir gjenkjennelse, ikke poeng. <a href="{{ '/triader/' | relative_url }}">Triader-artikkelen</a> viser for eksempel hvordan beskrivende analyse av relasjonsmønstre gir mer handlingsrom enn en poengsum på «teamsamhold.»</p>
     </div>
 
-    <div class="frame-element animate-on-scroll fade-in-up">
+    <div class="info-box animate-on-scroll fade-in-up">
         <h3>Pfeffer: Tall er politiske</h3>
         <p>Jeffrey Pfeffer, forskeren bak mye av forståelsen av <a href="{{ '/makt/' | relative_url }}">makt i organisasjoner</a>, advarer: «Numbers are political. They are used to persuade, to claim credit, and to deflect blame.»[^pfeffer2010]</p>
         <p>En poengsum på tillit blir umiddelbart et politisk verktøy. Lederen med lav skår må forsvare seg. Lederen med høy skår får makt. Samtalen handler ikke lenger om utvikling — den handler om posisjonering. Ved å ikke score, holder Ledelse 60:2 samtalen der den hører hjemme: i diagnostikk og utvikling.</p>
     </div>
 
-    <div class="frame-element animate-on-scroll fade-in-up">
+    <div class="info-box animate-on-scroll fade-in-up">
         <h3>Multi-dimensionalitet</h3>
         <p>Scoring forutsetter en enkelt dimensjon. Organisasjoner er flerdimensjonale. Tillit kan være høy i én relasjon og lav i en annen. Struktur kan fungere i én avdeling og ikke i neste. En poengsum fanger ikke dette — den reduserer kompleksitet til et tall som skjuler mer enn det avslører.</p>
         <p>Alternativet er mønstergjenkjenning: «Ledergruppen din viser sterke strukturelle reflekser, men svak politisk bevissthet. Her er hva det betyr for beslutningstakingen deres.» Det er mer presist, mer handlingsrettet, og mindre spillbart enn en poengsum.</p>
     </div>
 </section>
 
-<section class="frame-section animate-on-scroll fade-in-up">
+<section class="section container--wide animate-on-scroll fade-in-up">
     <h2>Integrering i praksis — tre caser</h2>
     <p>Teori er én ting. Slik ser multiframe thinking ut i virkelige situasjoner:</p>
 
-    <div class="frame-element animate-on-scroll fade-in-up">
+    <div class="info-box animate-on-scroll fade-in-up">
         <h3>Case 1: Omorganisering</h3>
         <p>En mellomstor teknologibedrift vokste fra 30 til 120 ansatte på to år. Strukturen som fungerte i oppstartsfasen, bremset nå beslutningstaking. En enrammet leder ville startet med ny organisasjonskart.</p>
         <p>Multiframe-tilnærmingen starter med fire spørsmål: Hvilken struktur tjener strategien (struktur)? Hvem har uformell makt som må hensyntas (politikk)? Hvordan oppleves endringen for de ansatte (mennesker)? Hvilken historie forteller vi om hvorfor vi endrer oss (symboler)?</p>
         <p>Rekkefølgen betyr noe: Struktur først, deretter politikk (hvem vinner/hvem taper), deretter mennesker (støtte og utvikling), til slutt symboler (mening og identitet).[^bolman2017]</p>
     </div>
 
-    <div class="frame-element animate-on-scroll fade-in-up">
+    <div class="info-box animate-on-scroll fade-in-up">
         <h3>Case 2: Fusjon</h3>
         <p>To like store selskaper slås sammen. En enrammet leder ville kjørt due diligence på tallene og deretter implementert ny struktur. Feilen: Ingen spurte om de ansatte i selskap A følte seg som tapere, om kulturene var kompatible, eller om maktdynamikken mellom de to ledergruppene ville blokkere samarbeid.</p>
         <p>Multiframe-tilnærmingen starter med symboler: Hvem er vi nå? Hvilken historie forteller vi om fusjonen? Deretter politikk: Hvem får hvilke posisjoner? Deretter struktur: Hvordan organiserer vi det nye selskapet? Til slutt mennesker: Hvordan sikrer vi at ansatte føler seg sett i prosessen?</p>
     </div>
 
-    <div class="frame-element animate-on-scroll fade-in-up">
+    <div class="info-box animate-on-scroll fade-in-up">
         <h3>Case 3: Krise</h3>
         <p>En leder våkner til en krise: en større kunde har trukket seg, en nøkkelperson har sagt opp, og styret krever svar innen 48 timer. I en krise har du ikke tid til sekvensiell analyse. Multiframe thinking betyr at du intuitivt vurderer alle fire dimensjoner samtidig.</p>
         <p>Struktur: Hvem må gjøre hva de neste 48 timene? Politikk: Hvem må informeres, og hvem kan bli en alliert? Mennesker: Hvem er mest påvirket og trenger støtte? Symboler: Hvilken historie forteller vi — både internt og eksternt?</p>
@@ -169,34 +169,34 @@ json_ld:
     <p>Felles for alle tre casene: Multiframe thinking gir ikke «det rette svaret.» Det gir bedre spørsmål. Og i en kompleks verden er bedre spørsmål ofte mer verdifullt enn raske svar.</p>
 </section>
 
-<section class="frame-section animate-on-scroll fade-in-up">
+<section class="section container--wide animate-on-scroll fade-in-up">
     <h2>Hvordan utvikle multiframe-kapabilitet</h2>
     <p>Multiframe thinking er en ferdighet som kan trenes. Her er fire konkrete praksiser:</p>
 
-    <div class="frame-element animate-on-scroll fade-in-up">
+    <div class="info-box animate-on-scroll fade-in-up">
         <h3>1. Eksplisitt reframing i møter</h3>
         <p>Gjør det til en vane å stoppe opp og si: «La oss se på dette fra et annet perspektiv.» Tving deg selv og teamet til å vurdere minst to rammeverk før dere konkluderer. Still spørsmålet: «Hva ville dette sett ut som gjennom linsen vi bruker minst?»</p>
     </div>
 
-    <div class="frame-element animate-on-scroll fade-in-up">
+    <div class="info-box animate-on-scroll fade-in-up">
         <h3>2. Rullerende perspektiver</h3>
         <p>I ledergruppen: tilordn hvert rammeverk til en person som har ansvar for å bringe det perspektivet inn i diskusjonen. Ruller slik at alle får trene på alle perspektiver. «Du har struktur denne uken — pass på at vi ikke glemmer å spørre hvordan ting henger sammen.»</p>
     </div>
 
-    <div class="frame-element animate-on-scroll fade-in-up">
+    <div class="info-box animate-on-scroll fade-in-up">
         <h3>3. Tverrfaglig lesing</h3>
         <p>Ledere som leser innenfor én disiplin utvikler enrammetenking. Utfordringen: En ingeniør bør lese om makt (Pfeffer). En HR-leder bør lese om struktur (Bolman & Deal, kapittel 3). En markedsfører bør lese om psykologisk trygghet (Edmondson). Multiframetenkning krever bredde.</p>
     </div>
 
-    <div class="frame-element animate-on-scroll fade-in-up">
+    <div class="info-box animate-on-scroll fade-in-up">
         <h3>4. Ledelse 60:2 som multiframe-praksis</h3>
         <p>60:2-intervjuet er i seg selv en multiframe-øvelse. Spørsmålene tvinger ledergruppen til å skifte perspektiv — fra struktur til mennesker, fra politikk til symboler — i løpet av en times samtale. Ikke fordi poenget er å bli flink til å bytte rammeverk, men fordi det enkelte spørsmålet gir mening bare innenfor ett rammeverk av gangen.</p>
     </div>
 </section>
 
-<section class="frame-section animate-on-scroll fade-in-up">
+<section class="section container--wide animate-on-scroll fade-in-up">
     <h2>Spørsmål for multiframe-diagnostikk</h2>
-    <ul class="frame-questions stagger-parent" style="--stagger-delay: 80ms;">
+    <ul class="question-list stagger-parent" style="--stagger-delay: 80ms;">
         <li class="animate-on-scroll slide-in-left stagger">Hvilket rammeverk strekker du deg først etter når noe går galt — struktur, mennesker, politikk eller symboler?</li>
         <li class="animate-on-scroll slide-in-left stagger">Når endret du sist mening fordi du så situasjonen fra et annet perspektiv?</li>
         <li class="animate-on-scroll slide-in-left stagger">Har teamet ditt en «utpekt skeptiker» for hvert rammeverk — noen som aktivt utfordrer det dominerende perspektivet?</li>
@@ -205,16 +205,16 @@ json_ld:
     </ul>
 </section>
 
-<section class="frame-cta animate-on-scroll fade-in-up">
+<section class="section section--spacious container--narrow cta-section animate-on-scroll fade-in-up">
     <h2>Få kartlagt ledergruppens perspektivbredde</h2>
     <p>Ledelse 60:2 kartlegger ikke bare hva ledergruppen din mener — den avdekker hvilke perspektiver som dominerer og hvilke som mangler. Bestill en uforpliktende samtale for å lære mer.</p>
-    <div class="frame-cta-buttons">
+    <div class="cta-buttons">
         <a href="https://outlook.office.com/book/ledelse@noexcuse.no/?ismsaljsauthenabled" class="product-cta">Bestill uforpliktende samtale</a>
         <a href="{{ '/' | relative_url }}" class="product-cta product-cta--secondary">Les mer om Ledelse 60:2 →</a>
     </div>
 </section>
 
-<section class="frame-section frame-about animate-on-scroll fade-in-up">
+<section class="section container--wide about-section animate-on-scroll fade-in-up">
     <h2>Referanser</h2>
     <p>Artikkelen bygger på Bolman & Deal (2017) sin forskning på rammeverk og organisasjonsanalyse, Douglas Hubbard (2014) sitt arbeid med måling av komplekse fenomener, Dave Logan (2011) om beskrivende kulturanalyse, og Jeffrey Pfeffer (2010) om makt og politikk i organisasjoner.</p>
 </section>

--- a/_pages/ledelse_tillit.md
+++ b/_pages/ledelse_tillit.md
@@ -72,37 +72,37 @@ json_ld:
 
 {% include hero.html %}
 
-<section class="frame-section animate-on-scroll fade-in-up">
+<section class="section container--wide animate-on-scroll fade-in-up">
     <h2>Hvorfor tillit er ledelsens valuta</h2>
     <p>Tenk på de beste teamene du har jobbet med. Hva var annerledes der? Sannsynligvis ikke at de hadde bedre verktøy eller flere møter. Det var sannsynligvis måten folk snakket til hverandre — ærlig, direkte, uten frykt for konsekvensene.</p>
     <p>Robert Greenleaf introduserte begrepet «servant leadership» i 1970.[^greenleaf1970] Han argumenterte for at ledere først og fremst bør tjene sine medarbeidere, ikke omvendt. Dette er ikke bare en idealistisk idé — forskning viser at det fungerer. En meta-analyse fra 2019 konkluderer med at servant leadership har «positive effects on employee outcomes including organizational commitment, job satisfaction, performance, and citizenship behavior.»[^eva2019]</p>
 </section>
 
-<section class="frame-section animate-on-scroll fade-in-up">
+<section class="section container--wide animate-on-scroll fade-in-up">
     <h2>De fire pilarene for tillitsbasert ledelse</h2>
     
-    <div class="frame-element animate-on-scroll fade-in-up">
+    <div class="info-box animate-on-scroll fade-in-up">
         <h3>1. Psykologisk trygghet</h3>
         <p>Amy Edmondson fra Harvard definerer psykologisk trygghet som «a shared belief held by members of a team that the team is safe for interpersonal risk taking.»[^edmondson2019] I praksis betyr det: folk tør si ifra når noe er galt, tør komme med nye ideer, tør innrømme feil.</p>
         <p><strong>Tegn på høy psykologisk trygghet:</strong> Feil diskuteres som læringsmuligheter. Uenighet er forventet og velkomment. Ledere spør «hvordan kan jeg hjelpe?» heller enn «hvem har skylden?»</p>
         <p><strong>Tegn på lav psykologisk trygghet:</strong> Informasjon holdes tilbake. Kritikk gis aldri direkte. Folk sier «det er bare å vente og se» heller enn å utfordre.</p>
     </div>
 
-    <div class="frame-element animate-on-scroll fade-in-up">
+    <div class="info-box animate-on-scroll fade-in-up">
         <h3>2. Tjenende lederskap</h3>
         <p>Greenleaf mente at en leder først og fremst bør spørre seg: «Hvordan kan jeg hjelpe andre til å vokse og yte sitt beste?» [^greenleaf1970] Dette krever en annen type ydmykhet enn tradisjonelt topplederideal.</p>
         <p><strong>Tegn på tjenende lederskap:</strong> Ledere lytter før de snakker. De anerkjenner andres bidrag. De setter teamets suksess over egen ære.</p>
         <p><strong>Tegn på selv-opptatt lederskap:</strong> Beslutninger tas for å styrke egen posisjon. Suksesser tillegges egen innsats. Feedback gis sjelden eller aldri.</p>
     </div>
 
-    <div class="frame-element animate-on-scroll fade-in-up">
+    <div class="info-box animate-on-scroll fade-in-up">
         <h3>3. Tillit som system</h3>
         <p>Tillit er ikke bare en følelse — det er et system av forventninger og atferd som enten forsterker eller underminerer samarbeid.[^dirks2009] God styring handler om å vite hvem som faktisk har makt til å beslutte — ikke hvem som formelt sitter i lederrollen. Autoritet uten ansvar er en risikofaktor. Compliance er ikke byråkrati — det er tydelighet. Når roller er definerte og ansvar er dokumentert, unngår man den typen uklarhet som fører til at oppgaver faller mellom stoler og tillit blir satt på prøve.</p>
         <p><strong>Tegn på tillit som system:</strong> Løfter holdes. Forventninger er tydelige. Folk tar ansvar for egne handlinger.</p>
         <p><strong>Tegn på tillitsbrist:</strong> Løfter brytes uten forklaring. Folk dekker seg bak prosedyrer. «Det var ikke min avdeling» blir unnskyldningen.</p>
     </div>
 
-    <div class="frame-element animate-on-scroll fade-in-up">
+    <div class="info-box animate-on-scroll fade-in-up">
         <h3>4. Autonomi som tillitsdriver</h3>
         <p>Mennesker er motiverte når de opplever mestring, tilhørighet og mening. Ytre motivatorer (bonus, straff) kan drive kortvarig atferd, men varig engasjement krever indre motivasjon: autonomi, mestring og tilhørighet. Når ledere stoler på at ansatte kan bruke sunn fornuft, blir kontroll unødvendig — og byråkratiet mister sin begrunnelse.</p>
         <p>Autonomi er ikke frihet fra struktur — det er frihet <em>innenfor</em> struktur. Tydelige roller og forventninger muliggjør tillit, de svekker den ikke.</p>
@@ -111,38 +111,38 @@ json_ld:
     </div>
 </section>
 
-<section class="frame-section animate-on-scroll fade-in-up">
+<section class="section container--wide animate-on-scroll fade-in-up">
     <h2>Hvorfor de fleste ledere feiler på tillit</h2>
     <p>De fleste ledere tror de er mer tilgjengelige enn de faktisk er. En undersøkelse viser at 94% av ledere mener de gir constructive feedback, men bare 65% av medarbeidere er enige.[^zenger2022] Denne gapen — mellom lederes intensjon og medarbeideres opplevelse — er tillitsproblemet.</p>
     <p>Tillit bygges ikke av gode intensjoner. Det bygges av konsekvent atferd over tid. En leder som en gang svikter, kan miste tillit som tar år å bygge opp igjen.</p>
 </section>
 
-<section class="frame-section animate-on-scroll fade-in-up">
+<section class="section container--wide animate-on-scroll fade-in-up">
     <h2>Vanlige tillitsutfordringer i norske organisasjoner</h2>
     
-    <div class="frame-challenges stagger-parent">
-        <div class="frame-challenge animate-on-scroll fade-in-up stagger">
+    <div class="grid grid--2 challenges-grid stagger-parent">
+        <div class="challenge-card animate-on-scroll fade-in-up stagger">
             <h4>Hierarkisk blindhet</h4>
             <p>Ledere som ikke ser at deres atferd oppfattes annerledes avhengig av posisjon. Det som føles som «direkte» oppfattes som «domsnutt» av underordnede.</p>
         </div>
-        <div class="frame-challenge animate-on-scroll fade-in-up stagger">
+        <div class="challenge-card animate-on-scroll fade-in-up stagger">
             <h4>Informerings asymmetri</h4>
             <p>Ledere vet mer enn de deler. Medarbeidere tolker dette som mistillit. Kommunikasjonen blir formell og overfladisk.</p>
         </div>
-        <div class="frame-challenge animate-on-scroll fade-in-up stagger">
+        <div class="challenge-card animate-on-scroll fade-in-up stagger">
             <h4>Historisk baggage</h4>
             <p>Tidligere svik sitter i kulturen. Nye ledere møtes med «vi har hørt dette før»-holdning. Initiativ blir møtt med skepsis.</p>
         </div>
-        <div class="frame-challenge animate-on-scroll fade-in-up stagger">
+        <div class="challenge-card animate-on-scroll fade-in-up stagger">
             <h4>Inkonsekvent oppfølging</h4>
             <p>Ledere som sier én ting og gjør noe annet. Beslutninger som omgjøres uten forklaring. Prioriteringer som stadig endres.</p>
         </div>
     </div>
 </section>
 
-<section class="frame-section animate-on-scroll fade-in-up">
+<section class="section container--wide animate-on-scroll fade-in-up">
     <h2>Spørsmål for å kartlegge tillitsnivået</h2>
-    <ul class="frame-questions stagger-parent" style="--stagger-delay: 80ms;">
+    <ul class="question-list stagger-parent" style="--stagger-delay: 80ms;">
         <li class="animate-on-scroll slide-in-left stagger">Hvor ofte gir du feedback som folk faktisk husker — og bruker?</li>
         <li class="animate-on-scroll slide-in-left stagger">Hva ville skjedd hvis en medarbeider kom til deg med en dårlig nyhet i dag?</li>
         <li class="animate-on-scroll slide-in-left stagger">Når ble siste gang du omgjorde en beslutning uten å forklare hvorfor?</li>
@@ -151,16 +151,16 @@ json_ld:
     </ul>
 </section>
 
-<section class="frame-cta animate-on-scroll fade-in-up">
+<section class="section section--spacious container--narrow cta-section animate-on-scroll fade-in-up">
     <h2>Få kartlagt ledergruppens tillitsnivå</h2>
     <p>Ledelse 60:2 inneholder spørsmål som kartlegger psykologisk trygghet, tillitsbasert kommunikasjon og hvordan ledere faktisk oppfattes. Bestill en uforpliktende samtale for å lære mer.</p>
-    <div class="frame-cta-buttons">
+    <div class="cta-buttons">
         <a href="https://outlook.office.com/book/ledelse@noexcuse.no/?ismsaljsauthenabled" class="product-cta">Bestill uforpliktende samtale</a>
         <a href="{{ '/' | relative_url }}" class="product-cta product-cta--secondary">Les mer om Ledelse 60:2 →</a>
     </div>
 </section>
 
-<section class="frame-section frame-about animate-on-scroll fade-in-up">
+<section class="section container--wide about-section animate-on-scroll fade-in-up">
     <h2>Referanser</h2>
     <p>Artikkelen bygger på forskning fra blant andre Robert Greenleaf (servant leadership), Amy Edmondson (psychological safety), og en omfattende metastudie av servant leadership-effekter fra 2019.[^greenleaf1970][^eva2019][^edmondson2019][^dirks2009][^zenger2022]</p>
 </section>

--- a/_pages/ledelse_triader.md
+++ b/_pages/ledelse_triader.md
@@ -36,45 +36,45 @@ json_ld:
       name: "Teamdynamikk"
 ---
 
-<section class="frame-hero"{% if page.hero_effect %} data-hero-effect="{{ page.hero_effect }}"{% endif %}>
-    <div class="frame-hero-image hero-image">
+<section class="hero"{% if page.hero_effect %} data-hero-effect="{{ page.hero_effect }}"{% endif %}>
+    <div class="hero-image">
         <img src="{{ '/assets/images/banners/hero-triade.webp' | relative_url }}" alt="Abstrakt geometrisk illustrasjon av tre sammenkoblede noder">
     </div>
-    <div class="frame-hero-content">
-        <p class="frame-breadcrumb"><a href="{{ '/' | relative_url }}">← No Excuse AS</a></p>
+    <div class="hero-content">
+        <p class="hero-breadcrumb"><a href="{{ '/' | relative_url }}">← No Excuse AS</a></p>
         <h1 class="hero-title">Triader — styrken i trekantrelasjoner</h1>
-        <p class="frame-intro hero-intro">To personer er en samtale. Tre personer er et system. Lær hvorfor triader er den mest undervurderte byggesteinen i velfungerende organisasjoner.</p>
+        <p class="hero-intro">To personer er en samtale. Tre personer er et system. Lær hvorfor triader er den mest undervurderte byggesteinen i velfungerende organisasjoner.</p>
     </div>
 </section>
 
-<section class="frame-section animate-on-scroll fade-in-up">
+<section class="section container--wide animate-on-scroll fade-in-up">
     <p>Tenk på teamet ditt. Hvem snakker med hvem? Hvilke relasjoner er avhengige av at én bestemt person er til stede? Hva skjer med informasjonsflyten når den personen er borte?</p>
     <p>De fleste ledergrupper er bygget på dyader — to-person-relasjoner. Sjefen og nestlederen. Prosjektlederen og kunden. Mentoren og mentee. Disse relasjonene føles effektive, men de har en strukturell svakhet: Når én person faller ut, brytes forbindelsen.</p>
     <p>Dave Logan, John King og Halee Fischer-Wright forsket i over et tiår på hva som kjennetegner høytytende organisasjonskulturer. Deres konklusjon, publisert i <em>Tribal Leadership</em> (2011), peker på triader — tre-person-relasjoner — som den kritiske byggesteinen i kulturer som presterer over tid.[^logan2011]</p>
     <p>Denne artikkelen forklarer hvorfor triader fungerer, hvordan de oppstår, og hva som ødelegger dem. Det er ikke et teambuildings-verktøy. Det er en strukturell innsikt om hvordan informasjon, tillit og makt faktisk beveger seg i organisasjoner.</p>
 </section>
 
-<section class="frame-section animate-on-scroll fade-in-up">
+<section class="section container--wide animate-on-scroll fade-in-up">
     <h2>Dyadeproblemet — hvorfor to er en sårbar relasjon</h2>
     <p>Dyader er den mest grunnleggende sosiale enheten. To mennesker som har en relasjon. Det høres enkelt ut, og det er nettopp problemet.</p>
     <p>Logan og kolleger identifiserer flere strukturelle svakheter ved dyader som gjør dem til en risikabel byggestein for organisasjonskultur:</p>
 
-    <div class="frame-element animate-on-scroll fade-in-up">
+    <div class="info-box animate-on-scroll fade-in-up">
         <h3>1. Konflikt blir personlig</h3>
         <p>I en dyad er det ingen tredjepart som kan nøytralisere spenning. Når uenighet oppstår, blir det fort et spørsmål om «du mot meg» i stedet for «oss mot problemet.» Uten en tredje person som kan balansere perspektivet, eskalerer små uenigheter til personlige konflikter.</p>
     </div>
 
-    <div class="frame-element animate-on-scroll fade-in-up">
+    <div class="info-box animate-on-scroll fade-in-up">
         <h3>2. Informasjon blir fanget</h3>
         <p>I en ren dyade har to personer informasjon som resten av teamet ikke har. Dette skaper asymmetri som svekker tilliten og gjør at beslutninger tas på ufullstendig grunnlag. «Visste du ikke det?» er symptom på et dyade-drevet informasjonssystem.</p>
     </div>
 
-    <div class="frame-element animate-on-scroll fade-in-up">
+    <div class="info-box animate-on-scroll fade-in-up">
         <h3>3. Når én slutter, forsvinner alt</h3>
         <p>Den mest åpenbare svakheten: Hvis én person i en dyade forsvinner (slutter, blir syk, omorganiseres), brytes relasjonen fullstendig. Kunnskap, relasjoner og beslutningskapasitet forsvinner med personen. Organisasjonen må starte på nytt.</p>
     </div>
 
-    <div class="frame-element animate-on-scroll fade-in-up">
+    <div class="info-box animate-on-scroll fade-in-up">
         <h3>4. Kulturell modenhet</h3>
         <p>I Logans stadiummodell er dyader kjennetegnende for Stage 2 («livet suger, min spesielt») og Stage 3 («jeg er best»). I Stage 2 er relasjonene preget av avmakt og isolasjon. I Stage 3 bygges relasjonene rundt individuelle prestasjoner — «jeg og min allierte» — ikke rundt felles mål.[^logan2011] Dette er ikke onde mennesker, det er folk som opererer i en kultur som belønner individet fremfor teamet.</p>
     </div>
@@ -82,48 +82,48 @@ json_ld:
     <p>Problemet er ikke at dyader er onde. Problemet er at de er utilstrekkelige som eneste byggestein. Ethvert team har dyader. Spørsmålet er om dere også har triader.</p>
 </section>
 
-<section class="frame-section animate-on-scroll fade-in-up">
+<section class="section container--wide animate-on-scroll fade-in-up">
     <h2>Hva triader er — og hvorfor de er stabile</h2>
     <p>En triade er tre personer med gjensidige, ikke-eksklusive relasjoner. Det høres enkelt ut, men forskjellen fra en dyade er strukturell, ikke kvantitativ.</p>
 
-    <div class="frame-element animate-on-scroll fade-in-up">
+    <div class="info-box animate-on-scroll fade-in-up">
         <h3>Ingen enkeltperson kontrollerer forbindelsen</h3>
         <p>I en dyade kan én person bryte relasjonen ved å trekke seg unna. I en triade holder de to gjenværende forbindelsen i live. Triaden kan repareres. Dyaden må gjenoppbygges fra bunnen av. Dette er ikke psykologi — det er matematikk. Tre forbindelser (A–B, B–C, A–C) gir redundans som to forbindelser (A–B) ikke har.</p>
     </div>
 
-    <div class="frame-element animate-on-scroll fade-in-up">
+    <div class="info-box animate-on-scroll fade-in-up">
         <h3>Informasjon flyter i flere baner</h3>
         <p>I en triade har informasjon tre veier å gå. Det betyr at kunnskap sjelden blir fanget i én relasjon. Hvis A forteller B noe, og B ikke videreformidler det til C, kan C fortsatt få informasjonen fra A direkte. Systemet selvkorrigerer.</p>
     </div>
 
-    <div class="frame-element animate-on-scroll fade-in-up">
+    <div class="info-box animate-on-scroll fade-in-up">
         <h3>Konflikt blir triangulert, ikke polarisert</h3>
         <p>Når uenighet oppstår i en triade, finnes det en tredjepart som kan bidra med perspektiv. Dette reduserer sannsynligheten for at konflikt blir personlig. C kan si: «Jeg ser at dere ser dette forskjellig — la oss finne ut hva vi er enige om.» En dyade har ingen slik mekanisme.</p>
     </div>
 
-    <div class="frame-element animate-on-scroll fade-in-up">
+    <div class="info-box animate-on-scroll fade-in-up">
         <h3>Resilient mot utskifting</h3>
         <p>Når én person i en triade forsvinner, gjenstår en dyade. Relasjonskapitalen er ikke tapt — den kan bygges ut til en ny triade. Overgangen er mykere, kunnskapen bevares hos den gjenværende dyaden, og organisasjonen mister mindre.</p>
     </div>
 </section>
 
-<section class="frame-section animate-on-scroll fade-in-up">
+<section class="section container--wide animate-on-scroll fade-in-up">
     <h2>Hvordan triader oppstår — tre betingelser</h2>
     <p>Triader oppstår ikke av seg selv. I organisasjoner som er dominert av Stage 3-kultur («jeg er best») aktivt motvirkes de, fordi kunnskapsdeling og relasjonsbygging på tvers oppleves som en trussel mot individuell posisjon.</p>
     <p>Logan identifiserer tre betingelser som må være til stede for at triader skal dannes:[^logan2011]</p>
 
-    <div class="frame-element animate-on-scroll fade-in-up">
+    <div class="info-box animate-on-scroll fade-in-up">
         <h3>1. Felles verdier eller formål</h3>
         <p>Triader trenger et tredje element som binder dem sammen utover personlig kjemi. Det kan være et felles prosjekt, en delt overbevisning om hvordan arbeid bør gjøres, eller en forpliktelse til en større sak. Uten dette blir triaden personavhengig og faller tilbake til dyade når relasjonen blir utfordret.</p>
         <p>Dette er hvorfor det <a href="{{ '/identitet/' | relative_url }}">symbolske perspektivet</a> er viktig: kultur, verdier og felles mening er limet som gjør triader holdbare. Bolman og Deal kaller dette det symbolske rammeverket — organisasjoner som kulturer båret av felles fortellinger og ritualer.[^bolman2017]</p>
     </div>
 
-    <div class="frame-element animate-on-scroll fade-in-up">
+    <div class="info-box animate-on-scroll fade-in-up">
         <h3>2. Komplementære evner</h3>
         <p>Triader fungerer best når de tre personene bidrar med noe forskjellig. Ikke fordi forskjellighet i seg selv er bra, men fordi komplementære evner skaper gjensidig avhengighet. A trenger B for noe B kan, B trenger C, og C trenger A. Strukturelt perspektiv (Bolman & Deal) handler om å designe roller som utfyller hverandre — triader er den mest effektive enheten for slik rolledesign.[^bolman2017]</p>
     </div>
 
-    <div class="frame-element animate-on-scroll fade-in-up">
+    <div class="info-box animate-on-scroll fade-in-up">
         <h3>3. Vilje til å dele nettverket</h3>
         <p>Dette er den vanskeligste betingelsen. Logan er tydelig: «Triads only form when people are willing to share their network.» I en organisasjon der relasjoner er makt, oppleves nettverksdeling som å gi fra seg posisjon. Å introdusere to personer for hverandre og trekke seg tilbake krever en trygghet som bare finnes i modne kulturer.</p>
     </div>
@@ -131,51 +131,51 @@ json_ld:
     <p>Det er verdt å merke seg at disse betingelsene speiler spenningen mellom <a href="{{ '/makt/' | relative_url }}">makt og tjeneste</a> som vi har skrevet om tidligere. Viljen til å dele nettverket forutsetter et tjenende perspektiv på ledelse — at din rolle er å bygge broer, ikke å kontrollere hvem som snakker med hvem.</p>
 </section>
 
-<section class="frame-section animate-on-scroll fade-in-up">
+<section class="section container--wide animate-on-scroll fade-in-up">
     <h2>Triader i praksis — fire arketyper</h2>
     <p>Triader er ikke en teoretisk konstruksjon. De oppstår naturlig i velfungerende team, ofte uten at noen kaller dem det. Her er fire praktiske arketyper du kjenner igjen fra din egen organisasjon:</p>
 
-    <div class="frame-element animate-on-scroll fade-in-up">
+    <div class="info-box animate-on-scroll fade-in-up">
         <h3>Prosjekttriaden: sponsor, leder, ekspert</h3>
         <p>Den mest utbredte triaden i organisasjonslivet. Sponsoren eier mandat og budsjett. Lederen koordinerer gjennomføring. Eksperten sikrer faglig kvalitet. Ingen av de tre kan alene drive prosjektet fremover. Hvis sponsoren faller fra, kan leder og ekspert sammen opprettholde fremdriften mens en ny sponsor finnes.</p>
     </div>
 
-    <div class="frame-element animate-on-scroll fade-in-up">
+    <div class="info-box animate-on-scroll fade-in-up">
         <h3>Mentortriaden: mentor, mentee, kollega</h3>
         <p>Tradisjonell mentoring er en dyade — mentor og mentee. Problemet er at mentoren blir en allmektig kilde til sannhet, og mentee utvikler ikke et selvstendig nettverk. I en mentortriade inkluderes en kollega på samme nivå som mentee, slik at læring blir en delt aktivitet og mentoren får perspektiv på hvordan kunnskapen faktisk tas i bruk.</p>
     </div>
 
-    <div class="frame-element animate-on-scroll fade-in-up">
+    <div class="info-box animate-on-scroll fade-in-up">
         <h3>Ledertriaden: operativ, strategisk, kulturell</h3>
         <p>I en ledergruppe på tre dekker man ofte tre roller: den som holder driften i gang, den som tenker fremover, og den som passer på kulturen. Når disse tre jobber som en triade, ikke som tre dyader til CEO, skapes en robust ledelsesstruktur som overlever utskifting av enkeltpersoner.</p>
     </div>
 
-    <div class="frame-element animate-on-scroll fade-in-up">
+    <div class="info-box animate-on-scroll fade-in-up">
         <h3>Overbroende triader: brobygging mellom siloer</h3>
         <p>Den mest strategiske bruken av triader er å bygge bro mellom avdelinger som ikke snakker sammen. En triade som består av én person fra avdeling A, én fra avdeling B, og én som fungerer som brobygger, kan overkomme silotenkning på en måte som hierarkiske styringsgrupper sjelden klarer.</p>
     </div>
 </section>
 
-<section class="frame-section animate-on-scroll fade-in-up">
+<section class="section container--wide animate-on-scroll fade-in-up">
     <h2>Når triader ikke fungerer — advarselstegn</h2>
     <p>Triader er ikke en magisk løsning. De kan også gå galt, og når de gjør det, er konsekvensene verre enn dyader fordi flere er involvert.</p>
 
-    <div class="frame-element animate-on-scroll fade-in-up">
+    <div class="info-box animate-on-scroll fade-in-up">
         <h3>Triangulering — å snakke om, ikke med</h3>
         <p>Det vanligste problemet. I stedet for at A og B løser konflikten direkte, snakker A med C om B. Triaden blir en kanal for baksnakking i stedet for en styrkende struktur. Dette er ikke en triade — det er en dyade (A og C) som ekskluderer den tredje (B). Ekte triader krever at alle tre relasjonene er likeverdige og direkte.</p>
     </div>
 
-    <div class="frame-element animate-on-scroll fade-in-up">
+    <div class="info-box animate-on-scroll fade-in-up">
         <h3>Kollektiv mot en</h3>
         <p>To personer som allierer seg mot den tredje. Dette er en triade i navnet, men i praksis en dyade med en utestengt deltaker. Skjer ofte når to personer har en historie som den tredje ikke deler, eller når én person oppleves som en trussel mot de to andres posisjon.</p>
     </div>
 
-    <div class="frame-element animate-on-scroll fade-in-up">
+    <div class="info-box animate-on-scroll fade-in-up">
         <h3>Maktkonsentrasjon — én som nekter å dele</h3>
         <p>Logans tredje betingelse er den som oftest brytes. Én person i triaden nekter å dele nettverket sitt og holder de to andre adskilt. Resultatet er en «hub and spoke»-struktur der den ene eier all informasjon og alle relasjoner. Dette er maktdynamikk i praksis — les mer i vår artikkel om <a href="{{ '/makt/' | relative_url }}">makt og tjeneste i ledergruppen</a>.</p>
     </div>
 
-    <div class="frame-element animate-on-scroll fade-in-up">
+    <div class="info-box animate-on-scroll fade-in-up">
         <h3>Manglende gjensidig verdi</h3>
         <p>Hvis én person i triaden bare mottar uten å gi, blir relasjonen utvinnende. Triaden opprettholdes av to personers generøsitet, men når den ene av dem trekker seg, kollapser strukturen. Bærekraftige triader krever at alle tre får noe verdifullt ut av relasjonen.</p>
     </div>
@@ -183,9 +183,9 @@ json_ld:
     <p>Felles for alle disse feilmodiene er at de oppstår når kulturen ikke er moden nok til å bære triaden. En organisasjon som fortsatt er preget av Stage 3-tenkning («jeg er best») vil ha store problemer med å opprettholde ekte triader. Triader er et symptom på kulturmodenhet, ikke en snarvei til den.</p>
 </section>
 
-<section class="frame-section animate-on-scroll fade-in-up">
+<section class="section container--wide animate-on-scroll fade-in-up">
     <h2>Spørsmål for å kartlegge triader i din organisasjon</h2>
-    <ul class="frame-questions stagger-parent" style="--stagger-delay: 80ms;">
+    <ul class="question-list stagger-parent" style="--stagger-delay: 80ms;">
         <li class="animate-on-scroll slide-in-left stagger">Hvem i teamet ditt ville fortsette å samarbeide effektivt hvis du forsvant i morgen?</li>
         <li class="animate-on-scroll slide-in-left stagger">Er viktige relasjoner i organisasjonen din dyader eller triader? Hvordan vet du det?</li>
         <li class="animate-on-scroll slide-in-left stagger">Hvem tjener på at to personer i organisasjonen ikke snakker sammen?</li>
@@ -194,16 +194,16 @@ json_ld:
     </ul>
 </section>
 
-<section class="frame-cta animate-on-scroll fade-in-up">
+<section class="section section--spacious container--narrow cta-section animate-on-scroll fade-in-up">
     <h2>Få kartlagt ledergruppens relasjonsstruktur</h2>
     <p>Ledelse 60:2 inneholder spørsmål som kartlegger hvordan relasjoner og informasjon flyter i ledergruppen din — og hvor moden kulturen er for triader. Bestill en uforpliktende samtale for å lære mer.</p>
-    <div class="frame-cta-buttons">
+    <div class="cta-buttons">
         <a href="https://outlook.office.com/book/ledelse@noexcuse.no/?ismsaljsauthenabled" class="product-cta">Bestill uforpliktende samtale</a>
         <a href="{{ '/' | relative_url }}" class="product-cta product-cta--secondary">Les mer om Ledelse 60:2 →</a>
     </div>
 </section>
 
-<section class="frame-section frame-about animate-on-scroll fade-in-up">
+<section class="section container--wide about-section animate-on-scroll fade-in-up">
     <h2>Referanser</h2>
     <p>Artikkelen bygger på forskning fra blant andre Dave Logan, John King & Halee Fischer-Wright (Tribal Leadership) og Bolman & Deal (organisasjonsteori).</p>
 </section>

--- a/_pages/ledelse_usikkerhet.md
+++ b/_pages/ledelse_usikkerhet.md
@@ -51,11 +51,11 @@ json_ld:
 
 {% include hero.html %}
 
-<section class="frame-section animate-on-scroll fade-in-up">
+<section class="section container--wide animate-on-scroll fade-in-up">
     <p>Styr unna uønskede hendelser og fang mulighetene som byr seg. En moden ledelse ligger i forkant av endringer for å holde stø kurs. Forankre krav til informasjonssikkerhet, kvalitet og miljø på riktig sted: I ledelsen.</p>
 </section>
 
-<section class="frame-section animate-on-scroll fade-in-up">
+<section class="section container--wide animate-on-scroll fade-in-up">
     <h2>Hva er organisasjonskultur egentlig?</h2>
     <p>Edgar Schein definerer kultur som «a pattern of shared basic assumptions learned by an organization as it solved its problems of external adaptation and internal integration.»[^schein2010] Kort sagt: det er måten vi faktisk gjør ting på, ikke bare det vi sier vi gjør.</p>
     <p>Schein identifiserer tre nivåer av kultur:[^schein2010]</p>
@@ -71,37 +71,37 @@ json_ld:
     <p>Spørsmålet ledergrupper bør stille seg i usikre tider er ikke «hva er kulturen vår?» — det er «hvilken kultur kommer til syne når vi ikke lenger har kontroll?»</p>
 </section>
 
-<section class="frame-section animate-on-scroll fade-in-up">
+<section class="section container--wide animate-on-scroll fade-in-up">
     <h2>De fem kulturstadiene — fra Logan</h2>
     <p>David Logan deler organisasjoner inn i fem kulturstadier, basert på hvordan medlemmene ser på seg selv og andre:[^logan2009]</p>
     
-    <div class="frame-element animate-on-scroll fade-in-up">
+    <div class="info-box animate-on-scroll fade-in-up">
         <h3>Trinn 1: «Livet suger»</h3>
         <p>En subkultur preget av apati og offermentalitet. Folk tror ingenting kan endres. Dette finnes sjelden i fungerende organisasjoner, men kan oppstå i nedlagte avdelinger eller under kriser.</p>
     </div>
 
-    <div class="frame-element animate-on-scroll fade-in-up">
+    <div class="info-box animate-on-scroll fade-in-up">
         <h3>Trinn 2: «Mitt liv suger»</h3>
         <p>Individuell apati. Folk er offer for omstendighetene. «Hva er vitsen?» er den dominerende holdningen. Rundt 25% av befolkningen opererer på dette stadiet.[^logan2009]</p>
     </div>
 
-    <div class="frame-element animate-on-scroll fade-in-up">
+    <div class="info-box animate-on-scroll fade-in-up">
         <h3>Trinn 3: «Jeg er great, du er det ikke»</h3>
         <p>Individualistisk egoisme. «Jeg er god, andre er dårligere.» Konkurranse innad. Seige på «vi er best»-mentality. Rundt 48% av organisasjoner befinner seg her.[^logan2009]</p>
     </div>
 
-    <div class="frame-element animate-on-scroll fade-in-up">
+    <div class="info-box animate-on-scroll fade-in-up">
         <h3>Trinn 4: «Vi er great, andre er ikke»</h3>
         <p>Tribe-tenkning. «Vi er gode, andre grupper er dårligere.» Sterk intern identitet, men kan føre til fiendskap mot andre. Rundt 22% av organisasjoner.[^logan2009]</p>
     </div>
 
-    <div class="frame-element animate-on-scroll fade-in-up">
+    <div class="info-box animate-on-scroll fade-in-up">
         <h3>Trinn 5: «Livet er great»</h3>
         <p>Ektepisentret. «Vi lykkes sammen.» Organisasjonen feirer suksess eksternt og internt. Kun 3% av organisasjoner når dette stadiet, ifølge Logan.[^logan2009]</p>
     </div>
 </section>
 
-<section class="frame-section animate-on-scroll fade-in-up">
+<section class="section container--wide animate-on-scroll fade-in-up">
     <h2>Hvorfor endring er så vanskelig</h2>
     <p>John Kotter dokumenterte at rundt 70% av alle endringsinitiativer feiler.[^kotter2012] Årsakene er systematiske:</p>
     <ul>
@@ -116,7 +116,7 @@ json_ld:
     <p>Når usikkerhet oppstår, oppstår også maktkamper. De som griper muligheten i uklare situasjoner, former retningen — uavhengig av om de har formell autoritet. Ledergrupper som ikke er bevisst på dette, oppdager for sent at veivalg er tatt av dem som handlet raskest, ikke av dem som hadde best innsikt.</p>
 </section>
 
-<section class="frame-section animate-on-scroll fade-in-up">
+<section class="section container--wide animate-on-scroll fade-in-up">
     <h2>Kotters 8-stegs modell for endring</h2>
     <p>John Kotter har kartlagt hvorfor endringsinitiativer feiler — og hvordan de faktisk kan lykkes. Hans forskning viser at de fleste endringsforsøk mislykkes fordi de gjør én eller flere av åtte kritiske feil. Her er hans åtte steg, fra akutt til forankret.[^kotter2012]</p>
     
@@ -216,36 +216,36 @@ json_ld:
     <p>Scheins tre kulturnivåer kobler seg til Kotters steg: artefakter påvirkes av kommunikasjon (Steg 4) og hindringsfjerning (Steg 5); erklærte verdier påvirkes av nødvendighet (Steg 1) og kulturell forankring (Steg 8); grunnleggende antakelser endres gjennom langsiktig bygging (Steg 7) og kulturell forankring (Steg 8).[^schein2010] Logans stadier forteller <em>hvor</em> organisasjonen er — Kotter forklarer <em>hvordan</em> den beveger seg videre.[^logan2009]</p>
 </section>
 
-<section class="frame-section animate-on-scroll fade-in-up">
+<section class="section container--wide animate-on-scroll fade-in-up">
     <h2>Vanlige kulturutfordringer</h2>
     
-    <div class="frame-challenges stagger-parent">
-        <div class="frame-challenge animate-on-scroll fade-in-up stagger">
+    <div class="grid grid--2 challenges-grid stagger-parent">
+        <div class="challenge-card animate-on-scroll fade-in-up stagger">
             <h4>Uoverensstemmelse mellom verdier og praksis</h4>
             <p>«Vi er innovative» står på veggen, men ideer drepes i møter. Kulturen sier noe annet enn det ledelsen tror.</p>
         </div>
-        <div class="frame-challenge animate-on-scroll fade-in-up stagger">
+        <div class="challenge-card animate-on-scroll fade-in-up stagger">
             <h4>Tacite kunnskap som ikke deles</h4>
             <p>Kunnskapen sitter i hodene til enkelte, ikke i systemer. Når folk slutter, forsvinner kunnskapen.</p>
         </div>
-        <div class="frame-challenge animate-on-scroll fade-in-up stagger">
+        <div class="challenge-card animate-on-scroll fade-in-up stagger">
             <h4>Silo-tenkning</h4>
             <p>Avdelinger som jobber for seg selv. «Det der er ikke mitt problem»-mentalitet. Koordinering på tvers av avdelinger er tilfeldig.</p>
         </div>
-        <div class="frame-challenge animate-on-scroll fade-in-up stagger">
+        <div class="challenge-card animate-on-scroll fade-in-up stagger">
             <h4>«Alltid sånn her»-mentalitet</h4>
             <p>Historisk suksess blir institusjonlisert. «Vi har alltid gjort det sånn» blir argumentet mot fornyelse.</p>
         </div>
-        <div class="frame-challenge animate-on-scroll fade-in-up stagger">
+        <div class="challenge-card animate-on-scroll fade-in-up stagger">
             <h4>Strukturell usikkerhet</h4>
             <p>Mål i ulike avdelinger som motvirker hverandre. Koordinering som skulle vært automatisk, krever stadige møter. Det oppleves som kulturproblem, men er egentlig strukturproblem — målene er ikke samordnet, og ingen har sett på om de henger sammen.</p>
         </div>
     </div>
 </section>
 
-<section class="frame-section animate-on-scroll fade-in-up">
+<section class="section container--wide animate-on-scroll fade-in-up">
     <h2>Spørsmål for å kartlegge kulturen</h2>
-    <ul class="frame-questions stagger-parent" style="--stagger-delay: 80ms;">
+    <ul class="question-list stagger-parent" style="--stagger-delay: 80ms;">
         <li class="animate-on-scroll slide-in-left stagger">Hvordan ville en nyansatt beskrive kulturen etter tre måneder?</li>
         <li class="animate-on-scroll slide-in-left stagger">Hvilke historier fortelles om organisasjonens suksesser — og hvem er helten?</li>
         <li class="animate-on-scroll slide-in-left stagger">Hva skjer hvis noen bryter med «hvordan vi gjør ting her»?</li>
@@ -254,10 +254,10 @@ json_ld:
     </ul>
 </section>
 
-<section class="frame-cta animate-on-scroll fade-in-up">
+<section class="section section--spacious container--narrow cta-section animate-on-scroll fade-in-up">
     <h2>Få kartlagt ledergruppens håndtering av usikkerhet</h2>
     <p>Ledelse 60:2 inneholder spørsmål som kartlegger hvordan ledergruppen håndterer usikkerhet, kultur og endring. Bestill en uforpliktende samtale for å lære mer.</p>
-    <div class="frame-cta-buttons">
+    <div class="cta-buttons">
         <a href="https://outlook.office.com/book/ledelse@noexcuse.no/?ismsaljsauthenabled" class="product-cta">Bestill uforpliktende samtale</a>
         <a href="{{ '/' | relative_url }}" class="product-cta product-cta--secondary">Les mer om Ledelse 60:2 →</a>
     </div>

--- a/assets/css/article.css
+++ b/assets/css/article.css
@@ -1,28 +1,35 @@
+/* Section — content sections */
 .perspektiv-section,
-.frame-section {
+.frame-section,
+.section.container--wide {
     /* Width/spacing via .section.container--wide */
 }
 
 .perspektiv-section h2,
-.frame-section h2 {
+.frame-section h2,
+.section.container--wide h2 {
     font-size: 1.6em;
     margin-bottom: 20px;
 }
 
 .perspektiv-section h3,
-.frame-section h3 {
+.frame-section h3,
+.section.container--wide h3 {
     font-size: 1.2em;
     margin-bottom: 12px;
 }
 
 .perspektiv-section p,
-.frame-section p {
+.frame-section p,
+.section.container--wide p {
     line-height: 1.7;
     margin-bottom: 16px;
 }
 
+/* Info box — highlighted content blocks */
 .perspektiv-element,
-.frame-element {
+.frame-element,
+.info-box {
     background: var(--box-background-light);
     padding: var(--space-lg);
     border-radius: var(--radius-lg);
@@ -32,21 +39,26 @@
 }
 
 .perspektiv-element:hover,
-.frame-element:hover {
+.frame-element:hover,
+.info-box:hover {
     transform: translateY(-2px);
     box-shadow: var(--shadow-md);
 }
 
+/* Challenge grid — 2-column card layout */
 .perspektiv-challenges,
-.frame-challenges {
+.frame-challenges,
+.grid.grid--2.challenges-grid {
     display: grid;
     grid-template-columns: 1fr 1fr;
     gap: 20px;
     margin: 24px 0;
 }
 
+/* Challenge card — individual challenge */
 .perspektiv-challenge,
-.frame-challenge {
+.frame-challenge,
+.challenge-card {
     background: var(--box-background-light);
     padding: 20px;
     border-radius: var(--radius-lg);
@@ -54,32 +66,38 @@
 }
 
 .perspektiv-challenge:hover,
-.frame-challenge:hover {
+.frame-challenge:hover,
+.challenge-card:hover {
     transform: translateY(-4px);
     box-shadow: var(--shadow-lg);
 }
 
 .perspektiv-challenge h4,
-.frame-challenge h4 {
+.frame-challenge h4,
+.challenge-card h4 {
     margin: 0 0 8px 0;
     font-size: 1em;
 }
 
 .perspektiv-challenge p,
-.frame-challenge p {
+.frame-challenge p,
+.challenge-card p {
     margin: 0;
     font-size: 0.95em;
     opacity: 0.85;
 }
 
+/* Question list — diagnostic questions */
 .perspektiv-questions,
-.frame-questions {
+.frame-questions,
+.question-list {
     list-style: none;
     padding: 0;
 }
 
 .perspektiv-questions li,
-.frame-questions li {
+.frame-questions li,
+.question-list li {
     padding: 12px 0;
     border-bottom: 1px solid var(--border-color-light);
     padding-left: 24px;
@@ -87,15 +105,18 @@
 }
 
 .perspektiv-questions li:before,
-.frame-questions li:before {
+.frame-questions li:before,
+.question-list li:before {
     content: "→";
     position: absolute;
     left: 0;
     color: var(--primary-accent);
 }
 
+/* CTA section — call to action */
 .perspektiv-cta,
-.frame-cta {
+.frame-cta,
+.cta-section {
     text-align: center;
     background: var(--box-background-light);
     border-radius: var(--radius-xl);
@@ -103,34 +124,42 @@
 }
 
 .perspektiv-cta h2,
-.frame-cta h2 {
+.frame-cta h2,
+.cta-section h2 {
     font-size: 1.6em;
     margin-bottom: 16px;
 }
 
 .perspektiv-cta p,
-.frame-cta p {
+.frame-cta p,
+.cta-section p {
     font-size: 1.05em;
     line-height: 1.6;
     margin-bottom: 24px;
     opacity: 0.85;
 }
 
+/* CTA buttons — flex container */
 .perspektiv-cta-buttons,
-.frame-cta-buttons {
+.frame-cta-buttons,
+.cta-buttons {
     display: flex;
     gap: 16px;
     justify-content: center;
     flex-wrap: wrap;
 }
 
+/* About section — references */
 .perspektiv-about,
-.frame-about {
+.frame-about,
+.about-section {
     border-top: 1px solid var(--border-color-light);
 }
 
+/* About link */
 .perspektiv-link,
-.frame-link {
+.frame-link,
+.about-link {
     display: inline-block;
     margin-top: 16px;
     color: var(--link-color-light);
@@ -147,12 +176,14 @@
 
 @media (max-width: 599px) {
     .perspektiv-challenges,
-    .frame-challenges {
+    .frame-challenges,
+    .grid.grid--2.challenges-grid {
         grid-template-columns: 1fr;
     }
 
     .perspektiv-cta-buttons,
-    .frame-cta-buttons {
+    .frame-cta-buttons,
+    .cta-buttons {
         flex-direction: column;
         align-items: center;
     }
@@ -305,21 +336,35 @@
     background: var(--surface-hover-dark);
 }
 
-/* Perspektiv dark mode overrides */
+/* Dark mode overrides */
 .dark-mode .perspektiv-element,
+.dark-mode .frame-element,
+.dark-mode .info-box,
 .dark-mode .perspektiv-challenge,
-.dark-mode .perspektiv-cta {
+.dark-mode .frame-challenge,
+.dark-mode .challenge-card,
+.dark-mode .perspektiv-cta,
+.dark-mode .frame-cta,
+.dark-mode .cta-section {
     background: var(--box-background-dark);
 }
 
-.dark-mode .perspektiv-questions li {
+.dark-mode .perspektiv-questions li,
+.dark-mode .frame-questions li,
+.dark-mode .question-list li {
     border-bottom-color: var(--border-color-dark);
 }
 
-.dark-mode .perspektiv-about {
+.dark-mode .perspektiv-about,
+.dark-mode .frame-about,
+.dark-mode .about-section {
     border-top-color: var(--border-color-dark);
 }
 
 .dark-mode .perspektiv-breadcrumb a {
+    color: var(--link-color-dark);
+}
+
+.dark-mode .about-link {
     color: var(--link-color-dark);
 }

--- a/assets/css/typography.css
+++ b/assets/css/typography.css
@@ -48,7 +48,8 @@ small {
 /* Reading width for articles */
 .article-body,
 .frame-section,
-.perspektiv-section {
+.perspektiv-section,
+.section.container--wide {
     max-width: 65ch;
     margin-inline: auto;
 }


### PR DESCRIPTION
## Summary

Completes P5 (Layout Migration) by converting all 7 article pages from legacy `.frame-*` class names to the unified layout system classes defined in `.design/layouts.md`.

## Changes

### Article Pages (7 files)
All `_pages/ledelse_*.md` article pages converted:

| Old Class | New Class | Count |
|-----------|-----------|-------|
| `.frame-section` | `.section.container--wide` | ~40 |
| `.frame-cta` | `.section.section--spacious.container--narrow.cta-section` | 7 |
| `.frame-element` | `.info-box` | ~20 |
| `.frame-challenges` | `.grid.grid--2.challenges-grid` | 7 |
| `.frame-challenge` | `.challenge-card` | ~28 |
| `.frame-questions` | `.question-list` | 7 |
| `.frame-cta-buttons` | `.cta-buttons` | 7 |
| `.frame-about` | `.about-section` | 7 |
| `.frame-link` | `.about-link` | 7 |
| `.frame-hero` | `.hero` | 2 |
| `.frame-hero-*` | `.hero-*` | ~6 |

**Pages converted:** tillit, usikkerhet, forankring, generativ-ki, triader, makt, perspektiv

### CSS
- **article.css**: Added new selectors alongside existing aliases for backward compatibility
- **typography.css**: Added `.section.container--wide` to reading-width rule
- All new classes have `.dark-mode` variants
- Old `.frame-*` and `.perspektiv-*` selectors retained for backward compatibility with `_layouts/perspektiv.html`

## How to test
1. Verify `/tillit/`, `/usikkerhet/`, `/forankring/`, `/generativ-ki/`, `/triader/`, `/makt/`, `/perspektiv/` render correctly
2. Check dark mode toggles correctly on converted pages
3. Check mobile breakpoints (≤599px) maintain readable layout
4. `bundle exec jekyll build` exits 0

## Pre-merge notes
- Pure refactoring — no content text changed, only CSS classes
- Backward compatibility preserved via dual-class selectors in CSS
- Perspective pages (`/struktur/`, `/mennesker/`, `/påvirkning/`, `/identitet/`) use `_layouts/perspektiv.html` and are unaffected

Refs: P5
