### PR TITLE
feat(perspektiv): R19-R22 — nav link, hero CTAs, frame back-nav

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -41,10 +41,7 @@ Completed items belong in `CHANGELOG.md` only.
 | C3 | Case presentation design | Blocked | C1, C2 |
 | C4 | Visitor flow / inbound sales journey | Blocked | C1, C2, C3 |
 | Q7 | Katalysator product | Blocked | User availability (deferred to June 2026) |
-| R19 | Add "Perspektiv" menu link between "Ledelse 60:2" and "Om oss" | Planned | — |
 | R20 | Generate and add illustrations to /perspektiv per page design rules | Planned | — |
-| R21 | Add four CTA buttons (Identitet, Struktur, Mennesker, Påvirkning) as CSS overlay on /perspektiv header banner | Planned | R20 |
-| R22 | Add inline CTA buttons on relevant pages linking to topic sections | Planned | — |
 | R16 | Article illustrations — 25 images for Makt, Perspektiv, Triader (T2 framework + T3 section + T4 micro) | Planned | — |
 | R17 | Frame micro illustrations — 16 T4 micro spots for challenge cards on Struktur, Mennesker, Identitet, Påvirkning | Planned | — |
 | R18 | Product & process illustrations — 20 images for Ledelse 60:2, Metode, Avtale, Step pages | Planned | — |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **R19 — Perspektiv menu link**: Added "Perspektiv" to `_data/navigation.yml` between "Ledelse 60:2" and "Om oss", linking to `/perspektiv/`
+- **R21 — Hero CTA overlay on /perspektiv**: Four frame-perspective buttons (Struktur, Mennesker, Påvirkning, Identitet) as CSS grid overlay at bottom of hero banner. Uses `hero-frame-nav`/`hero-frame-link` classes in `perspektiv-styles.css` with dark mode support and mobile wrap layout
+- **R22 — Frame page back-navigation**: Added "↑ Fire perspektiver" cross-navigation link in `_layouts/perspektiv.html`, linking all four frame pages back to `/perspektiv/` overview
 - **R15 — Values illustrations for Om Oss**: Replaced placeholder `●` circles in `_pages/om_oss.md` value cards with 3 generated spot illustrations (`verdi-ansvarlighet.webp`, `verdi-tillit.webp`, `verdi-aerlighet.webp`). Images are 400×400px WebP, ≤15KB each, square 1:1, Scandinavian minimal style with distinct color palettes per value. Updated `assets/css/about.css` `.value-icon` to render `<img>` elements at 60×60px with `object-fit: cover` and `border-radius: var(--radius-md)`. Images use `aria-hidden="true"` and empty `alt` (decorative, per WCAG).
 
 ### Added

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -2,5 +2,7 @@
   url: /
 - title: Ledelse 60:2
   url: /ledelse-60-2/
+- title: Perspektiv
+  url: /perspektiv/
 - title: Om oss
   url: /om-oss/

--- a/_layouts/perspektiv.html
+++ b/_layouts/perspektiv.html
@@ -138,7 +138,8 @@ layout: page
     {% if prev_frame %}
     <a href="{{ '/' | append: prev_frame.id | append: '/' | relative_url }}" class="product-cta product-cta--secondary">← {{ prev_frame.title }}</a>
     {% endif %}
-    <a href="{{ '/metode/' | relative_url }}" class="product-cta product-cta--secondary">↑ Om metode</a>
+    <a href="{{ '/perspektiv/' | relative_url }}" class="product-cta product-cta--secondary">↑ Fire perspektiver</a>
+    <a href="{{ '/metode/' | relative_url }}" class="product-cta product-cta--secondary">Om metode →</a>
     {% if next_frame %}
     <a href="{{ '/' | append: next_frame.id | append: '/' | relative_url }}" class="product-cta product-cta--secondary">{{ next_frame.title }} →</a>
     {% endif %}

