### PR TITLE
fix(a11y): add descriptive alt text to 88 markdown images across 13 pages

### DIFF
--- a/_pages/identitet.md
+++ b/_pages/identitet.md
@@ -98,22 +98,22 @@ En moden ledelse forstår at risiko ikke er noe man setter på lista en gang i �
 
 ![Illustrasjon av vanlige identitetsrelaterte utfordringer](/assets/images/banners/illustrasjon-identitet-utfordringer.webp)
 
-*   ![](/assets/images/banners/identitet-t4-empty-values.webp "")
+*   ![Abstrakt illustrasjon av tomme verdier som ikke er forankret](/assets/images/banners/identitet-t4-empty-values.webp "")
 
     #### Tomme verdier
 
     Verdier som ikke reflekterer faktisk atferd. Konsulentlede verdiprogrammer som aldri ble forankret.
-*   ![](/assets/images/banners/identitet-t4-individual-dominance.webp "")
+*   ![Abstrakt illustrasjon av individuell dominans i organisasjonskultur](/assets/images/banners/identitet-t4-individual-dominance.webp "")
 
     #### Individuell dominans
 
     En kultur preget av «stjerneledere» og individualisme. Belønning av «helt-innsats» heller enn samarbeid. Individualistisk tankegang som demper kollektiv vekst.
-*   ![](/assets/images/banners/identitet-t4-storylessness.webp "")
+*   ![Abstrakt illustrasjon av historieløs organisasjon uten fortellinger](/assets/images/banners/identitet-t4-storylessness.webp "")
 
     #### Historieløshet
 
     En organisasjon uten fortellinger — nye folk får ingen kontekst. Kulturen er usynlig fordi den aldri er blitt eksplisitt.
-*   ![](/assets/images/banners/identitet-t4-change-fatigue.webp "")
+*   ![Abstrakt illustrasjon av forandringstretthet i organisasjonen](/assets/images/banners/identitet-t4-change-fatigue.webp "")
 
     #### Forandringstretthet
 

--- a/_pages/ledelse_forankring.md
+++ b/_pages/ledelse_forankring.md
@@ -83,7 +83,7 @@ Daniel Kahneman og Amos Tversky dokumenterte hvordan menneskelig tenkning system
 
 ## De fire dimensjonene av beslutningstaking
 
-*   ![](/assets/images/banners/forankring-t3-formal-vs-real-power.webp)
+*   ![Abstrakt illustrasjon av gapet mellom formell og reell beslutningsmakt](/assets/images/banners/forankring-t3-formal-vs-real-power.webp)
 
     ### 1. Formell vs. reell beslutningsmakt
 
@@ -93,7 +93,7 @@ Daniel Kahneman og Amos Tversky dokumenterte hvordan menneskelig tenkning system
 
     **Tegn på skjev makt:** De med formell autoritet dominerer. Ekspertise ignoreres når den kommer fra feil person. Beslutninger tas bak lukkede dører.
 
-*   ![](/assets/images/banners/forankring-t3-interests.webp)
+*   ![Abstrakt illustrasjon av interesser som byggesteiner for forankring](/assets/images/banners/forankring-t3-interests.webp)
 
     ### 2. Interesser som forankringens byggesteiner
 
@@ -105,7 +105,7 @@ Daniel Kahneman og Amos Tversky dokumenterte hvordan menneskelig tenkning system
 
     **Tegn på manglende interessekartlegging:** Initiativer presenteres som «åpenbart riktige» — og møtes med taus motstand.
 
-*   ![](/assets/images/banners/forankring-t3-bias.webp)
+*   ![Abstrakt illustrasjon av kognitiv bias som påvirker beslutningsvalg](/assets/images/banners/forankring-t3-bias.webp)
 
     ### 3. Kognitiv bias som påvirker valg
 
@@ -115,7 +115,7 @@ Daniel Kahneman og Amos Tversky dokumenterte hvordan menneskelig tenkning system
 
     **Tegn på bias-blindhet:** Beslutninger tas av enkeltpersoner. Ingen utfordrer premissene. Suksess tillegges egen dyktighet, feil tillegges eksterne forhold.
 
-*   ![](/assets/images/banners/forankring-t3-conflict.webp)
+*   ![Abstrakt illustrasjon av konflikt og forhandling i beslutningsprosesser](/assets/images/banners/forankring-t3-conflict.webp)
 
     ### 4. Konflikt og forhandling
 
@@ -125,7 +125,7 @@ Daniel Kahneman og Amos Tversky dokumenterte hvordan menneskelig tenkning system
 
     **Tegn på dysfunksjonell konflikt:** Konflikter begraves til de eskalerer. Beslutninger omgjøres etter møter. «Enighet» maskerer undertrykt uenighet.
 
-*   ![](/assets/images/banners/forankring-t3-culture.webp)
+*   ![Abstrakt illustrasjon av beslutningskultur og groupthink](/assets/images/banners/forankring-t3-culture.webp)
 
     ### 5. Beslutningskultur
 
@@ -137,22 +137,22 @@ Daniel Kahneman og Amos Tversky dokumenterte hvordan menneskelig tenkning system
 
 ## Vanlige beslutningsfallgruber
 
-*   ![](/assets/images/banners/forankring-t4-confirmation.webp "")
+*   ![Abstrakt illustrasjon av bekreftelsesbias](/assets/images/banners/forankring-t4-confirmation.webp "")
 
     #### Bekreftelsesbias
 
     Vi søker informasjon som støtter det vi allerede tror, og ignorerer det som utfordrer det. Beslutninger tas basert på ønsketenkning.
-*   ![](/assets/images/banners/forankring-t4-anchoring.webp "")
+*   ![Abstrakt illustrasjon av ankerfeste som beslutningsfelle](/assets/images/banners/forankring-t4-anchoring.webp "")
 
     #### Ankerfeste
 
     Det første tallet eller forslaget som presenteres får uforholdsmessig stor innflytelse. «Vi har alltid gjort det sånn» blir argumentet.
