### PR TITLE
feat(pages): add step page content and fix broken links

### DIFF
--- a/_pages/step-interview.md
+++ b/_pages/step-interview.md
@@ -11,3 +11,33 @@ url: "/intervju/"
 ---
 
 ![Strukturert intervju](/assets/images/banners/intervju-t3-intervju.webp)
+
+Dette er kjernen i Ledelse 60:2. Et strukturert intervju der ledergruppen sammen reflekterer over 60 spørsmål fordelt på fire rammer. Selve samtalen er like verdifull som analysen.
+
+## Hva skjer?
+
+- Et strukturert intervju på to timer med inntil fem ledere
+- 60 diagnostiske spørsmål fordelt på fire rammer: struktur, mennesker, påvirkning og identitet
+- Dere svarer på spørsmålene og reflekterer underveis
+- Vi noterer og observerer uten å avbryte refleksjonene deres
+
+## Hvorfor dette er viktig
+
+Refleksjonen dere gjør underveis gir øyeblikkelig innsikt i hvordan ledergruppen fungerer. Mange oppdager ting de ikke hadde satt ord på tidligere, rett og slett fordi de aldri har tatt seg tid til å stoppe opp og spørre.
+
+De fire rammene (struktur, mennesker, påvirkning og identitet) sikrer at dere ser på ledelsen fra alle vinkler, ikke bare den mest praktiske eller kjente.
+
+## Hva du trenger
+
+- To timer uforstyrret tid
+- Inntil fem ledere fra organisasjonen
+- Et møterom med plass til alle, gjerne med projektor eller skjerm
+
+## Neste steg
+
+Etter intervjuet setter vi oss ned og analyserer svarene. Innen en uke har dere en konkret rapport med anbefalinger.
+
+[Se rapport og anbefalinger →](/rapport/)
+
+**Les mer:** [Om metoden](/metode/) | [Ledelse 60:2](/ledelse-60-2/)
+

--- a/_pages/step-report.md
+++ b/_pages/step-report.md
@@ -11,3 +11,32 @@ url: "/rapport/"
 ---
 
 ![Rapport og anbefalinger](/assets/images/banners/rapport-t3-rapport.webp)
+
+En tydelig rapport som viser hvor dere står sammenliknet med typisk bestepraksis. Ikke generisk teoristoff, men konkrete funn fra intervjuet med ledergruppen deres.
+
+## Hva skjer?
+
+- Vi analyserer svarene fra intervjuet og sammenlikner med referansepraksis
+- Rapporten peker på styrker og forbedringsmuligheter innenfor hver av de fire rammene
+- Dere får konkrete anbefalinger tilpasset deres situasjon
+- Rapporten leveres normalt innen en uke etter intervjuet
+
+## Hvorfor dette er viktig
+
+En ekstern vurdering gir et perspektiv det er vanskelig å få internt. Rapporten fungerer som et felles referansepunkt for ledergruppen, og gir dere noe konkret å jobbe videre med.
+
+Anbefalingene er praktiske og konkrete. Ikke store omstillingsprosjekter, men enkle grep som gjør en forskjell for akkurat deres ledergruppe.
+
+## Hva du trenger
+
+- Ingenting annet enn tiden dere allerede har brukt på samtale og intervju
+- Rapporten leveres digitalt, og dere bestemmer selv om dere vil ta den videre internt eller sammen med oss
+
+## Neste steg
+
+Er dere klare for å komme i gang? Da booker vi inn en uforpliktende samtale.
+
+[Bestill uforpliktende samtale →](/samtale/)
+
+**Les mer:** [Om metoden](/metode/) | [Ledelse 60:2](/ledelse-60-2/)
+

--- a/_pages/step-talk.md
+++ b/_pages/step-talk.md
@@ -11,3 +11,33 @@ url: "/samtale/"
 ---
 
 ![Uforpliktende samtale](/assets/images/banners/samtale-t3-samtale.webp)
+
+En uforpliktende prat for å bli kjent med hverandre og metoden. Ingen kontrakter, ingen forpliktelser. Bare en ærlig samtale om situasjonen deres.
+
+## Hva skjer?
+
+- Et videomøte på 30–45 minutter
+- Du beskriver situasjonen, utfordringene og forventningene deres
+- Vi gir en umiddelbar vurdering av om Ledelse 60:2 passer for dere
+- Dere får anledning til å stille spørsmål om metoden og prosessen
+
+## Hvorfor dette er viktig
+
+Mange ledergrupper hopper rett på løsninger før de har stoppet opp og vurdert om problemet er riktig forstått. Denne samtalen gir dere en sjanse til å kjenne på om tilnærmingen passer, uten å bruke tid eller penger på noe som ikke treffer.
+
+Vi har ingen interesse av å presse dere inn i en prosess som ikke passer. Er ikke Ledelse 60:2 rett for dere, sier vi ifra. Da sparer begge parter tid.
+
+## Hva du trenger
+
+- 30–45 minutter til en videosamtale
+- En leder som kan gi et ærlig bilde av situasjonen
+- Et rolig sted med god nok internettforbindelse
+
+## Neste steg
+
+Høres dette riktig ut? Da booker vi inn et strukturert intervju med ledergruppen.
+
+[Bestill intervju →](/intervju/)
+
+**Les mer:** [Om metoden](/metode/) | [Ledelse 60:2](/ledelse-60-2/)
+


### PR DESCRIPTION
## What
- **R25**: Added substantive body text to /samtale/, /intervju/, /rapport/ step pages
- **R31**: Fixed broken link /om-metode/ → /metode/ in cross-link footers

## How to test
1. Navigate to /samtale/, /intervju/, /rapport/ — each page now has descriptive sections (Hva skjer, Hvorfor dette er viktig, Hva du trenger, Neste steg)
2. Verify the "Om metoden" link in the footer of each page goes to /metode/ (not /om-metode/)

## Pre-merge notes
- No CI available locally (no Ruby/bundle for Jekyll build)
- Lint not run (no CI hooks configured)