### PR TITLE
feat(n5): wire spot illustrations for Struktur frame

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -35,7 +35,7 @@ Completed items belong in `CHANGELOG.md` only.
 | P5 | Migrate `_pages/ledelse_*.md` to layout system | Done | A1 |
 | X2 | Dark mode consistency pass | Done | — |
 | F5 | Image generation for N1-N3 | Done | — |
-| F6 | Spot illustration naming cleanup — rename index-based spot images to concept-based names, move to banners/ | Doing | — |
+| F6 | Spot illustration naming cleanup — rename index-based spot images to concept-based names, move to banners/ | Done | — |
 | C1 | Customer case planning & discovery | Blocked | Brainstorming session |
 | C2 | Customer case intake form | Blocked | C1 |
 | C3 | Case presentation design | Blocked | C1, C2 |

--- a/_layouts/perspektiv.html
+++ b/_layouts/perspektiv.html
@@ -39,9 +39,7 @@ layout: page
 <section class="perspektiv-section section container--wide animate-on-scroll fade-in-up">
   <h2>De tre hovedelementene</h2>
 
-  {% assign spot_names = "0,1,2" | split: "," %}
   {% for element in frame.elements %}
-  {% assign spot_index = spot_names[forloop.index0] %}
   <div class="perspektiv-element animate-on-scroll fade-in-up">
     {% assign spot_num = forloop.index0 | modulo: 2 %}
     {% assign float_class = "" %}
@@ -51,9 +49,8 @@ layout: page
       {% assign float_class = "argument-illustration argument-illustration--right" %}
     {% endif %}
 
-    {% assign img_name = 'spot-' | append: frame.id | append: '-' | append: spot_index %}
-    {% if page.show_spots %}
-    <img src="{{ '/assets/images/banners/' | append: img_name | append: '.webp' | relative_url }}"
+    {% if page.show_spots and element.spot_image %}
+    <img src="{{ element.spot_image | relative_url }}"
          alt="Illustrasjon: {{ element.title }}"
          class="{{ float_class }}"
          loading="lazy">
@@ -76,9 +73,8 @@ layout: page
 
 <!-- Leader Value with spot illustration -->
 <section class="perspektiv-section section container--wide animate-on-scroll fade-in-up">
-  {% if page.show_spots %}
-  {% assign leader_img = 'spot-' | append: frame.id | append: '-3' %}
-  <img src="{{ '/assets/images/banners/' | append: leader_img | append: '.webp' | relative_url }}"
+  {% if page.show_spots and frame.leader_value.spot_image %}
+  <img src="{{ frame.leader_value.spot_image | relative_url }}"
        alt="Illustrasjon: {{ frame.leader_value.heading }}"
        class="argument-illustration argument-illustration--right"
        loading="lazy">

--- a/_pages/struktur.md
+++ b/_pages/struktur.md
@@ -3,6 +3,7 @@ class: frame
 layout: perspektiv
 permalink: /struktur/
 frame_id: "struktur"
+show_spots: true
 category: "frame"
 title: "Strukturperspektivet i ledelse"
 description: "Lær hvordan strukturperspektivet kan hjelpe ledergruppen å få oversikt over roller, ansvar og koordinering. Struktur handler om å skape et system der oppgaver og mål henger sammen."
@@ -39,18 +40,21 @@ intro:
 
 elements:
   - title: "Roller og ansvar"
+    spot_image: "assets/images/banners/spot-struktur-roller.webp"
     body: |
       Hvem gjør hva? Roller er de minste meningsfulle enhetene i en organisasjon. Når roller er utydelige, oppstår det ansvarsskyvning. Når de er klare, vet folk hva som forventes av dem — og hva de kan forvente av andre. Uten en strukturert måte å kartlegge roller på, risikerer ledergruppen å overse uklarheter inntil de skaper konflikter.
     signs:
       positive: "Ledere kan beskrive sine ansvarsområder presist. De vet hvem som signerer hva. Beslutninger tas på riktig nivå."
       negative: "«Det er ikke min jobb» eller «Hvem skal jeg egentlig spørre?» Dominans av e-post og møter for å koordinere arbeid som burde gå av seg selv."
   - title: "Mål og koordinering"
+    spot_image: "assets/images/banners/spot-struktur-mal-og-koordinering.webp"
     body: |
       Organisasjoner eksisterer for å oppnå noe. Mål er det som gir retning. Koordinering er det som får ulike deler til å trekke i samme retning. Strukturerte spørsmål om måljustering avdekker silotenking før den koster resultater — uten dem forblir konkurrerende prioriteringer usynlige for ledelsen.
     signs:
       positive: "Mål i ulike avdelinger forsterker hverandre. Det er enkelt å spores hvordan delmål bidrar til hovedmål. Prioriteringer er relativt entydige."
       negative: "Silotenking. Mål som konkurrerer med hverandre. Avdelinger som driver egne initiativ uten å kjenne til hverandre. Mye tid brukt på «å samordne» arbeid som burde ha vært koordinert fra start."
   - title: "Prosesser og regler"
+    spot_image: "assets/images/banners/spot-struktur-prosesser-og-regler.webp"
     body: |
       Prosesser er hvordan arbeid faktisk utføres. Regler er de formelle og uformelle normene som styrer atferd. En god struktur har balanse: nok regler til å gi trygghet, få nok til å stimulere vekst.
 
@@ -61,6 +65,7 @@ elements:
 
 leader_value:
   heading: "Hvorfor struktur betyr noe for ledergruppen"
+  spot_image: "assets/images/banners/spot-struktur-hvorfor-struktur-betyr-noe.webp"
   body: |
     Strukturperspektivet er kanskje det minst «sexy» av de fire perspektivene, men det er ofte der problemene starter. Mange ledelsesproblemer — lav gjennomføringskraft, uklare ansvarsforhold, ineffektive møter — handler i bunn om strukturelle utfordringer, ikke kultur- eller relasjonsproblemer.
 


### PR DESCRIPTION
## What

Wires the 4 concept-based spot illustrations into the Struktur perspective page.

## Changes

- : Add  and explicit  fields to each element and leader_value
- : Use  and  directly instead of computing index-based filenames

## Spot images used

| Section | Image |
|---------|-------|
| Roller og ansvar |  |
| Mål og koordinering |  |
| Prosesser og regler |  |
| Hvorfor struktur betyr noe |  |

## How to test

1. Build site with Jekyll
2. Visit  
3. Verify 4 spot illustrations appear at correct positions (alternating left/right float)
4. Check mobile: images should stack full-width at ≤599px

## Pre-merge notes

- Layout change is backward-compatible: pages without  fields will render without spots (same as before)
- Other frame pages (mennesker, påvirkning, identitet) not yet wired — will be handled in N4, N6, N7

Refs N5