### PR TITLE
feat(ledelse-60-2): UI/UX improvements — hero CTA, section headers, stat bridge, sticky bar, timeline steps, footer nav

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -70,14 +70,14 @@ Completed items belong in `CHANGELOG.md` only.
 | R24.8 | **Hero sizing fix** — `height: 100vh` → `calc(100vh - var(--header-height))` so hero doesn't extend below first viewport | Done | — |
 | R24.9 | **Hero image regeneration** — Perspektiv and GRC heroes regenerated as Style 1 (three silhouettes in Nordic landscape, 4K) to match Om Oss/Om Metode/Ledelse 60:2 | Done | — |
 | R24.10 | **Featured nav styling** — "Ledelse 60:2" emphasized in main menu with `.nav-featured` CTA pill | Done | — |
-| U1 | **Hero primary CTA** — add `.product-cta` button in hero overlay linking to booking | Planned | — |
-| U2 | **Plain text CTAs to styled buttons** — convert inline links in article body to `.product-cta` buttons | Planned | U1 |
-| U3 | **Section headers between card grids** — add `<h2>` headings above benefit grid and step grid | Planned | — |
-| U4 | **Visual section separation** — subtle background on step grid section to distinguish from benefits | Planned | U3 |
-| U5 | **Redundant CTA consolidation** — remove duplicate inline CTA from article body bottom | Planned | — |
-| U6 | **Dedicated "Om metodikk" callout** — extract `/metode/` link into info-box callout after process image | Planned | — |
-| U9 | **Footer navigation links** — add site nav links (Perspektiv, GRC, Om oss) to footer | Planned | — |
-| U10 | **Process image alt text** — update T2 process flow alt text to describe the three steps | Planned | — |
-| U11 | **Sticky CTA bar on scroll** — persistent bottom bar with booking button, dismissible, hides on footer overlap | Planned | U1 |
-| U12 | **Hero → card bridge (stat row)** — "4 perspektiver · 60 spørsmål · 2 timer" between hero and benefit grid | Planned | — |
-| U13 | **Step cards as numbered timeline** — horizontal connector line between step cards, prominent numbered badges, mobile vertical timeline | Planned | U4 |
+| U1 | **Hero primary CTA** — add `.product-cta` button in hero overlay linking to booking | Done | — |
+| U2 | **Plain text CTAs to styled buttons** — convert inline links in article body to `.product-cta` buttons | Done | U1 |
+| U3 | **Section headers between card grids** — add `<h2>` headings above benefit grid and step grid | Done | — |
+| U4 | **Visual section separation** — subtle background on step grid section to distinguish from benefits | Done | U3 |
+| U5 | **Redundant CTA consolidation** — remove duplicate inline CTA from article body bottom | Done | — |
+| U6 | **Dedicated "Om metodikk" callout** — extract `/metode/` link into info-box callout after process image | Done | — |
+| U9 | **Footer navigation links** — add site nav links (Perspektiv, GRC, Om oss) to footer | Done | — |
+| U10 | **Process image alt text** — update T2 process flow alt text to describe the three steps | Done | — |
+| U11 | **Sticky CTA bar on scroll** — persistent bottom bar with booking button, dismissible, hides on footer overlap | Done | U1 |
+| U12 | **Hero → card bridge (stat row)** — "4 perspektiver · 60 spørsmål · 2 timer" between hero and benefit grid | Done | — |
+| U13 | **Step cards as numbered timeline** — horizontal connector line between step cards, prominent numbered badges, mobile vertical timeline | Done | U4 |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Ledelse 60:2 UI/UX improvements (U1–U13)**: 10-item backlog completion for `/ledelse-60-2/` product page — hero CTA button (U1), styled inline CTAs (U2), section headers above card grids (U3/U4), removed redundant CTA (U5), metodikk info-box callout (U6), footer nav links (U9), process image alt text (U10), sticky CTA bar with IntersectionObserver (U11), stat bridge row (U12), numbered timeline step cards (U13). New includes: `stat-bridge.html`, `cta-buttons.html`, `metodikk-callout.html`, `sticky-cta.html`. New script: `sticky-cta.js` with generic stagger-parent IntersectionObserver.
+
 ### Fixed
 - **CTA buttons (R24.1)**: Added `cta:` frontmatter to home page and Ledelse 60:2; wired `cta-section.html` include into `home.html` layout
 - **Blank content below hero (R24.2)**: Removed `.animate-on-scroll` scroll-opacity system (IntersectionObserver failure left content at `opacity: 0` permanently). Preserved brand entrance animations and parallax hero effect.