--- a/_pages/ledelse_perspektiv.md
+++ b/_pages/ledelse_perspektiv.md
@@ -56,6 +56,12 @@ json_ld:
         <h1 class="hero-title">Fire perspektiver — se mer enn du ser</h1>
         <p class="hero-intro">De fleste ledere ser verden gjennom ett filter. De beste ser gjennom fire — og vet hvilket som passer når. Multiframe thinking er ikke teori, det er en ferdighet.</p>
     </div>
+    <div class="hero-frame-nav">
+        <a href="{{ '/struktur/' | relative_url }}" class="hero-frame-link">Struktur</a>
+        <a href="{{ '/mennesker/' | relative_url }}" class="hero-frame-link">Mennesker</a>
+        <a href="{{ '/påvirkning/' | relative_url }}" class="hero-frame-link">Påvirkning</a>
+        <a href="{{ '/identitet/' | relative_url }}" class="hero-frame-link">Identitet</a>
+    </div>
 </section>
 
 <section class="section container--wide animate-on-scroll fade-in-up">

--- a/assets/css/perspektiv-styles.css
+++ b/assets/css/perspektiv-styles.css
@@ -112,6 +112,70 @@
     }
 }
 
+/* Hero frame navigation — CTA overlay at bottom of hero banner */
+.hero-frame-nav {
+    grid-area: 1 / 1;
+    align-self: end;
+    display: flex;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: var(--space-md);
+    padding: var(--space-lg) var(--space-xl);
+    z-index: 2;
+}
+
+.hero-frame-link {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 48px;
+    padding: 12px 28px;
+    background-color: var(--primary-navy);
+    color: var(--primary-azure);
+    text-decoration: none;
+    border-radius: var(--radius-sm);
+    font-weight: 600;
+    font-size: 1em;
+    border: 2px solid var(--primary-azure);
+    cursor: pointer;
+    transition: background-color 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.hero-frame-link:hover {
+    background-color: var(--primary-azure);
+    color: var(--primary-navy);
+    transform: translateY(-2px);
+}
+
+/* Dark mode */
+.dark-mode .hero-frame-link {
+    background-color: var(--primary-azure);
+    color: var(--primary-navy);
+    border-color: var(--primary-navy);
+}
+
+.dark-mode .hero-frame-link:hover {
+    background-color: var(--primary-navy);
+    color: var(--primary-azure);
+    border-color: var(--primary-azure);
+}
+
+/* Mobile */
+@media (max-width: 599px) {
+    .hero-frame-nav {
+        padding: var(--space-md);
+        gap: var(--space-sm);
+    }
+
+    .hero-frame-link {
+        flex: 1 1 calc(50% - var(--space-sm));
+        padding: 10px 16px;
+        font-size: 0.9em;
+        min-height: 44px;
+        text-align: center;
+    }
+}
+
 /* Cross-navigation between frames */
 .perspektiv-cross-nav {
     display: flex;


### PR DESCRIPTION
## Changes

### R19 — Perspektiv menu link
Added "Perspektiv" to `_data/navigation.yml` between "Ledelse 60:2" and "Om oss", linking to `/perspektiv/`.

### R21 — Hero CTA overlay
Four frame-perspective buttons (Struktur, Mennesker, Påvirkning, Identitet) as CSS grid overlay at bottom of `/perspektiv/` hero banner. Uses `.hero-frame-nav`/`.hero-frame-link` classes with dark mode support and mobile wrap layout.

### R22 — Frame page back-navigation
Added "↑ Fire perspektiver" cross-navigation link in `_layouts/perspektiv.html`, giving all four frame pages a persistent back-link to the `/perspektiv/` overview article.

### How to test
1. Visit `/perspektiv/` — verify four CTA buttons at bottom of hero banner link to `/struktur/`, `/mennesker/`, `/påvirkning/`, `/identitet/`
2. Hover each button — verify navy↔azure color swap
3. Visit any frame page (e.g., `/struktur/`) — verify "↑ Fire perspektiver" link in cross-navigation section
4. Toggle dark mode — verify CTAs invert correctly
5. Test mobile — verify buttons wrap to 2-column layout

### Pre-merge notes
- No pre-existing build or test failures
- Visual changes: new hero CTA overlay + cross-nav link on frame pages

Closes R19, R21, R22