-*   ![](/assets/images/banners/forankring-t4-sunk-cost.webp "")
+*   ![Abstrakt illustrasjon av sunk cost-fallacy](/assets/images/banners/forankring-t4-sunk-cost.webp "")
 
     #### Sunk cost-fallacy
 
     Vi fortsetter med feil investeringer fordi vi allerede har brukt så mye. Å kutte tap oppfattes som å innrømme feil.
-*   ![](/assets/images/banners/forankring-t4-overconfidence.webp "")
+*   ![Abstrakt illustrasjon av overdreven selvtillit som beslutningsfelle](/assets/images/banners/forankring-t4-overconfidence.webp "")
 
     #### Overdreven selvtillit
 

--- a/_pages/ledelse_generativ-ki.md
+++ b/_pages/ledelse_generativ-ki.md
@@ -69,25 +69,25 @@ Den som kan formulere gode spørsmål, vurdere svar kritisk, og integrere KI i m
 
 ## Hva KI-ledelse faktisk betyr
 
-*   ![](/assets/images/banners/genki-t3-question-formulation.webp)
+*   ![Abstrakt illustrasjon av kompetansen å formulere gode spørsmål til KI](/assets/images/banners/genki-t3-question-formulation.webp)
 
     ### 1. Formulere gode spørsmål
 
     Vage spørsmål gir vage svar. En leder som mestrer KI, lærer seg å presisere intensjon — ikke bare skrive «skriv en e-post». Den som kan definere hva som faktisk trengs, får resultater den andre ikke engang ser.
 
-*   ![](/assets/images/banners/genki-t3-critical-evaluation.webp)
+*   ![Abstrakt illustrasjon av kompetansen å vurdere KI-utdata kritisk](/assets/images/banners/genki-t3-critical-evaluation.webp)
 
     ### 2. Vurdere utdata kritisk
 
     KI hallusinerer, kopierer bias, og opererer uten kontekst. En god KI-leder antar aldri at svaret er riktig — den tester det mot virkeligheten. Kalibrering er kontinuerlig: stemmer modellens selvtillit med faktisk kvalitet?
 
-*   ![](/assets/images/banners/genki-t3-human-integration.webp)
+*   ![Abstrakt illustrasjon av å integrere KI i menneskelige arbeidsprosesser](/assets/images/banners/genki-t3-human-integration.webp)
 
     ### 3. Integrere KI i menneskelige prosesser
 
     KI produserer innhold; mennesker produserer verdi. Gapet mellom dem må lukkes med menneskelig dømmekraft. Ledere må bygge arbeidsflyter der KI-assistert arbeid alltid passerer gjennom menneskelig evaluering før det når kunden.
 
-*   ![](/assets/images/banners/genki-t3-accountability.webp)
+*   ![Abstrakt illustrasjon av ansvarlighet ved KI-bruk](/assets/images/banners/genki-t3-accountability.webp)
 
     ### 4. Opprettholde ansvarlighet
 
@@ -95,25 +95,25 @@ Den som kan formulere gode spørsmål, vurdere svar kritisk, og integrere KI i m
 
 ## Tenkeevner som skiller effektive KI-brukere fra passive
 
-*   ![](/assets/images/banners/genki-t3-epistemic-humility.webp)
+*   ![Abstrakt illustrasjon av epistemisk ydmykhet i KI-bruk](/assets/images/banners/genki-t3-epistemic-humility.webp)
 
     ### Epistemisk ydmykhet
 
     Vite hva du ikke vet. KI kan få deg til å føle deg smartere enn du er. Den som tror modellen vet mer enn den faktisk gjør, tar dårlige beslutninger.
 
-*   ![](/assets/images/banners/genki-t3-precision.webp)
+*   ![Abstrakt illustrasjon av presisjon av intensjon i KI-kommunikasjon](/assets/images/banners/genki-t3-precision.webp)
 
     ### Presisjon av intensjon
 
     Vage spørsmål gir vage svar. KI-ledere må lære seg å presisere hva de faktisk trenger, ikke bare beskrive det de tror de vil ha.
 
-*   ![](/assets/images/banners/genki-t3-iteration.webp)
+*   ![Abstrakt illustrasjon av iterativ forbedring i KI-dialog](/assets/images/banners/genki-t3-iteration.webp)
 
     ### Iterativ forbedring
 
     KI-interaksjon er dialog, ikke én-klikk. De beste resultatene kommer fra å stille oppfølgingsspørsmål, utfordre premisser, og gradvis presisere fram mot det som faktisk trengs.
 
-*   ![](/assets/images/banners/genki-t3-calibration.webp)
+*   ![Abstrakt illustrasjon av kalibrering — teste KI-selvtillit mot virkelighet](/assets/images/banners/genki-t3-calibration.webp)
 
     ### Kalibrering
 
