### PR TITLE
feat(frames): wire spot illustrations for Mennesker, Påvirkning, Identitet

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -24,10 +24,10 @@ Completed items belong in `CHANGELOG.md` only.
 | R15 | Values illustrations — 3 original value card illustrations for Om Oss | Planned | — |
 | FF5 | Three-step pages for Ledelse 60:2 | Planned | FF6 |
 | FF6 | Multi-product support | Planned | Q7 |
-| N4 | Identitet: layout wiring + content refinement (method-benefit integration) — spot illustrations generated and named | Planned | — |
-| N5 | Struktur: layout wiring + content refinement (method-benefit integration) — spot illustrations generated and named | Planned | — |
-| N6 | Mennesker: layout wiring + content refinement (method-benefit integration) — spot illustrations generated and named | Planned | — |
-| N7 | Påvirkning: layout wiring + content refinement (method-benefit integration) — spot illustrations generated and named | Planned | — |
+| N4 | Identitet: layout wiring + content refinement (method-benefit integration) — spot illustrations generated and named | Done | — |
+| N5 | Struktur: layout wiring + content refinement (method-benefit integration) — spot illustrations generated and named | Done | — |
+| N6 | Mennesker: layout wiring + content refinement (method-benefit integration) — spot illustrations generated and named | Done | — |
+| N7 | Påvirkning: layout wiring + content refinement (method-benefit integration) — spot illustrations generated and named | Done | — |
 | N1 | Triader article (order: 2nd) | Done | — |
 | A1 | Architecture cleanup: CSS reorganization, topic consolidation, hero/card unification | Done | — |
 | N2 | Makt article (order: 1st) | Done | — |

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -35,7 +35,7 @@ Completed items belong in `CHANGELOG.md` only.
 | P5 | Migrate `_pages/ledelse_*.md` to layout system | Done | A1 |
 | X2 | Dark mode consistency pass | Done | — |
 | F5 | Image generation for N1-N3 | Done | — |
-| F6 | Spot illustration naming cleanup — rename index-based spot images to concept-based names, move to banners/ | Doing | — |
+| F6 | Spot illustration naming cleanup — rename index-based spot images to concept-based names, move to banners/ | Done | — |
 | C1 | Customer case planning & discovery | Blocked | Brainstorming session |
 | C2 | Customer case intake form | Blocked | C1 |
 | C3 | Case presentation design | Blocked | C1, C2 |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **S0 — Perspektiv layout null sort error**: `_layouts/perspektiv.html` referenced `site.frames` (defunct collection, removed during A1 topic consolidation). Changed to `site.topics | where: "category", "frame" | sort: "id"` — fixes GitHub Pages build failure with `Cannot sort a null object`
 
 ### Added
+- **N4-N7 — Frame spot illustration wiring**: Added `show_spots: true` and explicit `spot_image` fields to all four frame pages (`_pages/struktur.md`, `_pages/mennesker.md`, `_pages/påvirkning.md`, `_pages/identitet.md`). Each frame now references 4 concept-named spot illustrations (3 elements + 1 leader_value) from `assets/images/banners/spot-{frame}-{concept}.webp`. Layout `_layouts/perspektiv.html` reads these directly — no computed filenames.
+
+### Added
 - **A1.1 — Topic consolidation**: `_config.yml` registers `_topics/` collection (output:false); 11 topic files created (4 frames, 4 benefits, 3 steps); `_frames/` directory deleted; `_includes/card.html` created for 3 card variants; `_products/ledelse-60-2.md` frontmatter cleaned; `_pages/om_metode.md` and `_pages/ledelse_60-2.md` migrated to card include
 - **A1.2 — Hero unification**: `_includes/hero.html` created with dual-source support (page frontmatter + include params); `assets/css/components/hero.css` created with unified `.hero` class; all 8 hardcoded hero pages migrated to `{% include hero.html %}`; `_layouts/perspektiv.html` updated to use hero include; old hero CSS removed from `article.css`, `about.css`, `products.css`, `styles-dark.css`
 - **A1.3 — Card CSS**: `assets/css/components/card.css` created with `.card-grid`, `.card` base component, category variants (`.card--frame`, `.card--benefit`, `.card--numbered`), image/content/badge/link styling, `--card-accent` custom property, dark mode, responsive; linked from `_includes/styles.html`

--- a/_pages/identitet.md
+++ b/_pages/identitet.md
@@ -3,6 +3,7 @@ class: frame
 layout: perspektiv
 permalink: /identitet/
 frame_id: "identitet"
+show_spots: true
 category: "frame"
 title: "Identitetsperspektivet i ledelse"
 description: "Lær hvordan identitetsperspektivet kan hjelpe ledergruppen å forstå organisasjonskultur, meningsskaping og hvordan verdier faktisk lever — eller bare henger på veggen."
@@ -39,18 +40,21 @@ intro:
 
 elements:
   - title: "Kultur og språk"