--- a/_includes/cta-buttons.html
+++ b/_includes/cta-buttons.html
@@ -1,0 +1,8 @@
+{% comment %}
+  CTA buttons row — renders inline CTAs as styled .product-cta buttons.
+  Used to convert plain markdown links into actionable buttons.
+{% endcomment %}
+<div class="cta-buttons-row">
+  <a href="https://outlook.office.com/book/ledelse@noexcuse.no/?ismsaljsauthenabled" class="product-cta">Bestill Ledelse 60:2</a>
+  <a href="#hvordan" class="product-cta product-cta--secondary">Hvordan fungerer det? ↓</a>
+</div>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,5 +1,10 @@
 <footer class="footer">
-    <p>&copy; {{ site.data.metadata.impressum.copyright_year }} {{ site.data.metadata.title }},
+    <nav class="footer-nav" aria-label="Sidenavigasjon">
+        <a href="/perspektiv/">Perspektiv</a>
+        <a href="/grc/">GRC</a>
+        <a href="/om-oss/">Om oss</a>
+    </nav>
+    <p class="footer-legal">&copy; {{ site.data.metadata.impressum.copyright_year }} {{ site.data.metadata.title }},
         <a href="https://virksomhet.brreg.no/nb/oppslag/enheter/935794420">{{ site.data.metadata.impressum.orgnr }}</a>,
         <a href="mailto:{{ site.data.metadata.impressum.email }}">{{ site.data.metadata.impressum.email }}</a>.
         Oslo, Norge

--- a/_includes/hero.html
+++ b/_includes/hero.html
@@ -25,6 +25,8 @@
 {% assign hero_alt = include.alt | default: include.image_alt | default: page.hero.alt %}
 {% assign hero_title = include.title | default: page.hero.title %}
 {% assign hero_intro = include.intro | default: page.hero.intro %}
+{% assign hero_cta_text = include.cta_text | default: page.hero.cta_text %}
+{% assign hero_cta_url = include.cta_url | default: page.hero.cta_url %}
 {% assign hero_effect = include.hero_effect | default: page.hero_effect %}
 {% assign hero_simple = include.simple | default: page.hero.simple | default: false %}
 {% assign hero_show_frame_nav = include.show_frame_nav | default: page.hero.show_frame_nav | default: false %}
@@ -49,6 +51,11 @@
     <h1 class="hero-title">{{ hero_title }}</h1>
     {% if hero_intro %}
     <p class="hero-intro">{{ hero_intro }}</p>
+    {% endif %}
+    {% if hero_cta_text and hero_cta_url %}
+    <div class="hero-cta">
+      <a href="{{ hero_cta_url }}" class="product-cta">{{ hero_cta_text }}</a>
+    </div>
     {% endif %}
   </div>
   {% if hero_show_frame_nav %}

--- a/_includes/metodikk-callout.html
+++ b/_includes/metodikk-callout.html
@@ -1,0 +1,5 @@
+<div class="info-box metodikk-callout">
+  <h3>Vitenskapelig fundament</h3>
+  <p>Ledelse 60:2 bygger på etterprøvbare beskrivelser av ledelsesfunksjonen, med utgangspunkt i anerkjent organisasjonsteori.</p>
+  <a href="/metode/" class="metodikk-link">Les mer om metoden →</a>
+</div>

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -4,3 +4,4 @@
 <script src="{{ '/assets/scripts/animations.js' | relative_url }}"></script>
 <script src="{{ '/assets/scripts/navbar.js' | relative_url }}"></script>
 <script src="{{ '/assets/scripts/review-questions.js' | relative_url }}" defer></script>
