### PR TITLE
refactor: GRC perspective cards with banner illustrations (R30)

### DIFF
--- a/_includes/grc-perspective-cards.html
+++ b/_includes/grc-perspective-cards.html
@@ -1,10 +1,16 @@
-{% assign grc_frames = site.pages | where: "class", "frame" | sort: "weight" %}
-
-{% for frame in grc_frames %}
-  {% assign accent = frame.color_accent | default: "#2A4D6E" %}
-  <div class="info-box animate-on-scroll fade-in-up" style="--card-accent: {{ accent }}; border-left-color: var(--card-accent);">
-    <h3>{{ frame.title }}</h3>
-    {{ frame.grc_description | markdownify }}
-    <p><a href="{{ frame.url | relative_url }}" class="card-link">Les mer i {{ frame.title | downcase }} →</a></p>
-  </div>
-{% endfor %}
+<div class="card-grid card-grid--grc">
+  {% assign grc_frames = site.pages | where: "class", "frame" | sort: "weight" %}
+  {% for frame in grc_frames %}
+    {% assign accent = frame.color_accent | default: "#2A4D6E" %}
+    <article class="card card--frame" style="--card-accent: {{ accent }}">
+      {% if frame.banner %}
+      <img src="{{ frame.banner | relative_url }}" alt="{{ frame.title }}" class="card-image" loading="lazy">
+      {% endif %}
+      <div class="card-content">
+        <h3>{{ frame.title }}</h3>
+        {{ frame.grc_description | markdownify }}
+        <a href="{{ frame.url | relative_url }}" class="card-link">Les mer i {{ frame.title | downcase }} →</a>
+      </div>
+    </article>
+  {% endfor %}
+</div>

--- a/assets/css/components/card.css
+++ b/assets/css/components/card.css
@@ -22,6 +22,10 @@
     grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
 }
 
+.card-grid--grc {
+    grid-template-columns: repeat(2, 1fr);
+}
+
 /* Base Card */
 .card {
     padding: 0;


### PR DESCRIPTION
## R30 — GRC Perspective Cards Refactor

### Problem
The four GRC governance perspectives (struktur, mennesker, påvirkning, identitet) were rendered as plain .info-box divs with no visual hierarchy — no images, no card structure.

### Changes
1. **_includes/grc-perspective-cards.html**: Replaced .info-box divs with .card.card--frame components from the existing card system. Each card now includes:
   - Banner illustration — each frame's banner image via frame.banner (16:9 .card-image)
   - Perspective title — frame.title
   - GRC description — frame.grc_description rendered via markdownify
   - Cross-link — .card-link to the frame article
   - Accent color — --card-accent from frame.color_accent (border-top on .card--frame)
2. **assets/css/components/card.css**: Added .card-grid--grc for explicit 2×2 grid layout

### Verification
- 2×2 grid on desktop, single column on mobile (existing @media (max-width: 599px))
- Dark mode supported via existing .card dark mode styles
- Existing frame page data reused — zero new frontmatter

Closes R30