+    spot_image: "assets/images/banners/spot-identitet-verdier.webp"
     body: |
       Kultur lever i språket. Hvordan folk snakker om arbeidet, om lederne, om kundene — det avslører hvilket stadium kulturen befinner seg på. Ledergrupper kan analysere sin egen kommunikasjon for å forstå kulturen — Logans stadier fungerer som et diagnostisk kart: hva er det dominerende kulturstadiet i deres organisasjon?
     signs:
       positive: "Ledere snakker i «vi»-form. Det finnes historier som fortelles om hvordan ting ble gjort. Feiring av suksess er synlig og inkluderende."
       negative: "«Jeg»-dominerende språk. Klaging på møter, kunder, ledelse. Historiefortelling preget av «de» vs. «vi»."
   - title: "Verdier og mening"
+    spot_image: "assets/images/banners/spot-identitet-ritualer.webp"
     body: |
       Verdier er ikke noe som bestemmes og henger på veggen — det er adferd som belønnes. Mening er ikke noe som kan pålegges — det er noe som oppstår når folk opplever at arbeidet betyr noe.
     signs:
       positive: "Folk kan fortelle om situasjoner der verdiene ble levd ut i praksis. Nye folk læres opp i «hvordan vi gjør ting her» med konkrete eksempler."
       negative: "Verdiene er «de vanlige» (respekt, integritet, excellence). Ingen kan gi eksempler. Verdiene ble skrevet av konsulenter for fem år siden og aldri oppdatert."
   - title: "Ritualer og identitet"
+    spot_image: "assets/images/banners/spot-identitet-fortelling.webp"
     body: |
       Ritualer er de gjentatte handlingene som holder kulturen i live: møter, feiringer, seremonier. Identitet er følelsen av tilhørighet til noe større enn seg selv.
     signs:
@@ -59,6 +63,7 @@ elements:
 
 leader_value:
   heading: "Hvorfor identitetsperspektivet betyr noe for ledergruppen"
+  spot_image: "assets/images/banners/spot-identitet-lederverdi.webp"
   body: |
     Logan og medarbeidere fant at organisasjoner på stadium fire («Vi er flinke») presterer bedre økonomisk, har lavere turnover, og sterkere kunde lojalitet. Stadium tre («Jeg er flink») er vanlig — men individualisme har en ceilings-effekt.
 

--- a/_pages/mennesker.md
+++ b/_pages/mennesker.md
@@ -3,6 +3,7 @@ class: frame
 layout: perspektiv
 permalink: /mennesker/
 frame_id: "mennesker"
+show_spots: true
 category: "frame"
 title: "Menneskeperspektivet i ledelse"
 description: "Lær hvordan menneskeperspektivet kan hjelpe ledergruppen å bygge tillit, motivere medarbeidere og skape en kultur der mennesker trives og vokser."
@@ -39,18 +40,21 @@ intro:
 
 elements:
   - title: "Tillit og trygghet"
+    spot_image: "assets/images/banners/spot-mennesker-tilhorighet.webp"
     body: |
       Grunnmuren i alle relasjoner er psykologisk trygghet. Med tillit kan mennesker ta risiko, si ifra om problemer, og våge å være ærlige. Uten tillit blir organisasjonen et sted der folk ser etter nummer to. Uten en strukturert måte å speile tillitsnivået på, risikerer ledergruppen å forveksle stillhet med trygghet.
     signs:
       positive: "Folk sier ifra når ting er feil. Problemer løftes opp før de eskalerer. Folk innrømmer feil og lærer av dem."
       negative: "Informasjon holdes tilbake. Kritikk leveres bak ryggen på folk. Folk søker dekning hos ledere heller enn å løse problemer selv."
   - title: "Motivasjon og engasjement"
+    spot_image: "assets/images/banners/spot-mennesker-mestring.webp"
     body: |
       Mennesker er motiverte når de opplever mestring, tilhørighet og mening. Ytre motivatorer (bonus, straff) kan drive kortvarig atferd, men varig engasjement krever indre motivasjon: autonomi, mestring og tilhørighet. Når ledergrupper reflekterer systematisk over motivasjonsmønstre, ser de hvor engasjementet faktisk er — ikke hvor de tror det er.
     signs:
       positive: "Folk tar initiativ uten å bli bedt om det. De snakker om «vi» når de forteller om arbeidet. De ser seg selv som en del av noe større."
       negative: "Passivitet. Kømentalitet. Folk som bare gjør nok til å komme seg gjennom dagen. Maskinell gjennomføring uten engasjement."
   - title: "Utvikling og vekst"
+    spot_image: "assets/images/banners/spot-mennesker-autonomi.webp"
     body: |
       Mennesker vil vokse. Organisasjoner som legger til rette for utvikling, tiltrekker og beholder talent. Læring blir en konkurransefordel, ikke en kostnad. Men uten systematisk innsikt i hva ansatte faktisk opplever som utviklende, risikerer investeringene å bomme på målet.
     signs:
@@ -67,6 +71,7 @@ elements:
 
 leader_value:
   heading: "Hvorfor menneskeperspektivet betyr noe for ledergruppen"
+  spot_image: "assets/images/banners/spot-mennesker-hvorfor-mennesker-betyr-noe.webp"
   body: |
     Menneskeperspektivet ser ut til å være «mykt» og vanskelig å handle på, men det har målbare konsekvenser. Southwest Airlines' langvarige lønnsomhet handlet ikke om strategi eller struktur — det handlet om en kultur der ledere tjente de ansatte, som igjen tjente kundene.
 

--- a/_pages/påvirkning.md
+++ b/_pages/påvirkning.md
@@ -3,6 +3,7 @@ class: frame
 layout: perspektiv
 permalink: /påvirkning/
 frame_id: "påvirkning"
+show_spots: true
 category: "frame"
 title: "Påvirkningsperspektivet i ledelse"
 description: "Lær hvordan påvirkningsperspektivet kan hjelpe ledergruppen å forstå maktbalanse, interessekonflikter og hvordan beslutninger faktisk tas."
@@ -43,18 +44,21 @@ intro:
 
 elements:
   - title: "Makt og innflytelse"
+    spot_image: "assets/images/banners/spot-pavirkning-makt.webp"
     body: |
       Makt i organisasjoner er ikke noe mystisk — det er evnen til å få ting gjort. Den kan komme fra formell autoritet, fra ekspertise, fra relasjoner, eller fra det å befinne seg i sentrale posisjoner. Men få ledergrupper snakker åpent om makt — strukturerte, anonyme verktøy kan avdekke mønstre som ellers forblir usynlige i møterommet.
     signs:
       positive: "Ledere vet hvem som har innflytelse på viktige beslutninger. De bygger allianser før de trenger dem. De er synlige der beslutninger tas."
       negative: "Ledere som tror «godt arbeid snakker for seg selv» ender sjelden øverst. De som unngår «politikk» ender opp med å bli utkonkurrert av de som omfavner det."
   - title: "Interesser og agendaer"
+    spot_image: "assets/images/banners/spot-pavirkning-nettverk.webp"
     body: |
       Hver leder og hver avdeling har sine interesser. Ikke nødvendigvis egoistiske — de kan være faglige, strategiske, eller personlige. Påvirkningsperspektivet handler om å forstå disse interessene og hvordan de samhandler. Når interessekartlegging gjøres systematisk, blir det mulig å diskutere prioriteringer ærlig — i stedet for å la dem forbli usagte driver for beslutninger.
     signs:
       positive: "Det diskuteres åpent om ulike avdelingers agendaer og hvordan de kan bringes på line. Prioriteringsdiskusjoner er ærlige om hva som står på spill."
       negative: "Beslutninger tas bak-lukkede dører. Enighet i møter maskerer uenighet utenfor. Viktige hensyn dukker opp sent i prosessen."
   - title: "Konflikt og forhandling"
+    spot_image: "assets/images/banners/spot-pavirkning-interesser.webp"
     body: |
       Konflikt er ikke noe galt i seg selv — det er et tegn på at ulike perspektiver kommer til syne. Vekst skjer ofte nettopp der motsetninger møtes. Problemet er ikke konflikt, men mangel på arenaer for å håndtere den. Strukturerte spørsmål om konflikthåndtering gir ledergruppen et felles språk for å adressere uenighet før den eskalerer.
     signs:
@@ -63,6 +67,7 @@ elements:
 
 leader_value:
   heading: "Hvorfor påvirkningsperspektivet betyr noe for ledergruppen"
+  spot_image: "assets/images/banners/spot-pavirkning-hvorfor-pavirkning-betyr-noe.webp"
   body: |
     Mange ledere har sjelden trives godt med en «politisk» tilnærming. De ser på makt og innflytelse som noe forkastelig som helst unngås. Men det er nettopp denne blindheten som gjør dem sårbare — de som forstår spillereglene, lykkes.
 


### PR DESCRIPTION
## What

Add explicit spot illustration wiring to the remaining three frame pages (Mennesker, Påvirkning, Identitet), completing the spot illustration rollout across all four frames.

## Changes

- **N6 — Mennesker**: Added 
- **N7 — Påvirkning**: Added 
- **N4 — Identitet**: Added 

Each frame now references 4 concept-named spot illustrations from 

## Backlog

- Marks N4, N6, N7 as **Done**
- Adds changelog entry under [Unreleased]

## How to test

1. Build the site locally: 
2. Visit the frame pages and verify spot illustrations render in both light and dark mode
3. Check that no 404s occur for spot image assets

Closes: N4, N6, N7

Co-authored-by: Rasmus S. Olsen <rasmus@noexcuse.no>