+<script src="{{ '/assets/scripts/sticky-cta.js' | relative_url }}"></script>

--- a/_includes/stat-bridge.html
+++ b/_includes/stat-bridge.html
@@ -1,0 +1,10 @@
+{% comment %}
+  Stat bridge — single-line stat row between hero and benefit grid.
+  Activated per page via frontmatter:
+    stat_bridge: "4 perspektiver · 60 spørsmål · 2 timer"
+{% endcomment %}
+{% if page.stat_bridge %}
+<div class="stat-bridge animate-on-scroll fade-in-up">
+  <p class="stat-bridge-text">{{ page.stat_bridge }}</p>
+</div>
+{% endif %}

--- a/_includes/step-cards.html
+++ b/_includes/step-cards.html
@@ -3,7 +3,7 @@
   No parameters. Used on the Ledelse 60:2 landing page.
 {% endcomment %}
 
-<div class="card-grid card-grid--steps">
+<div class="card-grid card-grid--steps stagger-parent">
   {% assign steps = site.pages | where: "class", "step" | sort: "step_number" %}
   {% for topic in steps %}
     {% include card.html topic=topic %}

--- a/_includes/sticky-cta.html
+++ b/_includes/sticky-cta.html
@@ -1,0 +1,11 @@
+{% if page.cta %}
+<div id="sticky-cta-bar" class="sticky-cta-bar" role="complementary" aria-label="Bestill samtale">
+  <div class="sticky-cta-inner">
+    <span class="sticky-cta-text">Ledelse 60:2 — 60 spørsmål på 2 timer</span>
+    <div class="sticky-cta-actions">
+      <a href="https://outlook.office.com/book/ledelse@noexcuse.no/?ismsaljsauthenabled" class="product-cta product-cta--small">Bestill samtale</a>
+      <button class="sticky-cta-dismiss" aria-label="Lukk">×</button>
+    </div>
+  </div>
+</div>
+{% endif %}

--- a/_layouts/product.html
+++ b/_layouts/product.html
@@ -3,12 +3,24 @@ layout: default
 ---
 {% include hero.html %}
 
+{% include stat-bridge.html %}
+
 {% if page.show_benefit_cards %}
+<section class="section section--benefit-grid animate-on-scroll fade-in-up">
+  {% if page.benefit_heading %}
+  <h2 class="section-heading">{{ page.benefit_heading }}</h2>
+  {% endif %}
   {% include benefit-cards.html %}
+</section>
 {% endif %}
 
 {% if page.show_step_cards %}
+<section class="section section--step-grid animate-on-scroll fade-in-up">
+  {% if page.step_heading %}
+  <h2 class="section-heading">{{ page.step_heading }}</h2>
+  {% endif %}
   {% include step-cards.html %}
+</section>
 {% endif %}
 
 <div class="section container--wide article-body animate-on-scroll fade-in-up">
@@ -16,3 +28,5 @@ layout: default
 </div>
 
 {% include cta-section.html %}
+
+{% include sticky-cta.html %}

--- a/_pages/ledelse_60-2.md
+++ b/_pages/ledelse_60-2.md
@@ -14,7 +14,12 @@ hero:
   alt: "Ledelse 60:2"
   title: "Ledelse 60:2"
   intro: "Enkel, kunnskapsbasert orientering for ledergruppen. 60 spørsmål på 2 timer."
+  cta_text: "Bestill uforpliktende samtale"
+  cta_url: "https://outlook.office.com/book/ledelse@noexcuse.no/?ismsaljsauthenabled"
 hero_effect: parallax-fade
