### PR TITLE
fix(x2): dark mode consistency pass

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -33,7 +33,7 @@ Completed items belong in `CHANGELOG.md` only.
 | N2 | Makt article (order: 1st) | Done | — |
 | N3 | Perspektiv article (order: 3rd) | Done | N1, N2 |
 | P5 | Migrate `_pages/ledelse_*.md` to layout system | Planned | A1 |
-| X2 | Dark mode consistency pass | Planned | — |
+| X2 | Dark mode consistency pass | Done | — |
 | F5 | Image generation for N1-N3 | Blocked | N1, N2, N3 |
 | C1 | Customer case planning & discovery | Blocked | Brainstorming session |
 | C2 | Customer case intake form | Blocked | C1 |

--- a/assets/css/avtale.css
+++ b/assets/css/avtale.css
@@ -29,6 +29,10 @@
     border-bottom: 1px solid var(--border-color-light);
 }
 
+.dark-mode .avtale-page h2 {
+    border-bottom-color: var(--border-color-dark);
+}
+
 .avtale-page p {
     font-size: 1em;
     line-height: 1.6;

--- a/assets/css/partners.css
+++ b/assets/css/partners.css
@@ -40,6 +40,3 @@
 .partner-name {
     font-size: 0.85em;
 }
-{
-    font-size: 0.85em;
-}

--- a/assets/css/perspektiv-styles.css
+++ b/assets/css/perspektiv-styles.css
@@ -66,6 +66,10 @@
     background-color: var(--surface-raised-light);
 }
 
+.dark-mode .perspektiv-questions li:hover {
+    background-color: var(--surface-raised-dark);
+}
+
 .perspektiv-questions li:before {
     content: "→";
     font-weight: bold;
@@ -76,6 +80,10 @@
 .perspektiv-cta {
     box-shadow: var(--shadow-md);
     border: 1px solid var(--border-color-subtle-light);
+}
+
+.dark-mode .perspektiv-cta {
+    border-color: var(--border-color-dark);
 }
 
 /* Spot illustrations — floating, alternating left/right */


### PR DESCRIPTION
Fixes dark mode gaps in three CSS files:

- **perspektiv-styles.css**: Adds .dark-mode rules for question list hover background and CTA border color
- **avtale.css**: Adds .dark-mode rule for h2 border-bottom-color
- **partners.css**: Removes orphaned empty CSS rule block

Refs: X2