### PR TITLE
style(article-css): batch visual improvements — article body card bg, card differentiation, spacing, image sizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Hero overflow**: `height: 100vh` caused hero to extend below the first viewport by the header's height (~85px). Now using `calc(100vh - var(--header-height))` so next page content starts at the top of the viewport on first scroll.
 - **Header.css**: Removed stale orphaned CSS (flex-direction/gap/padding declarations outside any media query) that broke the cascade.
 
+### Changed
+- **Article body visual rhythm**: Added `background`, `border-radius`, and `box-shadow` to `.article-body` — whole article content now sits as a white card on the blue-gray page background, reducing the contrast jump between page background and in-article cards.
+- **In-article card backgrounds**: Changed info cards, challenge grid items, flow steps, and blockquotes from `var(--box-background-light)` to `var(--surface-subtle-light)` (light mode) and `var(--surface-subtle-dark)` (dark mode) — creates subtle visual hierarchy within the now-white article body container.
+- **Normalized vertical rhythm**: Reduced h2 margin-top from `var(--space-4xl)` (64px) to `var(--space-3xl)` (48px); tightened p/ul/ol margins from `var(--space-lg)` to `var(--space-md)` for more consistent spacing.
+- **Standalone image sizing**: Increased `max-width` from 600px to 680px for better use of the 800px article container.
+
 ## [1.8.0] - 2026-06-05
 
 ### Added

--- a/assets/css/article.css
+++ b/assets/css/article.css
@@ -1,6 +1,18 @@
-/* Article body — section vertical rhythm */
+/* ========================================
+   Article body — content card on page background
+   ======================================== */
+.article-body {
+    background: var(--box-background-light);
+    border-radius: var(--radius-xl);
+    box-shadow: var(--shadow-sm);
+    padding: var(--space-2xl) var(--space-xl);
+    margin-top: var(--space-lg);
+    margin-bottom: var(--space-lg);
+}
+
+/* Section vertical rhythm inside article body */
 .article-body > h2 {
-    margin-top: var(--space-4xl);
+    margin-top: var(--space-3xl);
 }
 
 .article-body > h2:first-child {
@@ -11,15 +23,25 @@
     margin-top: var(--space-2xl);
 }
 
+.article-body > h3:first-child {
+    margin-top: 0;
+}
+
 .article-body > p,
 .article-body > ul,
 .article-body > ol {
-    margin-bottom: var(--space-lg);
+    margin-bottom: var(--space-md);
 }
 
 .article-body > p:has(> img:only-child) {
     margin-top: var(--space-xl);
     margin-bottom: var(--space-xl);
+}
+
+/* Dark mode — article body */
+.dark-mode .article-body {
+    background: var(--box-background-dark);
+    box-shadow: var(--shadow-sm-dark);
 }
 
 /* Info card list — UL containing h3 subheadings (structural selector) */
@@ -29,7 +51,7 @@ ul:has(> li > h3) {
 }
 
 ul:has(> li > h3) > li {
-    background: var(--box-background-light);
+    background: var(--surface-subtle-light);
     padding: var(--space-lg);
     border-radius: var(--radius-lg);
     margin: 24px 0;
@@ -56,7 +78,7 @@ ul:has(> li > h3) > li img {
 }
 
 .dark-mode ul:has(> li > h3) > li {
-    background: var(--box-background-dark);
+    background: var(--surface-subtle-dark);
 }
 
 /* Section — content sections */
@@ -90,7 +112,7 @@ ul:has(> li > h4) {
 }
 
 ul:has(> li > h4) > li {
-    background: var(--box-background-light);
+    background: var(--surface-subtle-light);
     padding: 20px;
     border-radius: var(--radius-lg);
     transition: transform 0.3s ease, box-shadow 0.3s ease;
@@ -141,7 +163,7 @@ ul:has(> li > h4) > li p {
 /* Standalone section images — paragraph images whose parent is not a list item */
 :not(li) > p:has(> img:only-child) > img:not([class]) {
     width: 100%;
-    max-width: 600px;
+    max-width: 680px;
     display: block;
     margin: 0 auto 24px;
     border-radius: var(--radius-lg);
@@ -310,7 +332,9 @@ ul:has(> li > h4) > li p {
 }
 
 /* Dark mode overrides */
-.dark-mode .info-box,
+.dark-mode .info-box {
+    background: var(--surface-subtle-dark);
+}
 .dark-mode .cta-section {
     background: var(--box-background-dark);
 }
@@ -368,7 +392,7 @@ ul:has(> li > h4) > li p {
 .article-body > ol:has(> li > h3) > li {
     counter-increment: flow-step;
     position: relative;
-    background: var(--box-background-light);
+    background: var(--surface-subtle-light);
     padding: var(--space-lg) var(--space-lg) var(--space-lg) 56px;
     border-radius: var(--radius-lg);
     margin-bottom: 8px;
@@ -411,7 +435,7 @@ ul:has(> li > h4) > li p {
 }
 
 .dark-mode .article-body > ol:has(> li > h3) > li {
-    background: var(--box-background-dark);
+    background: var(--surface-subtle-dark);
 }
 
 /* ========================================
@@ -420,7 +444,7 @@ ul:has(> li > h4) > li p {
 .article-body > blockquote {
     margin: var(--space-xl) 0;
     padding: var(--space-lg) var(--space-xl);
-    background: var(--box-background-light);
+    background: var(--surface-subtle-light);
     border-radius: var(--radius-lg);
     border-left: 4px solid var(--primary-accent);
 }
@@ -437,7 +461,7 @@ ul:has(> li > h4) > li p {
 }
 
 .dark-mode .article-body > blockquote {
-    background: var(--box-background-dark);
+    background: var(--surface-subtle-dark);
 }
 
 /* ========================================


### PR DESCRIPTION
## Changes

CSS-only improvements to article.css — addresses the contrast gap between page background and in-article cards.

### Visual hierarchy fix
- Article body card: .article-body now has white background, border-radius, and subtle shadow — the whole article content sits as a card on the blue-gray page background instead of blending into it
- In-article card differentiation: Info cards (UL+h3), challenge grids (UL+h4), flow steps (OL+h3), and blockquotes now use surface-subtle instead of box-background, creating a subtle but clear visual distinction from the article body background

### Rhythm normalization
- h2 margin-top reduced 64px to 48px
- p/ul/ol margins tightened 24px to 16px
- Added h3:first-child zero-margin guard

### Image sizing
- Standalone article images: max-width 600px to 680px

## How to test
1. Visit any article with hero (e.g. /struktur/, /identitet/, /mennesker/)
2. Verify the article content now looks like a white card with rounded corners on the blue-gray background
3. Check that info cards, challenge grids, flow steps, and blockquotes are slightly differentiated from the article body (subtle off-white tint)
4. Verify dark mode renders consistently
5. Check standalone images are slightly larger

## Pre-merge notes
- CSS only, no template changes needed
- All color variables pre-existed in colors.css — no new CSS variables introduced