+stat_bridge: "4 perspektiver · 60 spørsmål · 2 timer"
+benefit_heading: "Fordeler med Ledelse 60:2"
+step_heading: "Slik fungerer det"
 story: "«Ledelse 60:2» er vår tilnærming til å bruke en enkel vitenskapelig metode for å sammenlikne etterprøvbare beskrivelser av ledelsesfunksjonen på et gitt nivå i en virksomhet. Virksomhetens utbytte er å få et bedre beslutningsgrunnlag for å prioritere forbedringer av hvordan ledelsen fungerer, og forbedring av administrative støttefunksjoner for styring og kontroll. Vår motivasjon er å bidra til utviklingen ny kunnskap om nordisk ledelses- og styringspraksis, noe som vi tror vil være viktig for norske virksomheters konkurranseevne."
 image: "assets/images/hero-illustration.webp"
 tags: "#ledelse #orientering #analyse #ledelse60-2"
@@ -56,19 +61,12 @@ cta:
   body: "Vi finner ut om Ledelse 60:2 er rett for dere. Ingen binding, ingen salgspitch — bare en ærlig vurdering."
 ---
 
-[Bestill Ledelse 60:2](https://outlook.office.com/book/ledelse@noexcuse.no/?ismsaljsauthenabled)
-[Hvordan fungerer det? ↓](#hvordan)
+{% include cta-buttons.html %}
 
 ## Historien bak metoden
 
 {{ page.story }}
 
-![Tretrinns prosess for ledelseskartlegging](/assets/images/banners/ledelse-60-2-t2-prosessflyt.webp)
+![Trinn 1: Uforpliktende samtale → Trinn 2: Strukturert intervju → Trinn 3: Rapport og anbefalinger](/assets/images/banners/ledelse-60-2-t2-prosessflyt.webp)
 
-[Les mer om metoden →](/metode/)
-
-## Hvordan jobber dere med bedre ledelse?
-
-Ta en uforpliktende samtale med oss, så finner vi ut om Ledelse 60:2 er rett for dere.
-
-[Velg et tidspunkt](https://outlook.office.com/bookwithme/user/5abd33238853466689e2b7f79805b19d%40noexcuse.no)
+{% include metodikk-callout.html %}

--- a/assets/css/footer.css
+++ b/assets/css/footer.css
@@ -4,3 +4,41 @@
     text-align: center;
     padding: 20px;
 }
+
+.footer-nav {
+    display: flex;
+    justify-content: center;
+    gap: var(--space-lg);
+    margin-bottom: var(--space-md);
+    flex-wrap: wrap;
+}
+
+.footer-nav a {
+    color: var(--footer-text-light);
+    text-decoration: none;
+    font-weight: 600;
+    font-size: 0.95em;
+    padding: 8px 4px;
+    min-height: 44px;
+    display: inline-flex;
+    align-items: center;
+}
+
+.footer-nav a:hover {
+    text-decoration: underline;
+}
+
+.footer-legal {
+    font-size: 0.85em;
+    opacity: 0.7;
+    margin: 0;
+}
+
+.dark-mode .footer {
+    background-color: var(--footer-background-dark);
+    color: var(--footer-text-dark);
+}
+
+.dark-mode .footer-nav a {
+    color: var(--footer-text-dark);
+}

--- a/assets/css/products.css
+++ b/assets/css/products.css
@@ -2,6 +2,293 @@
     /* Width/spacing via .section.container */
 }
 
+/* CTA buttons row — flex container for inline CTAs */
+.cta-buttons-row {
+    display: flex;
+    gap: var(--space-md);
+    flex-wrap: wrap;
+    margin-bottom: var(--space-lg);
+}
+
+/* Hero CTA button */
+.hero-cta {
+    margin-top: var(--space-lg);
+}
+
+/* Section headings above card grids */
+.section-heading {
+    text-align: center;
+    font-size: 2em;
+    margin-top: var(--space-4xl);
+    margin-bottom: var(--space-lg);
+}
+
+.section-heading:first-child {
+    margin-top: 0;
+}
+
+/* Benefit grid section */
+.section--benefit-grid {
+    max-width: var(--content-wide);
+    margin: 0 auto;
+    padding: var(--space-2xl) var(--space-md);
+}
+
+/* Step grid section with subtle background */
+.section--step-grid {
+    max-width: var(--content-wide);
+    margin: 0 auto;
+    padding: var(--space-4xl) var(--space-md);
+    background: var(--surface-subtle-light);
+    border-radius: var(--radius-xl);
+}
+
+.dark-mode .section--step-grid {
+    background: var(--surface-subtle-dark);
+}
+
+/* ========================================
+   Step timeline — numbered connector between step cards
+   ======================================== */
+
+/* Horizontal timeline layout (desktop) */
+.section--step-grid .card-grid--steps {
+    display: flex;
+    flex-direction: row;
+    gap: 0;
+    counter-reset: step-counter;
+    align-items: stretch;
+    position: relative;
+}
+
+.section--step-grid .card-grid--steps .card--numbered {
+    flex: 1;
+    counter-increment: step-counter;
+    position: relative;
+    margin: 0;
+    padding-top: var(--space-4xl);
+}
+
+/* Connector line between step cards */
+.section--step-grid .card-grid--steps::before {
+    content: "";
+    position: absolute;
+    top: calc(var(--space-lg) + 24px);
+    left: 25%;
+    right: 25%;
+    height: 0;
+    border-top: 2px dashed var(--border-color-light);
+    z-index: 0;
+}
+
+/* Numbered badge — large, circular, accent-colored */
+.section--step-grid .card-grid--steps .card--numbered::before {
+    content: counter(step-counter);
+    position: absolute;
+    top: var(--space-lg);
+    left: 50%;
+    transform: translateX(-50%);
+    width: 48px;
+    height: 48px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--primary-accent);
+    color: var(--primary-accent-contrast);
+    border-radius: 50%;
+    font-weight: 700;
+    font-size: 1.3em;
+    z-index: 1;
+}
+
+/* Stagger animation for step cards */
+.section--step-grid .card-grid--steps .card--numbered {
+    opacity: 0;
+    transform: translateY(24px);
+    transition: opacity 0.5s ease, transform 0.5s ease;
+}
+
+.section--step-grid .card-grid--steps .card--numbered:nth-child(1) { transition-delay: 0.0s; }
+.section--step-grid .card-grid--steps .card--numbered:nth-child(2) { transition-delay: 0.15s; }
+.section--step-grid .card-grid--steps .card--numbered:nth-child(3) { transition-delay: 0.3s; }
+
+/* Visible state for stagger animation (toggled by IntersectionObserver via stagger-parent) */
+.stagger-parent.is-visible .card--numbered {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+/* Dark mode connector */
+.dark-mode .section--step-grid .card-grid--steps::before {
+    border-top-color: var(--border-color-dark);
+}
+
+.dark-mode .section--step-grid .card-grid--steps .card--numbered:not(:last-child)::after {
+    border-left-color: var(--border-color-dark);
+}
+
+/* Mobile — vertical timeline */
+@media (max-width: 599px) {
+    .section--step-grid .card-grid--steps {
+        flex-direction: column;
+    }
+
+    .section--step-grid .card-grid--steps .card--numbered {
+        padding-top: 0;
+        padding-left: var(--space-4xl);
+    }
+
+    .section--step-grid .card-grid--steps .card--numbered::before {
+        top: var(--space-lg);
+        left: 0;
+        transform: none;
+        width: 36px;
+        height: 36px;
+        font-size: 1.1em;
+    }
+
+    /* Vertical connector line on the left (card-level, not grid-level) */
+    .section--step-grid .card-grid--steps .card--numbered:not(:last-child)::after {
+        top: calc(var(--space-lg) + 36px);
+        left: 18px;
+        right: auto;
+        width: 0;
+        height: calc(100% - var(--space-lg) - 24px);
+        border-top: none;
+        border-left: 2px dashed var(--border-color-light);
+    }
+}
+
+/* Stat bridge — hero → card grid connector */
+.stat-bridge {
+    text-align: center;
+    padding: var(--space-xl) var(--space-md);
+    max-width: var(--content-wide);
+    margin: 0 auto;
+}
+
+.stat-bridge-text {
+    font-size: 1.15em;
+    font-weight: 600;
+    letter-spacing: 0.03em;
+    color: var(--primary-accent-contrast);
+    opacity: 0.75;
+    margin: 0;
+}
+
+.dark-mode .stat-bridge-text {
+    opacity: 0.6;
+}
+
+/* ========================================
+   Sticky CTA bar
+   ======================================== */
+.sticky-cta-bar {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    z-index: 200;
+    background: var(--box-background-light);
+    border-top: 1px solid var(--border-color-light);
+    box-shadow: 0 -4px 12px rgba(0, 0, 0, 0.08);
+    transform: translateY(100%);
+    transition: transform 0.3s ease;
+    padding: var(--space-sm) var(--space-md);
+}
+
+.sticky-cta-bar.is-visible {
+    transform: translateY(0);
+}
+
+.sticky-cta-inner {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-md);
+    max-width: var(--content-max);
+    margin: 0 auto;
+}
+
+.sticky-cta-text {
+    font-weight: 600;
+    font-size: 0.95em;
+    color: var(--text-color-light);
+    white-space: nowrap;
+}
+
+.sticky-cta-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+    flex-shrink: 0;
+}
+
+.product-cta--small {
+    padding: 10px 20px;
+    font-size: 0.9em;
+    min-height: 44px;
+}
+
+.sticky-cta-dismiss {
+    width: 36px;
+    height: 36px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: none;
+    border: none;
+    font-size: 1.4em;
+    cursor: pointer;
+    color: var(--text-color-light);
+    opacity: 0.5;
+    min-height: 44px;
+    min-width: 44px;
+    padding: 0;
+    line-height: 1;
+    transition: opacity 0.2s ease;
+}
+
+.sticky-cta-dismiss:hover {
+    opacity: 1;
+}
+
+.dark-mode .sticky-cta-bar {
+    background: var(--box-background-dark);
+    border-top-color: var(--border-color-dark);
+    box-shadow: 0 -4px 12px rgba(0, 0, 0, 0.3);
+}
+
+.dark-mode .sticky-cta-text {
+    color: var(--text-color-dark);
+}
+
+.dark-mode .sticky-cta-dismiss {
+    color: var(--text-color-dark);
+}
+
+@media (max-width: 599px) {
+    .sticky-cta-inner {
+        flex-direction: column;
+        align-items: stretch;
+        gap: var(--space-xs);
+    }
+
+    .sticky-cta-text {
+        font-size: 0.85em;
+        text-align: center;
+        white-space: normal;
+    }
+
+    .sticky-cta-actions {
+        justify-content: center;
+    }
+
+    .sticky-cta-bar {
+        padding: var(--space-xs) var(--space-sm);
+    }
+}
+
 .product-hero {
     display: flex;
     align-items: center;

--- a/assets/scripts/sticky-cta.js
+++ b/assets/scripts/sticky-cta.js
@@ -1,0 +1,90 @@
+(function() {
+    'use strict';
+
+    /* ===== Sticky CTA Bar ===== */
+    var stickyBar = document.getElementById('sticky-cta-bar');
+    var hero = document.querySelector('.hero');
+
+    if (stickyBar && hero) {
+        var heroBottom = hero.offsetTop + hero.offsetHeight;
+        var ticking = false;
+
+        // Check for prior dismissal in this session
+        if (sessionStorage.getItem('sticky-cta-dismissed') === 'true') {
+            stickyBar.style.display = 'none';
+        } else {
+            function updateStickyBar() {
+                var scrollY = window.scrollY;
+                if (scrollY > heroBottom - 100) {
+                    stickyBar.classList.add('is-visible');
+                } else {
+                    stickyBar.classList.remove('is-visible');
+                }
+            }
+
+            function onScroll() {
+                if (!ticking) {
+                    window.requestAnimationFrame(function() {
+                        updateStickyBar();
+                        ticking = false;
+                    });
+                    ticking = true;
+                }
+            }
+
+            var reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
+            if (!reduceMotion.matches) {
+                window.addEventListener('scroll', onScroll, { passive: true });
+            }
+
+            reduceMotion.addEventListener('change', function(e) {
+                if (e.matches) {
+                    window.removeEventListener('scroll', onScroll);
+                    stickyBar.classList.remove('is-visible');
+                } else {
+                    window.addEventListener('scroll', onScroll, { passive: true });
+                }
+            });
+
+            // Dismiss button
+            var dismissBtn = stickyBar.querySelector('.sticky-cta-dismiss');
+            if (dismissBtn) {
+                dismissBtn.addEventListener('click', function() {
+                    stickyBar.classList.remove('is-visible');
+                    stickyBar.style.display = 'none';
+                    sessionStorage.setItem('sticky-cta-dismissed', 'true');
+                });
+            }
+
+            // IntersectionObserver for final CTA section — hide bar when cta-section is visible
+            var ctaSection = document.querySelector('.cta-section');
+            if (ctaSection && 'IntersectionObserver' in window) {
+                var ctaObserver = new IntersectionObserver(function(entries) {
+                    entries.forEach(function(entry) {
+                        if (entry.isIntersecting) {
+                            stickyBar.classList.remove('is-visible');
+                        }
+                    });
+                }, { rootMargin: '0px' });
+                ctaObserver.observe(ctaSection);
+            }
+        }
+    }
+
+    /* ===== Stagger Animation Observer ===== */
+    var staggerParents = document.querySelectorAll('.stagger-parent');
+    if (staggerParents.length > 0 && 'IntersectionObserver' in window) {
+        var staggerObserver = new IntersectionObserver(function(entries) {
+            entries.forEach(function(entry) {
+                if (entry.isIntersecting) {
+                    entry.target.classList.add('is-visible');
+                    staggerObserver.unobserve(entry.target);
+                }
+            });
+        }, { threshold: 0.15 });
+
+        staggerParents.forEach(function(el) {
+            staggerObserver.observe(el);
+        });
+    }
+})();


### PR DESCRIPTION
## Summary

Completes all 10 backlog items (U1–U13) from the [Ledelse 60:2 UI/UX spec](.specs/ledelse-60-2-ui-ux/README.md).

### Changes

| Backlog | Description | Files |
|---------|-------------|-------|
| U1 | Hero CTA button in overlay | frontmatter + hero.html + CSS |
| U2 | Inline CTAs as styled buttons | cta-buttons.html include |
| U3+U4 | Section headers + subtle step section bg | layout + CSS |
| U5 | Remove redundant bottom CTA | page content |
| U6 | /metode/ link → info-box callout | metodikk-callout.html |
| U9 | Footer nav links (Perspektiv, GRC, Om oss) | footer.html + CSS |
| U10 | Process image alt text (3 steps) | page content |
| U11 | Sticky CTA bar with JS | sticky-cta.html + JS + CSS |
| U12 | Stat bridge row | stat-bridge.html + layout + CSS |
| U13 | Numbered timeline step cards | CSS only (timeline + connector) |

### New files
- `_includes/stat-bridge.html` — frontmatter-driven stat row
- `_includes/cta-buttons.html` — styled CTA button row
- `_includes/metodikk-callout.html` — info-box for metodikklink
- `_includes/sticky-cta.html` — fixed bottom CTA bar
- `assets/scripts/sticky-cta.js` — IntersectionObserver for sticky bar + stagger-parent animation

### Commit
2f1742f

Co-authored-by: Rasmus S. Olsen <rasmus@noexcuse.no>