@@ -152,22 +152,22 @@ Den som kontrollerer KI, former retningen. Det er et spørsmål om [makt](/makt/
 
 ## Røde flagg
 
-*   ![](/assets/images/banners/genki-t4-no-human-review.webp "")
+*   ![Abstrakt illustrasjon av rødt flagg: KI uten menneskelig review](/assets/images/banners/genki-t4-no-human-review.webp "")
 
     #### KI-implementert uten menneskelig review
 
     Output fra modellen går direkte til kunde eller beslutning uten at et menneske har sett på det.
-*   ![](/assets/images/banners/genki-t4-ki-said-it.webp "")
+*   ![Abstrakt illustrasjon av rødt flagg: «KI sa det» som begrunnelse](/assets/images/banners/genki-t4-ki-said-it.webp "")
 
     #### «KI sa det»
 
     Brukt som begrunnelse for beslutninger. Modellen blir autoritet, ikke verktøy.
-*   ![](/assets/images/banners/genki-t4-quantity-over-quality.webp "")
+*   ![Abstrakt illustrasjon av rødt flagg: kvantitet over kvalitet i KI-bruk](/assets/images/banners/genki-t4-quantity-over-quality.webp "")
 
     #### Kvantitet over kvalitet
 
     Organisasjonen måler hvor mye KI som brukes, ikke om det faktisk fungerer. Høyere volum maskerer lavere verdi.
-*   ![](/assets/images/banners/genki-t4-faster-less-accurate.webp "")
+*   ![Abstrakt illustrasjon av rødt flagg: raskere men mindre nøyaktig med KI](/assets/images/banners/genki-t4-faster-less-accurate.webp "")
 
     #### Raskere, men mindre nøyaktig
 

--- a/_pages/ledelse_perspektiv.md
+++ b/_pages/ledelse_perspektiv.md
@@ -101,25 +101,25 @@ Denne artikkelen handler ikke om de fire rammeverkene — hvert av dem har sin e
 
 Enrammefellen er ikke at du har et favorittperspektiv. Det har alle. Fellen er at du bruker det samme perspektivet på alle problemer, uavhengig av hva situasjonen krever.
 
-*   ![](/assets/images/banners/perspektiv-t3-strukturfellen.webp)
+*   ![Abstrakt illustrasjon av strukturfellen — når struktur blir tvangstrøye](/assets/images/banners/perspektiv-t3-strukturfellen.webp)
 
     ### Når struktur blir tvangstrøye
 
     En leder som alltid starter med omorganisering, nye prosesser og rapporteringslinjer, kan skape kaos i en organisasjon som egentlig trenger kulturell trygghet. Strukturelle løsninger på menneskelige problemer skaper mer byråkrati uten å løse grunnårsaken.
 
-*   ![](/assets/images/banners/perspektiv-t3-menneskefellen.webp)
+*   ![Abstrakt illustrasjon av menneskefellen — når mennesker blir overfladisk](/assets/images/banners/perspektiv-t3-menneskefellen.webp)
 
     ### Når mennesker blir overfladisk
 
     En leder som alltid spør «hvordan har du det?» og aldri tar upopulære beslutninger, kan skape en hyggelig kultur som ikke presterer. Menneskerettede løsninger på strukturelle problemer gir gode samtaler, men ingen endring.
 
-*   ![](/assets/images/banners/perspektiv-t3-politisk-felle.webp)
+*   ![Abstrakt illustrasjon av politisk felle — når politikk blir kynisme](/assets/images/banners/perspektiv-t3-politisk-felle.webp)
 
     ### Når politikk blir kynisme
 
     En leder som alltid analyserer maktforhold og aldri handler, kan lamme organisasjonen. Politisk analyse uten strukturell gjennomføring blir spill og posisjonering — ikke ledelse.
 
-*   ![](/assets/images/banners/perspektiv-t3-symbolfellen.webp)
+*   ![Abstrakt illustrasjon av symbolfellen — når symbolikk blir tom](/assets/images/banners/perspektiv-t3-symbolfellen.webp)
 
     ### Når symbolikk blir tom
 

--- a/_pages/ledelse_tillit.md
+++ b/_pages/ledelse_tillit.md
@@ -114,7 +114,7 @@ Robert Greenleaf introduserte begrepet «servant leadership» i 1970. Han argume
 
 ## De fire pilarene for tillitsbasert ledelse
 
-*   ![](/assets/images/banners/tillit-t3-psychological-safety.webp)
+*   ![Abstrakt illustrasjon av psykologisk trygghet som tillitspilar](/assets/images/banners/tillit-t3-psychological-safety.webp)
 
     ### 1. Psykologisk trygghet
 
@@ -124,7 +124,7 @@ Robert Greenleaf introduserte begrepet «servant leadership» i 1970. Han argume
 
     **Tegn på lav psykologisk trygghet:** Informasjon holdes tilbake. Kritikk gis aldri direkte. Folk sier «det er bare å vente og se» heller enn å utfordre.
 
-*   ![](/assets/images/banners/tillit-t3-servant-leadership.webp)
+*   ![Abstrakt illustrasjon av tjenende lederskap som tillitspilar](/assets/images/banners/tillit-t3-servant-leadership.webp)
 
     ### 2. Tjenende lederskap
 
@@ -134,7 +134,7 @@ Robert Greenleaf introduserte begrepet «servant leadership» i 1970. Han argume
 
     **Tegn på selv-opptatt lederskap:** Beslutninger tas for å styrke egen posisjon. Suksesser tillegges egen innsats. Feedback gis sjelden eller aldri.
 
-*   ![](/assets/images/banners/tillit-t3-trust-system.webp)
+*   ![Abstrakt illustrasjon av tillit som system](/assets/images/banners/tillit-t3-trust-system.webp)
 
     ### 3. Tillit som system
 
@@ -144,7 +144,7 @@ Robert Greenleaf introduserte begrepet «servant leadership» i 1970. Han argume
 
     **Tegn på tillitsbrist:** Løfter brytes uten forklaring. Folk dekker seg bak prosedyrer. «Det var ikke min avdeling» blir unnskyldningen.
 
-*   ![](/assets/images/banners/tillit-t3-autonomy.webp)
+*   ![Abstrakt illustrasjon av autonomi som tillitsdriver](/assets/images/banners/tillit-t3-autonomy.webp)
 
     ### 4. Autonomi som tillitsdriver
 
@@ -164,22 +164,22 @@ Tillit bygges ikke av gode intensjoner. Det bygges av konsekvent atferd over tid
 
 ## Vanlige tillitsutfordringer i norske organisasjoner
 
-*   ![](/assets/images/banners/tillit-t4-hierarchical-blindness.webp "")
+*   ![Abstrakt illustrasjon av hierarkisk blindhet som tillitsutfordring](/assets/images/banners/tillit-t4-hierarchical-blindness.webp "")
 
     #### Hierarkisk blindhet
 
     Ledere som ikke ser at deres atferd oppfattes annerledes avhengig av posisjon. Det som føles som «direkte» oppfattes som «domsnutt» av underordnede.
-*   ![](/assets/images/banners/tillit-t4-info-asymmetry.webp "")
+*   ![Abstrakt illustrasjon av informasjonsasymmetri som tillitsutfordring](/assets/images/banners/tillit-t4-info-asymmetry.webp "")
 
     #### Informerings asymmetri
 
     Ledere vet mer enn de deler. Medarbeidere tolker dette som mistillit. Kommunikasjonen blir formell og overfladisk.
-*   ![](/assets/images/banners/tillit-t4-historical-baggage.webp "")
+*   ![Abstrakt illustrasjon av historisk bagasje som tillitsutfordring](/assets/images/banners/tillit-t4-historical-baggage.webp "")
 
     #### Historisk baggage
 
     Tidligere svik sitter i kulturen. Nye ledere møtes med «vi har hørt dette før»-holdning. Initiativ blir møtt med skepsis.
-*   ![](/assets/images/banners/tillit-t4-inconsistent-followup.webp "")
+*   ![Abstrakt illustrasjon av inkonsekvent oppfølging som tillitsutfordring](/assets/images/banners/tillit-t4-inconsistent-followup.webp "")
 
     #### Inkonsekvent oppfølging
 

--- a/_pages/ledelse_triader.md
+++ b/_pages/ledelse_triader.md
@@ -109,25 +109,25 @@ Problemet er ikke at dyader er onde. Problemet er at de er utilstrekkelige som e
 
 En triade er tre personer med gjensidige, ikke-eksklusive relasjoner. Det høres enkelt ut, men forskjellen fra en dyade er strukturell, ikke kvantitativ.
 
-*   ![](/assets/images/banners/triader-t3-no-control.webp)
+*   ![Abstrakt illustrasjon av triaderobusthet — tre sammenkoblede noder](/assets/images/banners/triader-t3-no-control.webp)
 
     ### Ingen enkeltperson kontrollerer forbindelsen
 
     I en dyade kan én person bryte relasjonen ved å trekke seg unna. I en triade holder de to gjenværende forbindelsen i live. Triaden kan repareres. Dyaden må gjenoppbygges fra bunnen av. Dette er ikke psykologi — det er matematikk. Tre forbindelser (A–B, B–C, A–C) gir redundans som to forbindelser (A–B) ikke har.
 
-*   ![](/assets/images/banners/triader-t3-information-flow.webp)
+*   ![Abstrakt illustrasjon av informasjonsflyt i tre baner i en triade](/assets/images/banners/triader-t3-information-flow.webp)
 
     ### Informasjon flyter i flere baner
 
     I en triade har informasjon tre veier å gå. Det betyr at kunnskap sjelden blir fanget i én relasjon. Hvis A forteller B noe, og B ikke videreformidler det til C, kan C fortsatt få informasjonen fra A direkte. Systemet selvkorrigerer.
 
-*   ![](/assets/images/banners/triader-t3-conflict-resolution.webp)
+*   ![Abstrakt illustrasjon av konfliktløsning gjennom triangulering i en triade](/assets/images/banners/triader-t3-conflict-resolution.webp)
 
     ### Konflikt blir triangulert, ikke polarisert
 
     Når uenighet oppstår i en triade, finnes det en tredjepart som kan bidra med perspektiv. Dette reduserer sannsynligheten for at konflikt blir personlig. C kan si: «Jeg ser at dere ser dette forskjellig — la oss finne ut hva vi er enige om.» En dyade har ingen slik mekanisme.
 
-*   ![](/assets/images/banners/triader-t3-resilience.webp)
+*   ![Abstrakt illustrasjon av triaderesiliens — relasjon overlever utskifting](/assets/images/banners/triader-t3-resilience.webp)
 
     ### Resilient mot utskifting
 
@@ -159,25 +159,25 @@ Det er verdt å merke seg at disse betingelsene speiler spenningen mellom [makt 
 
 Triader er ikke en teoretisk konstruksjon. De oppstår naturlig i velfungerende team, ofte uten at noen kaller dem det. Her er fire praktiske arketyper du kjenner igjen fra din egen organisasjon:
 
-*   ![](/assets/images/banners/triader-t3-project-triad.webp)
+*   ![Abstrakt illustrasjon av prosjekttriaden: sponsor, leder og ekspert](/assets/images/banners/triader-t3-project-triad.webp)
 
     ### Prosjekttriaden: sponsor, leder, ekspert
 
     Den mest utbredte triaden i organisasjonslivet. Sponsoren eier mandat og budsjett. Lederen koordinerer gjennomføring. Eksperten sikrer faglig kvalitet. Ingen av de tre kan alene drive prosjektet fremover. Hvis sponsoren faller fra, kan leder og ekspert sammen opprettholde fremdriften mens en ny sponsor finnes.
 
-*   ![](/assets/images/banners/triader-t3-mentor-triad.webp)
+*   ![Abstrakt illustrasjon av mentortriaden: mentor, mentee og kollega](/assets/images/banners/triader-t3-mentor-triad.webp)
 
     ### Mentortriaden: mentor, mentee, kollega
 
     Tradisjonell mentoring er en dyade — mentor og mentee. Problemet er at mentoren blir en allmektig kilde til sannhet, og mentee utvikler ikke et selvstendig nettverk. I en mentortriade inkluderes en kollega på samme nivå som mentee, slik at læring blir en delt aktivitet og mentoren får perspektiv på hvordan kunnskapen faktisk tas i bruk.
 
-*   ![](/assets/images/banners/triader-t3-leadership-triad.webp)
+*   ![Abstrakt illustrasjon av ledertriaden: operativ, strategisk og kulturell rolle](/assets/images/banners/triader-t3-leadership-triad.webp)
 
     ### Ledertriaden: operativ, strategisk, kulturell
 
     I en ledergruppe på tre dekker man ofte tre roller: den som holder driften i gang, den som tenker fremover, og den som passer på kulturen. Når disse tre jobber som en triade, ikke som tre dyader til CEO, skapes en robust ledelsesstruktur som overlever utskifting av enkeltpersoner.
 
-*   ![](/assets/images/banners/triader-t3-bridge-triad.webp)
+*   ![Abstrakt illustrasjon av overbroende triade som bygger bro mellom siloer](/assets/images/banners/triader-t3-bridge-triad.webp)
 
     ### Overbroende triader: brobygging mellom siloer
 

--- a/_pages/ledelse_usikkerhet.md
+++ b/_pages/ledelse_usikkerhet.md
@@ -93,31 +93,31 @@ Spørsmålet ledergrupper bør stille seg i usikre tider er ikke «hva er kultur
 
 David Logan deler organisasjoner inn i fem kulturstadier, basert på hvordan medlemmene ser på seg selv og andre:
 
-*   ![](/assets/images/banners/usikkerhet-t3-stage-1.webp)
+*   ![Abstrakt illustrasjon av Logans kulturstadium 1: «Livet suger»](/assets/images/banners/usikkerhet-t3-stage-1.webp)
 
     ### Trinn 1: «Livet suger»
 
     En subkultur preget av apati og offermentalitet. Folk tror ingenting kan endres. Dette finnes sjelden i fungerende organisasjoner, men kan oppstå i nedlagte avdelinger eller under kriser.
 
-*   ![](/assets/images/banners/usikkerhet-t3-stage-2.webp)
+*   ![Abstrakt illustrasjon av Logans kulturstadium 2: «Mitt liv suger»](/assets/images/banners/usikkerhet-t3-stage-2.webp)
 
     ### Trinn 2: «Mitt liv suger»
 
     Individuell apati. Folk er offer for omstendighetene. «Hva er vitsen?» er den dominerende holdningen. Rundt 25% av befolkningen opererer på dette stadiet.
 
-*   ![](/assets/images/banners/usikkerhet-t3-stage-3.webp)
+*   ![Abstrakt illustrasjon av Logans kulturstadium 3: «Jeg er great»](/assets/images/banners/usikkerhet-t3-stage-3.webp)
 
     ### Trinn 3: «Jeg er great, du er det ikke»
 
     Individualistisk egoisme. «Jeg er god, andre er dårligere.» Konkurranse innad. Seige på «vi er best»-mentality. Rundt 48% av organisasjoner befinner seg her.
 
-*   ![](/assets/images/banners/usikkerhet-t3-stage-4.webp)
+*   ![Abstrakt illustrasjon av Logans kulturstadium 4: «Vi er great»](/assets/images/banners/usikkerhet-t3-stage-4.webp)
 
     ### Trinn 4: «Vi er great, andre er ikke»
 
     Tribe-tenkning. «Vi er gode, andre grupper er dårligere.» Sterk intern identitet, men kan føre til fiendskap mot andre. Rundt 22% av organisasjoner.
 
-*   ![](/assets/images/banners/usikkerhet-t3-stage-5.webp)
+*   ![Abstrakt illustrasjon av Logans kulturstadium 5: «Livet er great»](/assets/images/banners/usikkerhet-t3-stage-5.webp)
 
     ### Trinn 5: «Livet er great»
 
@@ -144,49 +144,49 @@ Når usikkerhet oppstår, oppstår også maktkamper. De som griper muligheten i 
 
 John Kotter har kartlagt hvorfor endringsinitiativer feiler — og hvordan de faktisk kan lykkes. Hans forskning viser at de fleste endringsforsøk mislykkes fordi de gjør én eller flere av åtte kritiske feil. Her er hans åtte steg, fra akutt til forankret.
 
-1.  ![](/assets/images/banners/usikkerhet-t3-kotter-1.webp "")
+1.  ![Abstrakt illustrasjon av Kotters steg 1: Skap nødvendighet](/assets/images/banners/usikkerhet-t3-kotter-1.webp "")
 
     ### Skap nødvendighet
 
     Hjelp folk å se hvorfor endring er nødvendig nå — ikke til slutt. Hva koster det å ikke endre? Konkurransetrykk, regulatoriske endringer, arbeidsmarkedsskifter. Nødvendighet er ikke panikk — det er klarhet.
 
-2.  ![](/assets/images/banners/usikkerhet-t3-kotter-2.webp "")
+2.  ![Abstrakt illustrasjon av Kotters steg 2: Bygg en sterk koalisjon](/assets/images/banners/usikkerhet-t3-kotter-2.webp "")
 
     ### Bygg en sterk koalisjon
 
     Samle en gruppe med nok makt til å lede endringen. Inkluder formelle ledere og uformelle opinionsledere. Ikke alle trenger å være overbevist — men nøkkelaktører må være med.
 
-3.  ![](/assets/images/banners/usikkerhet-t3-kotter-3.webp "")
+3.  ![Abstrakt illustrasjon av Kotters steg 3: Formuler en visjon](/assets/images/banners/usikkerhet-t3-kotter-3.webp "")
 
     ### Formuler en visjon
 
     Beskriv hvordan fremtiden ser ut etter endringen. Enkel, klar, inspirerende — ikke en prosjektplan. Visjonen skal styre beslutninger, ikke bare kommunikasjon.
 
-4.  ![](/assets/images/banners/usikkerhet-t3-kotter-4.webp "")
+4.  ![Abstrakt illustrasjon av Kotters steg 4: Kommuniser visjonen](/assets/images/banners/usikkerhet-t3-kotter-4.webp "")
 
     ### Kommuniser visjonen
 
     Gjør visjonen til en pågående tilstedeværelse, ikke en engangsannonsering. Led med eksempel — handlinger taler høyere enn presentasjoner. Addresser angst og motstand direkte, ikke ignorer dem.
 
-5.  ![](/assets/images/banners/usikkerhet-t3-kotter-5.webp "")
+5.  ![Abstrakt illustrasjon av Kotters steg 5: Fjern hindringer](/assets/images/banners/usikkerhet-t3-kotter-5.webp "")
 
     ### Fjern hindringer
 
     Identifiser barrierer: strukturer, systemer, ferdigheter, vaner. Myndiggjør folk til å fjerne hindringer eller finne veier rundt dem. Feir tidlige seiere som fjerner en barriere.
 
-6.  ![](/assets/images/banners/usikkerhet-t3-kotter-6.webp "")
+6.  ![Abstrakt illustrasjon av Kotters steg 6: Skap kortsiktige seiere](/assets/images/banners/usikkerhet-t3-kotter-6.webp "")
 
     ### Skap kortsiktige seiere
 
     Planlegg synlige forbedringer innen 3-6 måneder. Ikke vent på den store transformasjonen — tidlige seiere bygger momentum. Analyser resultater ærlig — juster hvis seieren ikke var så stor som forventet.
 
-7.  ![](/assets/images/banners/usikkerhet-t3-kotter-7.webp "")
+7.  ![Abstrakt illustrasjon av Kotters steg 7: Bygg videre på endringen](/assets/images/banners/usikkerhet-t3-kotter-7.webp "")
 
     ### Bygg videre på endringen
 
     Bruk troverdigheten fra tidlige seiere til å angripe større endringer. Fremhev folk som gjennomførte tidlige endringer. Ikke erklær seier for tidlig — konsolidering tar tid.
 
-8.  ![](/assets/images/banners/usikkerhet-t3-kotter-8.webp "")
+8.  ![Abstrakt illustrasjon av Kotters steg 8: Forankre i kulturen](/assets/images/banners/usikkerhet-t3-kotter-8.webp "")
 
     ### Forankre i kulturen
 
@@ -209,27 +209,27 @@ Scheins tre kulturnivåer kobler seg til Kotters steg: artefakter påvirkes av k
 
 ## Vanlige kulturutfordringer
 
-*   ![](/assets/images/banners/usikkerhet-t4-values-practice.webp "")
+*   ![Abstrakt illustrasjon av uoverensstemmelse mellom verdier og praksis](/assets/images/banners/usikkerhet-t4-values-practice.webp "")
 
     #### Uoverensstemmelse mellom verdier og praksis
 
     «Vi er innovative» står på veggen, men ideer drepes i møter. Kulturen sier noe annet enn det ledelsen tror.
-*   ![](/assets/images/banners/usikkerhet-t4-tacit-knowledge.webp "")
+*   ![Abstrakt illustrasjon av taus kunnskap som ikke deles](/assets/images/banners/usikkerhet-t4-tacit-knowledge.webp "")
 
     #### Tacite kunnskap som ikke deles
 
     Kunnskapen sitter i hodene til enkelte, ikke i systemer. Når folk slutter, forsvinner kunnskapen.
-*   ![](/assets/images/banners/usikkerhet-t4-silo-thinking.webp "")
+*   ![Abstrakt illustrasjon av silotenkning i organisasjoner](/assets/images/banners/usikkerhet-t4-silo-thinking.webp "")
 
     #### Silo-tenkning
 
     Avdelinger som jobber for seg selv. «Det der er ikke mitt problem»-mentalitet. Koordinering på tvers av avdelinger er tilfeldig.
-*   ![](/assets/images/banners/usikkerhet-t4-always-done.webp "")
+*   ![Abstrakt illustrasjon av «alltid sånn her»-mentalitet](/assets/images/banners/usikkerhet-t4-always-done.webp "")
 
     #### «Alltid sånn her»-mentalitet
 
     Historisk suksess blir institusjonlisert. «Vi har alltid gjort det sånn» blir argumentet mot fornyelse.
-*   ![](/assets/images/banners/usikkerhet-t4-structural-uncertainty.webp "")
+*   ![Abstrakt illustrasjon av strukturell usikkerhet](/assets/images/banners/usikkerhet-t4-structural-uncertainty.webp "")
 
     #### Strukturell usikkerhet
 

--- a/_pages/mennesker.md
+++ b/_pages/mennesker.md
@@ -112,22 +112,22 @@ Gode rutiner og klare roller er ikke det motsatte av tillitsbasert ledelse — d
 
 ![Illustrasjon av vanlige menneskerelaterte utfordringer](/assets/images/banners/illustrasjon-mennesker-utfordringer.webp)
 
-*   ![](/assets/images/banners/mennesker-t4-psychological-safety.webp "")
+*   ![Abstrakt illustrasjon av manglende psykologisk trygghet](/assets/images/banners/mennesker-t4-psychological-safety.webp "")
 
     #### Manglende psykologisk trygghet
 
     Folk tørr ikke si ifra om problemer. Feil skjules. Kritikk leveres bak lukkede dører. Innovasjon dør før den får luft.
-*   ![](/assets/images/banners/mennesker-t4-empty-values.webp "")
+*   ![Abstrakt illustrasjon av tomme verdier som ikke etterleves](/assets/images/banners/mennesker-t4-empty-values.webp "")
 
     #### Tomme verdier
 
     Organisasjonen har verdier på veggen, men de stemmer ikke med hvordan folk faktisk oppfører seg. Verdiene er blitt flosler, ikke veiledning.
-*   ![](/assets/images/banners/mennesker-t4-silos.webp "")
+*   ![Abstrakt illustrasjon av siloer og manglende samarbeid](/assets/images/banners/mennesker-t4-silos.webp "")
 
     #### Sil og silo
 
     Avdelinger og individer jobber i siloer. Folk kjenner ikke til hva naboen driver med. Kunden matcher med én person som blir en flaskehals.
-*   ![](/assets/images/banners/mennesker-t4-meaninglessness.webp "")
+*   ![Abstrakt illustrasjon av for mye volum og for lite mening](/assets/images/banners/mennesker-t4-meaninglessness.webp "")
 
     #### For mye volum, for lite mening
 

--- a/_pages/om_avtale.md
+++ b/_pages/om_avtale.md
@@ -17,7 +17,7 @@ avtale: true
 
 ## §1 Endring og erstatning
 
-![](/assets/images/banners/avtale-t4-paragraf-1.webp)
+![Abstrakt illustrasjon av avtalevilkår §1 endring og erstatning](/assets/images/banners/avtale-t4-paragraf-1.webp)
 
 §1.1 Endringer i Oppdragets innhold eller omfang kan avtales særskilt. Som tillegg til Avtalen kan partene bli enige om nye oppdrag, rammetall for tid og kostnad, som avtales særskilt i hvert tilfelle. I den utstrekning ikke annet avtales i forbindelse med det nye oppdraget, gjelder Avtalen også for det.
 
@@ -29,7 +29,7 @@ avtale: true
 
 ## §2 Fakturering og reise
 
-![](/assets/images/banners/avtale-t4-paragraf-2.webp)
+![Abstrakt illustrasjon av avtalevilkår §2 fakturering og reise](/assets/images/banners/avtale-t4-paragraf-2.webp)
 
 §2.1 Fakturering skjer etterskuddsvis en gang pr. måned. Betalingsbetingelsene er netto pr. 15 dager. Det påløper forsinkelsesrenter ved for sen betaling etter bestemmelsene i Forsinkelsesrenteloven.
 
@@ -39,7 +39,7 @@ avtale: true
 
 ## §3 Rettigheter
 
-![](/assets/images/banners/avtale-t4-paragraf-3.webp)
+![Abstrakt illustrasjon av avtalevilkår §3 rettigheter](/assets/images/banners/avtale-t4-paragraf-3.webp)
 
 §3.1 Alle resultater som oppnås under bistanden er Kundens eiendom dersom ikke annet er avtalt. NO EXCUSE AS kan fritt utnytte de generelle erfaringer, metoder og teknikker som opparbeides og eventuelt utvikles gjennom denne avtale.
 
@@ -51,19 +51,19 @@ avtale: true
 
 ## §4 Taushetsplikt og sikkerhet
 
-![](/assets/images/banners/avtale-t4-paragraf-4.webp)
+![Abstrakt illustrasjon av avtalevilkår §4 taushetsplikt og sikkerhet](/assets/images/banners/avtale-t4-paragraf-4.webp)
 
 §4.1 NO EXCUSE AS sitt personale har taushetsplikt for alle opplysninger, inklusive informasjon om personlige forhold, som han / hun blir kjent med under arbeidet for Kunden, og skal ivareta Kundens kommuniserte sikkerhets- og kvalitetskrav. NO EXCUSE AS sitt personale forholder seg for øvrig til gjeldende regelverk ved utførelsen av arbeidet.
 
 ## §5 Mislighold og force majeur
 
-![](/assets/images/banners/avtale-t4-paragraf-5.webp)
+![Abstrakt illustrasjon av avtalevilkår §5 mislighold og force majeur](/assets/images/banners/avtale-t4-paragraf-5.webp)
 
 §5.1 Ved mislighold av denne kjøpekontrakt kan den part som rammes kreve erstatning for dokumentert økonomisk tap etter alminnelige prinsipper for erstatning i avtaleforhold, erstatningskravet kan ikke overstige kontraktssummen (eks mva). Skadeerstatning omfatter ikke indirekte tap eller følgesskader hos tredjemann. Dette gjelder også i force majeurtilfeller.
 
 ## §6 Tvister og verneting
 
-![](/assets/images/banners/avtale-t4-paragraf-6.webp)
+![Abstrakt illustrasjon av avtalevilkår §6 tvister og verneting](/assets/images/banners/avtale-t4-paragraf-6.webp)
 
 §6.1 Norsk rett gjelder for Avtalen og dens inngåelse. Kundens verneting vedtas som verneting.
 

--- a/_pages/om_metode.md
+++ b/_pages/om_metode.md
@@ -72,19 +72,19 @@ Hvert intervju produserer strukturerte, sammenliknbare data som anonymiseres og 
 
 Databehandlingen følger **De nasjonale forskningsetiske komiteenes (FEK) generelle forskningsetiske retningslinjer** (2014).
 
-![](/assets/images/banners/metode-t4-respekt.webp)
+![Abstrakt illustrasjon av forskningsetisk prinsipp: respekt](/assets/images/banners/metode-t4-respekt.webp)
 #### Respekt
 Informantene behandles med verdighet og integritet
 
-![](/assets/images/banners/metode-t4-konsekvenser.webp)
+![Abstrakt illustrasjon av forskningsetisk prinsipp: gode konsekvenser](/assets/images/banners/metode-t4-konsekvenser.webp)
 #### Gode konsekvenser
 Forskningen skal ha positiv nytteverdi for deltakerne og samfunnet
 
-![](/assets/images/banners/metode-t4-rettferdighet.webp)
+![Abstrakt illustrasjon av forskningsetisk prinsipp: rettferdighet](/assets/images/banners/metode-t4-rettferdighet.webp)
 #### Rettferdighet
 Prosjektet er rettferdig utformet og gjennomført
 
-![](/assets/images/banners/metode-t4-integritet.webp)
+![Abstrakt illustrasjon av forskningsetisk prinsipp: integritet](/assets/images/banners/metode-t4-integritet.webp)
 #### Integritet
 Prosjektet følger anerkjente normer og opptrer ansvarlig
 

--- a/_pages/om_oss.md
+++ b/_pages/om_oss.md
@@ -36,15 +36,15 @@ Vår tilnærming bygger på anerkjent organisasjonsteori (Bolman & Deals [fire p
 
 ![Abstrakt fremstilling av våre tre kjerneverdier: ansvarlighet, tillit og ærlighet](/assets/images/banners/banner-verdier.webp)
 
-![](/assets/images/banners/verdi-ansvarlighet.webp)
+![Abstrakt illustrasjon av kjerneverdien ansvarlighet](/assets/images/banners/verdi-ansvarlighet.webp)
 ### Ansvarlighet
 Vi får frem styrkene som ligger i ansvarlig og tillitsbasert ledelse
 
-![](/assets/images/banners/verdi-tillit.webp)
+![Abstrakt illustrasjon av kjerneverdien tillit](/assets/images/banners/verdi-tillit.webp)
 ### Tillit
 Vårt mål er å gjøre organisasjoner mer bærekraftige ved å styrke tillitsgrunnlaget
 
-![](/assets/images/banners/verdi-aerlighet.webp)
+![Abstrakt illustrasjon av kjerneverdien ærlighet](/assets/images/banners/verdi-aerlighet.webp)
 ### Ærlighet
 Våre metoder fokuserer på mennesker, vektlegger ærlighet og produserer målbare resultater
 

--- a/_pages/påvirkning.md
+++ b/_pages/påvirkning.md
@@ -100,22 +100,22 @@ Pfeffers research viser at politisk dyktighet korrelerer sterkt med ledereffekti
 
 ![Illustrasjon av vanlige påvirkningsrelaterte utfordringer](/assets/images/banners/illustrasjon-påvirkning-utfordringer.webp)
 
-*   ![](/assets/images/banners/pavirkning-t4-invisible-power.webp "")
+*   ![Abstrakt illustrasjon av usynlig beslutningsmakt](/assets/images/banners/pavirkning-t4-invisible-power.webp "")
 
     #### Usynlig beslutningsmakt
 
     De som formelt har makt, har ikke reell makt. Eller omvendt. Beslutninger tas «der» men av dem som «ikke skal ha noe med det å gjøre». Senior ledere kan ofte bryte uformelle regler — de har bygget opp «idiosynkratiske kreditter» gjennom tidligere bidrag som gir dem retten til å avvike fra normene.
-*   ![](/assets/images/banners/pavirkning-t4-hidden-agendas.webp "")
+*   ![Abstrakt illustrasjon av skjulte agendaer](/assets/images/banners/pavirkning-t4-hidden-agendas.webp "")
 
     #### Skjulte agendaer
 
     Aktører som ikke er transparente om sine interesser. Medarbeidere som jobber forbi offisielle kanaler for å påvirke beslutninger.
-*   ![](/assets/images/banners/pavirkning-t4-resource-struggles.webp "")
+*   ![Abstrakt illustrasjon av ressurskamper som maskeres som rasjonelle](/assets/images/banners/pavirkning-t4-resource-struggles.webp "")
 
     #### Ressurskamper som maskeres
 
     Budsjettkonflikter, GIS-struktureringer og andre strukturelle endringer som egentlig handler om makt og innflytelse, men fremstilles som rasjonelle.
-*   ![](/assets/images/banners/pavirkning-t4-too-much-agreement.webp "")
+*   ![Abstrakt illustrasjon av for mye enighet i ledergruppen](/assets/images/banners/pavirkning-t4-too-much-agreement.webp "")
 
     #### For mye enighet
 

--- a/_pages/struktur.md
+++ b/_pages/struktur.md
@@ -98,22 +98,22 @@ Douglas Hubbard, forfatteren av «How to Measure Anything», påpeker at mye som
 
 ![Illustrasjon av vanlige strukturspesifikke utfordringer](/assets/images/banners/illustrasjon-struktur-utfordringer.webp)
 
-*   ![](/assets/images/banners/struktur-t4-role-clarification.webp "")
+*   ![Abstrakt illustrasjon av uklar rolleavklaring som strukturutfordring](/assets/images/banners/struktur-t4-role-clarification.webp "")
 
     #### Uklar rolleavklaring
 
     To personer som tror de eier samme område. Eller ingen som eier det i det hele tatt. Ofte avslørt først når noe går galt.
-*   ![](/assets/images/banners/struktur-t4-goal-conflict.webp "")
+*   ![Abstrakt illustrasjon av målkonflikter som strukturutfordring](/assets/images/banners/struktur-t4-goal-conflict.webp "")
 
     #### Målkonflikter
 
     Avdeling A optimaliserer for sin målsetting som bremser avdeling B. Motivert av insentiver som ikke er koordinert.
-*   ![](/assets/images/banners/struktur-t4-coordination.webp "")
+*   ![Abstrakt illustrasjon av koordineringsproblemer som strukturutfordring](/assets/images/banners/struktur-t4-coordination.webp "")
 
     #### Koordineringsproblemer
 
     Mye tid brukes på å samordne arbeid som burde vært koordinert fra start. Fokus på «å skape buy-in» i stedet for å bygge struktur som sikrer involvering.
-*   ![](/assets/images/banners/struktur-t4-bureaucracy.webp "")
+*   ![Abstrakt illustrasjon av byråkratisk byrde som strukturutfordring](/assets/images/banners/struktur-t4-bureaucracy.webp "")
 
     #### Byråkratisk byrde
 


### PR DESCRIPTION
## What
- **A4**: Replaced all 88 empty  and  markdown images with descriptive Norwegian alt text
- Covers T3 section illustrations and T4 challenge micros across all 13 affected pages
- Each alt text describes the concept/function (not literal visual), max ~15 words, no "Bilde av" prefix

## Acceptance criteria
- [x] grep '!\\[\\](' _pages/*.md — zero matches (confirmed)
- [x] All alt text in Norwegian Bokmål
- [x] No "Bilde av" prefix used

## Files modified (13)
_pages/ledelse_usikkerhet.md (21), _pages/ledelse_generativ-ki.md (12), _pages/ledelse_forankring.md (9), _pages/ledelse_triader.md (8), _pages/ledelse_tillit.md (8), _pages/om_avtale.md (6), _pages/ledelse_perspektiv.md (4), _pages/struktur.md (4), _pages/mennesker.md (4), _pages/påvirkning.md (4), _pages/identitet.md (4), _pages/om_metode.md (4), _pages/om_oss.md (3)

## Pre-merge notes
- No CI available locally (no Ruby/bundle for Jekyll build)
- All alt text per spec in .specs/alt-text-audit/README.md