### PR TITLE
refactor: LLM ask modal — icons removed, list layout, auto-open URL (R32)

### DIFF
--- a/assets/css/components/questions.css
+++ b/assets/css/components/questions.css
@@ -135,81 +135,60 @@
     color: var(--text-color-dark);
 }
 
-/* ── Modal Question Text ────────────────── */
+/* ── Modal Question (quotation block) ───── */
 .review-questions-modal .modal-question {
-    font-size: 1.1em;
-    font-weight: 500;
-    line-height: 1.5;
+    font-size: 1.05em;
+    font-style: italic;
+    line-height: 1.6;
     margin: 0 0 var(--space-lg);
+    padding: var(--space-md) var(--space-lg);
     padding-right: var(--space-xl);
     color: var(--text-color-light);
+    border-left: 4px solid var(--primary-accent);
+    background: var(--surface-subtle-light);
+    border-radius: 0 var(--radius-md) var(--radius-md) 0;
 }
 
 .dark-mode .review-questions-modal .modal-question {
     color: var(--text-color-dark);
+    background: var(--surface-subtle-dark);
 }
 
-/* ── Provider Grid ───────────────────────── */
+/* ── Provider List (single column) ───────── */
 .review-questions-modal .provider-grid {
-    display: grid;
-    grid-template-columns: repeat(2, 1fr);
-    gap: 8px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
     margin-bottom: var(--space-lg);
-}
-
-@media (min-width: 600px) {
-    .review-questions-modal .provider-grid {
-        grid-template-columns: repeat(3, 1fr);
-    }
-}
-
-@media (min-width: 900px) {
-    .review-questions-modal .provider-grid {
-        grid-template-columns: repeat(4, 1fr);
-    }
 }
 
 .review-questions-modal .provider-btn {
     display: flex;
-    flex-direction: column;
     align-items: center;
-    justify-content: center;
-    gap: 4px;
-    padding: 8px 4px;
-    min-height: 56px;
-    min-width: 80px;
+    gap: 8px;
+    width: 100%;
+    padding: 12px 16px;
+    min-height: 44px;
     border: 1px solid var(--border-color-light);
     border-radius: var(--radius-md);
     background: transparent;
     cursor: pointer;
-    transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+    transition: background 0.2s ease, border-color 0.2s ease;
     font-family: inherit;
+    font-size: 1em;
+    text-align: left;
     color: var(--text-color-light);
 }
 
 .review-questions-modal .provider-btn:hover {
     background: var(--surface-hover-light);
     border-color: var(--primary-accent);
-    box-shadow: var(--shadow-xs);
 }
 
 .review-questions-modal .provider-btn.is-selected {
     border-color: var(--primary-accent);
     background: var(--surface-subtle-light);
     box-shadow: 0 0 0 1px var(--primary-accent);
-}
-
-.review-questions-modal .provider-btn svg {
-    width: 24px;
-    height: 24px;
-    color: var(--text-color-light);
-}
-
-.review-questions-modal .provider-btn span {
-    font-size: 0.75em;
-    line-height: 1.2;
-    text-align: center;
-    color: var(--text-color-light);
 }
 
 .dark-mode .review-questions-modal .provider-btn {
@@ -225,9 +204,49 @@
     background: var(--surface-subtle-dark);
 }
 
-.dark-mode .review-questions-modal .provider-btn svg,
-.dark-mode .review-questions-modal .provider-btn span {
+/* ── Collapsed Provider View ─────────────── */
+.review-questions-modal .provider-selected {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+    margin-bottom: var(--space-lg);
+    padding: 12px 16px;
+    border: 1px solid var(--primary-accent);
+    border-radius: var(--radius-md);
+    background: var(--surface-subtle-light);
+}
+
+.dark-mode .review-questions-modal .provider-selected {
+    background: var(--surface-subtle-dark);
+}
+
+.review-questions-modal .provider-selected-name {
+    font-weight: 600;
+    font-size: 1em;
+    color: var(--text-color-light);
+    flex: 1;
+}
+
+.dark-mode .review-questions-modal .provider-selected-name {
     color: var(--text-color-dark);
+}
+
+.review-questions-modal .change-provider-btn {
+    background: none;
+    border: none;
+    color: var(--primary-accent);
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 0.85em;
+    text-decoration: underline;
+    padding: 8px 12px;
+    min-height: 44px;
+    min-width: 44px;
+    white-space: nowrap;
+}
+
+.review-questions-modal .change-provider-btn:hover {
+    opacity: 0.8;
 }
 
 /* ── Preference Checkbox ────────────────── */
@@ -253,50 +272,44 @@
     color: var(--text-color-dark);
 }
 
-/* ── Copy Button ────────────────────────── */
+/* ── Copy Button (secondary action) ─────── */
 .review-questions-modal .copy-btn {
     display: flex;
     align-items: center;
     justify-content: center;
-    gap: var(--space-sm);
     width: 100%;
-    padding: 12px 24px;
-    border: none;
+    padding: 10px 20px;
+    min-height: 44px;
+    border: 1px solid var(--border-color-light);
     border-radius: var(--radius-lg);
-    background: var(--primary-accent);
-    color: var(--primary-accent-contrast);
+    background: transparent;
+    color: var(--text-color-light);
     font-family: inherit;
-    font-size: 1em;
-    font-weight: 600;
+    font-size: 0.9em;
     cursor: pointer;
-    transition: opacity 0.2s ease, transform 0.2s ease;
+    transition: background 0.2s ease, border-color 0.2s ease;
 }
 
 .review-questions-modal .copy-btn:hover {
-    opacity: 0.9;
-    transform: translateY(-1px);
-}
-
-.review-questions-modal .copy-btn:active {
-    transform: translateY(0);
+    background: var(--surface-hover-light);
+    border-color: var(--primary-accent);
 }
 
 .review-questions-modal .copy-btn.is-copied {
-    background: var(--primary-navy);
-    color: var(--primary-azure);
-}
-
-.review-questions-modal .copy-btn svg {
-    width: 18px;
-    height: 18px;
+    border-color: var(--primary-navy);
+    background: var(--surface-subtle-light);
 }
 
 .dark-mode .review-questions-modal .copy-btn {
-    background: var(--button-background-dark);
-    color: var(--button-text-color-dark);
+    border-color: var(--border-color-dark);
+    color: var(--text-color-dark);
+}
+
+.dark-mode .review-questions-modal .copy-btn:hover {
+    background: var(--surface-hover-dark);
 }
 
 .dark-mode .review-questions-modal .copy-btn.is-copied {
-    background: var(--primary-azure);
-    color: var(--primary-navy);
+    border-color: var(--primary-azure);
+    background: var(--surface-subtle-dark);
 }

--- a/assets/scripts/review-questions.js
+++ b/assets/scripts/review-questions.js
@@ -1,262 +1,317 @@
 (function () {
-  'use strict';
+    'use strict';
 
-  /* ── Constants ──────────────────────────── */
-  var STORAGE_KEY = 'noexcuse_ai_provider';
-  var STORE_EXPIRY_DAYS = 365;
+    /* ── Constants ──────────────────────────── */
+    var STORAGE_KEY = 'noexcuse_ai_provider';
+    var STORE_EXPIRY_DAYS = 365;
 
-  var PROVIDERS = [
-    { id: 'chatgpt', name: 'ChatGPT', url: 'https://chatgpt.com' },
-    { id: 'claude', name: 'Claude', url: 'https://claude.ai' },
-    { id: 'gemini', name: 'Gemini', url: 'https://gemini.google.com' },
-    { id: 'deepseek', name: 'DeepSeek', url: 'https://chat.deepseek.com' },
-    { id: 'perplexity', name: 'Perplexity', url: 'https://www.perplexity.ai' },
-    { id: 'copilot', name: 'Copilot', url: 'https://copilot.microsoft.com' },
-    { id: 'grok', name: 'Grok', url: 'https://grok.com' },
-  ];
+    var PROVIDERS = [
+        { id: 'chatgpt', name: 'ChatGPT', url: 'https://chatgpt.com' },
+        { id: 'claude', name: 'Claude', url: 'https://claude.ai' },
+        { id: 'gemini', name: 'Gemini', url: 'https://gemini.google.com' },
+        { id: 'deepseek', name: 'DeepSeek', url: 'https://chat.deepseek.com' },
+        { id: 'perplexity', name: 'Perplexity', url: 'https://www.perplexity.ai' },
+        { id: 'copilot', name: 'Copilot', url: 'https://copilot.microsoft.com' },
+        { id: 'grok', name: 'Grok', url: 'https://grok.com' }
+    ];
 
-  /* ── Provider SVG icons (monochrome) ────── */
-  var ICONS = {
-    chatgpt:
-      '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3c-1.5 0-2.7.8-3.3 2a4 4 0 00-4 4c0 .5.1 1 .3 1.5A3.5 3.5 0 003 14a3.5 3.5 0 003.5 3.5H12"/><circle cx="12" cy="12" r="1.5"/><path d="M12 3c1.5 0 2.7.8 3.3 2a4 4 0 014 4c0 .5-.1 1-.3 1.5A3.5 3.5 0 0021 14a3.5 3.5 0 01-3.5 3.5H12"/></svg>',
-    claude:
-      '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4L8 20h8L12 4z"/><path d="M12 4l-4 8h8l-4-8z" opacity=".5"/></svg>',
-    gemini:
-      '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2l2.5 5.5L20 7.5l-4 4.5 1 6L12 15l-5 3 1-6-4-4.5 5.5 0L12 2z"/></svg>',
-    deepseek:
-      '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M4 18c2-3 5-5 8-5s6 2 8 5"/><path d="M4 6c2 3 5 5 8 5s6-2 8-5"/></svg>',
-    perplexity:
-      '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="6"/><path d="M15.5 15.5L21 21"/><text x="9" y="14" font-size="9" font-weight="700" stroke="none" fill="currentColor">P</text></svg>',
-    copilot:
-      '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2l3 3-3 3-3-3 3-3z"/><path d="M12 13l3 3-3 3-3-3 3-3z"/><path d="M5 7l3 3-3 3-3-3 3-3z"/><path d="M19 7l3 3-3 3-3-3 3-3z"/></svg>',
-    grok:
-      '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M4 4l16 16M20 4L4 20"/><circle cx="12" cy="12" r="3"/></svg>',
-  };
+    /* ── State ──────────────────────────────── */
+    var modalEl = null;
+    var currentQuestion = '';
+    var selectedProvider = getSavedProvider() || '';
+    var copyTimer = null;
+    var isCollapsed = false;
 
-  /* ── State ──────────────────────────────── */
-  var modalEl = null;
-  var currentQuestion = '';
-  var selectedProvider = getSavedProvider() || '';
-  var copyTimer = null;
+    /* ── Init ───────────────────────────────── */
+    function init() {
+        if (!document.querySelector('.review-questions')) return;
+        buildModal();
+        attachQuestionClicks();
+    }
 
-  /* ── Init ───────────────────────────────── */
-  function init() {
-    if (!document.querySelector('.review-questions')) return;
-    buildModal();
-    attachQuestionClicks();
-  }
+    /* ── Build Modal DOM ────────────────────── */
+    function buildModal() {
+        modalEl = document.createElement('div');
+        modalEl.className = 'review-questions-modal';
+        modalEl.setAttribute('role', 'dialog');
+        modalEl.setAttribute('aria-modal', 'true');
+        modalEl.setAttribute('aria-label', 'Velg KI-verktøy');
 
-  /* ── Build Modal DOM ────────────────────── */
-  function buildModal() {
-    modalEl = document.createElement('div');
-    modalEl.className = 'review-questions-modal';
-    modalEl.setAttribute('role', 'dialog');
-    modalEl.setAttribute('aria-modal', 'true');
-    modalEl.setAttribute('aria-label', 'Velg KI-verktøy');
+        modalEl.innerHTML =
+            '<div class="modal-card">' +
+            '<button class="modal-close" aria-label="Lukk">&times;</button>' +
+            '<blockquote class="modal-question"></blockquote>' +
+            '<div class="provider-grid"></div>' +
+            '<div class="provider-selected" hidden>' +
+            '<span class="provider-selected-name"></span>' +
+            '<button class="change-provider-btn">Skift leverand&oslash;r</button>' +
+            '</div>' +
+            '<label class="preference-row">' +
+            '<input type="checkbox" id="remember-provider" />' +
+            '<span>Husk valget mitt &mdash; <em>vi lagrer kun ditt valg av KI-leverand&oslash;r lokalt i nettleseren din. Ingen data sendes til v&aring;re servere.</em></span>' +
+            '</label>' +
+            '<button class="copy-btn">Kopier prompt</button>' +
+            '</div>';
 
-    modalEl.innerHTML =
-      '<div class="modal-card">' +
-      '<button class="modal-close" aria-label="Lukk">&times;</button>' +
-      '<p class="modal-question"></p>' +
-      '<div class="provider-grid"></div>' +
-      '<label class="preference-row">' +
-      '<input type="checkbox" id="remember-provider" />' +
-      '<span>Husk valget mitt &mdash; <em>vi lagrer kun ditt valg av KI-leverand&oslash;r lokalt i nettleseren din. Ingen data sendes til v&aring;re servere.</em></span>' +
-      '</label>' +
-      '<button class="copy-btn">' +
-      '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>' +
-      '<span>Kopier prompt</span>' +
-      '</button>' +
-      '</div>';
+        document.body.appendChild(modalEl);
+        attachModalEvents();
+        renderProviders();
+    }
 
-    document.body.appendChild(modalEl);
-    attachModalEvents();
-    renderProviders();
-  }
+    /* ── Render Provider Buttons ────────────── */
+    function renderProviders() {
+        var grid = modalEl.querySelector('.provider-grid');
+        grid.innerHTML = '';
+        PROVIDERS.forEach(function (p) {
+            var btn = document.createElement('button');
+            btn.className = 'provider-btn' + (p.id === selectedProvider ? ' is-selected' : '');
+            btn.dataset.provider = p.id;
+            btn.setAttribute('aria-label', p.name);
+            btn.textContent = p.name;
+            btn.addEventListener('click', function () {
+                selectProvider(p.id);
+            });
+            grid.appendChild(btn);
+        });
+    }
 
-  /* ── Render Provider Buttons ────────────── */
-  function renderProviders() {
-    var grid = modalEl.querySelector('.provider-grid');
-    grid.innerHTML = '';
-    PROVIDERS.forEach(function (p) {
-      var btn = document.createElement('button');
-      btn.className = 'provider-btn' + (p.id === selectedProvider ? ' is-selected' : '');
-      btn.dataset.provider = p.id;
-      btn.setAttribute('aria-label', p.name);
-      btn.innerHTML = (ICONS[p.id] || '') + '<span>' + p.name + '</span>';
-      btn.addEventListener('click', function () {
-        selectProvider(p.id);
-      });
-      grid.appendChild(btn);
-    });
-  }
-
-  /* ── Modal Events ────────────────────────── */
-  function attachModalEvents() {
-    modalEl.querySelector('.modal-close').addEventListener('click', closeModal);
-    modalEl.addEventListener('click', function (e) {
-      if (e.target === modalEl) closeModal();
-    });
-    document.addEventListener('keydown', function onEscape(e) {
-      if (e.key === 'Escape' && modalEl.classList.contains('is-open')) {
-        closeModal();
-      }
-    });
-    modalEl.querySelector('.copy-btn').addEventListener('click', copyPrompt);
-  }
-
-  /* ── Attach Question Click Handlers ─────── */
-  function attachQuestionClicks() {
-    var items = document.querySelectorAll('.review-questions li[data-question]');
-    Array.prototype.forEach.call(items, function (li) {
-      li.addEventListener('click', function () {
-        openModal(li.dataset.question);
-      });
-      li.addEventListener('keydown', function (e) {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault();
-          openModal(li.dataset.question);
+    /* ── Collapse / Expand ──────────────────── */
+    function collapseList() {
+        isCollapsed = true;
+        var grid = modalEl.querySelector('.provider-grid');
+        var selected = modalEl.querySelector('.provider-selected');
+        var provider = getProvider(selectedProvider);
+        if (provider) {
+            selected.querySelector('.provider-selected-name').textContent = provider.name;
         }
-      });
-    });
-  }
+        grid.hidden = true;
+        selected.hidden = false;
+    }
 
-  /* ── Open / Close Modal ─────────────────── */
-  function openModal(question) {
-    currentQuestion = question;
-    modalEl.querySelector('.modal-question').textContent = question;
-    var copyBtn = modalEl.querySelector('.copy-btn');
-    copyBtn.classList.remove('is-copied');
-    copyBtn.querySelector('span').textContent = 'Kopier prompt';
+    function expandList() {
+        isCollapsed = false;
+        var grid = modalEl.querySelector('.provider-grid');
+        var selected = modalEl.querySelector('.provider-selected');
+        grid.hidden = false;
+        selected.hidden = true;
+    }
 
-    var checkbox = modalEl.querySelector('#remember-provider');
-    if (selectedProvider && getSavedProvider()) {
-      checkbox.checked = true;
+    function getProvider(id) {
+        for (var i = 0; i < PROVIDERS.length; i++) {
+            if (PROVIDERS[i].id === id) return PROVIDERS[i];
+        }
+        return null;
+    }
+
+    /* ── Modal Events ────────────────────────── */
+    function attachModalEvents() {
+        modalEl.querySelector('.modal-close').addEventListener('click', closeModal);
+        modalEl.addEventListener('click', function (e) {
+            if (e.target === modalEl) closeModal();
+        });
+        document.addEventListener('keydown', function onEscape(e) {
+            if (e.key === 'Escape' && modalEl.classList.contains('is-open')) {
+                closeModal();
+            }
+        });
+        modalEl.querySelector('.copy-btn').addEventListener('click', copyPrompt);
+        modalEl.querySelector('.change-provider-btn').addEventListener('click', expandList);
+    }
+
+    /* ── Attach Question Click Handlers ─────── */
+    function attachQuestionClicks() {
+        var items = document.querySelectorAll('.review-questions li[data-question]');
+        Array.prototype.forEach.call(items, function (li) {
+            li.addEventListener('click', function () {
+                openModal(li.dataset.question);
+            });
+            li.addEventListener('keydown', function (e) {
+                if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    openModal(li.dataset.question);
+                }
+            });
+        });
+    }
+
+    /* ── Open / Close Modal ─────────────────── */
+    function openModal(question) {
+        currentQuestion = question;
+        modalEl.querySelector('.modal-question').textContent = question;
+        var copyBtn = modalEl.querySelector('.copy-btn');
+        copyBtn.classList.remove('is-copied');
+        copyBtn.textContent = 'Kopier prompt';
+
+        var checkbox = modalEl.querySelector('#remember-provider');
+        var saved = getSavedProvider();
+        if (saved && selectedProvider === saved) {
+            checkbox.checked = true;
+        } else {
+            checkbox.checked = false;
+        }
+
+        highlightSelected();
+        selectedProvider = saved || '';
+
+        // Collapse if saved preference exists and checkbox is checked
+        if (selectedProvider && checkbox.checked) {
+            collapseList();
+        } else {
+            expandList();
+        }
+
+        document.body.style.overflow = 'hidden';
+        modalEl.classList.add('is-open');
+
+        // If saved preference exists, auto-open on modal open
+        if (selectedProvider && checkbox.checked) {
+            openProviderUrl(selectedProvider);
+        }
+    }
+
+    function closeModal() {
+        modalEl.classList.remove('is-open');
+        document.body.style.overflow = '';
+        if (copyTimer) {
+            clearTimeout(copyTimer);
+            copyTimer = null;
+        }
+    }
+
+    /* ── Provider Selection ─────────────────── */
+    function selectProvider(id) {
+        selectedProvider = id;
+        highlightSelected();
+
+        var checkbox = modalEl.querySelector('#remember-provider');
+        if (checkbox.checked) {
+            savePreference(id);
+        } else {
+            clearPreference();
+        }
+
+        // Auto-open the URL and close modal
+        openProviderUrl(id);
+    }
+
+    function openProviderUrl(id) {
+        var provider = getProvider(id);
+        if (!provider) return;
+
+        var url = buildPromptUrl(provider.url, currentQuestion);
+        window.open(url, '_blank');
+        closeModal();
+    }
+
+    function buildPromptUrl(baseUrl, question) {
+        var separator = baseUrl.indexOf('?') === -1 ? '?' : '&';
+        return baseUrl + separator + 'q=' + encodeURIComponent(question);
+    }
+
+    function highlightSelected() {
+        var btns = modalEl.querySelectorAll('.provider-btn');
+        Array.prototype.forEach.call(btns, function (btn) {
+            btn.classList.toggle('is-selected', btn.dataset.provider === selectedProvider);
+        });
+    }
+
+    /* ── Save / Load / Clear Preference ─────── */
+    function savePreference(id) {
+        try {
+            var d = new Date();
+            d.setTime(d.getTime() + STORE_EXPIRY_DAYS * 24 * 60 * 60 * 1000);
+            var expires = 'expires=' + d.toUTCString();
+            var cookie = STORAGE_KEY + '=' + encodeURIComponent(id) + ';' + expires + ';path=/;SameSite=Lax';
+            if (location.protocol === 'https:') cookie += ';Secure';
+            document.cookie = cookie;
+        } catch (_) { /* cookie may be blocked */ }
+    }
+
+    function clearPreference() {
+        try {
+            var expires = 'expires=Thu, 01 Jan 1970 00:00:00 GMT';
+            document.cookie = STORAGE_KEY + '=;' + expires + ';path=/;SameSite=Lax';
+        } catch (_) { /* cookie may be blocked */ }
+        selectedProvider = '';
+    }
+
+    function getSavedProvider() {
+        try {
+            var match = document.cookie.match(new RegExp('(?:^|;\\s*)' + STORAGE_KEY + '=([^;]*)'));
+            return match ? decodeURIComponent(match[1]) : '';
+        } catch (_) {
+            return '';
+        }
+    }
+
+    /* ── Copy Prompt ────────────────────────── */
+    function copyPrompt() {
+        var prompt = buildPrompt(currentQuestion);
+        copyToClipboard(prompt, function () {
+            var btn = modalEl.querySelector('.copy-btn');
+            btn.classList.add('is-copied');
+            btn.textContent = 'Kopiert!';
+
+            if (copyTimer) clearTimeout(copyTimer);
+            copyTimer = setTimeout(function () {
+                btn.classList.remove('is-copied');
+                btn.textContent = 'Kopier prompt';
+                copyTimer = null;
+            }, 3000);
+        });
+    }
+
+    function buildPrompt(question) {
+        var pageUrl = location.href;
+        var pageTitle = document.title || 'noexcuse.no';
+
+        return (
+            'Oppgave: Veiled brukeren i \u00e5 utforske et sp\u00f8rsm\u00e5l om ledelse og organisasjonskultur.\n\n' +
+            '**Sp\u00f8rsm\u00e5l:** ' + question + '\n\n' +
+            '**Utgangspunkt:** Sp\u00f8rsm\u00e5let er fra "' + pageTitle + '" p\u00e5 noexcuse.no (' + pageUrl + '). ' +
+            'Bruk innholdet p\u00e5 denne siden som kontekst for veiledningen. Siden inneholder JSON-LD strukturert data.\n\n' +
+            '**Bakgrunn:** noexcuse.no hjelper ledergrupper med \u00e5 f\u00e5 bedre blikk for ' +
+            'mennesker, identitet, struktur og p\u00e5virkning — basert p\u00e5 Bolman & Deals ' +
+            'fire perspektiver. Kjerneproduktet er Ledelse 60:2, en kunnskapsbasert ' +
+            'orientering for ledergrupper: 60 diagnostiske sp\u00f8rsm\u00e5l p\u00e5 2 timer.\n\n' +
+            '**Retningslinjer:**\n' +
+            '- Still oppf\u00f8lgingssp\u00f8rsm\u00e5l som hjelper brukeren \u00e5 reflektere over egen praksis\n' +
+            '- Vis til relevant innhold p\u00e5 noexcuse.no som utgangspunkt for videre lesning\n' +
+            '- Unng\u00e5 \u00e5 gi ferdige svar eller l\u00f8sninger — m\u00e5let er utforskning, ikke fasit\n' +
+            '- Bruk norsk bokm\u00e5l, v\u00e6r konkret og praktisk rettet mot ledergrupper'
+        );
+    }
+
+    function copyToClipboard(text, callback) {
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(text).then(callback).catch(function () {
+                fallbackCopy(text, callback);
+            });
+        } else {
+            fallbackCopy(text, callback);
+        }
+    }
+
+    function fallbackCopy(text, callback) {
+        var ta = document.createElement('textarea');
+        ta.value = text;
+        ta.style.position = 'fixed';
+        ta.style.left = '-9999px';
+        ta.style.top = '0';
+        document.body.appendChild(ta);
+        ta.focus();
+        ta.select();
+        try {
+            document.execCommand('copy');
+            callback();
+        } catch (_) { /* copy failed */ }
+        document.body.removeChild(ta);
+    }
+
+    /* ── Bootstrap ──────────────────────────── */
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
     } else {
-      checkbox.checked = false;
+        init();
     }
-
-    highlightSelected();
-    document.body.style.overflow = 'hidden';
-    modalEl.classList.add('is-open');
-  }
-
-  function closeModal() {
-    modalEl.classList.remove('is-open');
-    document.body.style.overflow = '';
-    if (copyTimer) {
-      clearTimeout(copyTimer);
-      copyTimer = null;
-    }
-  }
-
-  /* ── Provider Selection ─────────────────── */
-  function selectProvider(id) {
-    selectedProvider = id;
-    highlightSelected();
-
-    var checkbox = modalEl.querySelector('#remember-provider');
-    if (checkbox.checked) {
-      savePreference(id);
-    }
-  }
-
-  function highlightSelected() {
-    var btns = modalEl.querySelectorAll('.provider-btn');
-    Array.prototype.forEach.call(btns, function (btn) {
-      btn.classList.toggle('is-selected', btn.dataset.provider === selectedProvider);
-    });
-  }
-
-  /* ── Save / Load Preference ─────────────── */
-  function savePreference(id) {
-    try {
-      var d = new Date();
-      d.setTime(d.getTime() + STORE_EXPIRY_DAYS * 24 * 60 * 60 * 1000);
-      var expires = 'expires=' + d.toUTCString();
-      var cookie = STORAGE_KEY + '=' + encodeURIComponent(id) + ';' + expires + ';path=/;SameSite=Lax';
-      if (location.protocol === 'https:') cookie += ';Secure';
-      document.cookie = cookie;
-    } catch (_) { /* cookie may be blocked */ }
-  }
-
-  function getSavedProvider() {
-    try {
-      var match = document.cookie.match(new RegExp('(?:^|;\\s*)' + STORAGE_KEY + '=([^;]*)'));
-      return match ? decodeURIComponent(match[1]) : '';
-    } catch (_) {
-      return '';
-    }
-  }
-
-  /* ── Copy Prompt ────────────────────────── */
-  function copyPrompt() {
-    var prompt = buildPrompt(currentQuestion);
-    copyToClipboard(prompt, function () {
-      var btn = modalEl.querySelector('.copy-btn');
-      btn.classList.add('is-copied');
-      btn.querySelector('span').textContent = 'Kopiert!';
-
-      if (copyTimer) clearTimeout(copyTimer);
-      copyTimer = setTimeout(function () {
-        btn.classList.remove('is-copied');
-        btn.querySelector('span').textContent = 'Kopier prompt';
-        copyTimer = null;
-      }, 3000);
-    });
-  }
-
-  function buildPrompt(question) {
-    var pageUrl = location.href;
-    var pageTitle = document.title || 'noexcuse.no';
-
-    return (
-      'Oppgave: Veiled brukeren i \u00e5 utforske et sp\u00f8rsm\u00e5l om ledelse og organisasjonskultur.\n\n' +
-      '**Sp\u00f8rsm\u00e5l:** ' + question + '\n\n' +
-      '**Utgangspunkt:** Sp\u00f8rsm\u00e5let er fra "' + pageTitle + '" p\u00e5 noexcuse.no (' + pageUrl + '). ' +
-      'Bruk innholdet p\u00e5 denne siden som kontekst for veiledningen. Siden inneholder JSON-LD strukturert data.\n\n' +
-      '**Bakgrunn:** noexcuse.no hjelper ledergrupper med \u00e5 f\u00e5 bedre blikk for ' +
-      'mennesker, identitet, struktur og p\u00e5virkning — basert p\u00e5 Bolman & Deals ' +
-      'fire perspektiver. Kjerneproduktet er Ledelse 60:2, en kunnskapsbasert ' +
-      'orientering for ledergrupper: 60 diagnostiske sp\u00f8rsm\u00e5l p\u00e5 2 timer.\n\n' +
-      '**Retningslinjer:**\n' +
-      '- Still oppf\u00f8lgingssp\u00f8rsm\u00e5l som hjelper brukeren \u00e5 reflektere over egen praksis\n' +
-      '- Vis til relevant innhold p\u00e5 noexcuse.no som utgangspunkt for videre lesning\n' +
-      '- Unng\u00e5 \u00e5 gi ferdige svar eller l\u00f8sninger — m\u00e5let er utforskning, ikke fasit\n' +
-      '- Bruk norsk bokm\u00e5l, v\u00e6r konkret og praktisk rettet mot ledergrupper'
-    );
-  }
-
-  function copyToClipboard(text, callback) {
-    if (navigator.clipboard && navigator.clipboard.writeText) {
-      navigator.clipboard.writeText(text).then(callback).catch(function () {
-        fallbackCopy(text, callback);
-      });
-    } else {
-      fallbackCopy(text, callback);
-    }
-  }
-
-  function fallbackCopy(text, callback) {
-    var ta = document.createElement('textarea');
-    ta.value = text;
-    ta.style.position = 'fixed';
-    ta.style.left = '-9999px';
-    ta.style.top = '0';
-    document.body.appendChild(ta);
-    ta.focus();
-    ta.select();
-    try {
-      document.execCommand('copy');
-      callback();
-    } catch (_) { /* copy failed */ }
-    document.body.removeChild(ta);
-  }
-
-  /* ── Bootstrap ──────────────────────────── */
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', init);
-  } else {
-    init();
-  }
 })();


### PR DESCRIPTION
## R32 — LLM Ask Modal Refactor

### Problem
The review-questions modal had several UX issues: generic SVG icons that don't represent actual services, grid layout wasting space, flat question styling, no collapse/expand for saved preference, copy prompt too prominent, and required manual copy-paste instead of auto-navigation.

### Changes
**assets/scripts/review-questions.js:**
- Removed all 7 provider SVG icons (ICONS object deleted)
- Providers displayed as single-column list (buttons with text only)
- Selecting a provider auto-opens the AI service URL with prompt as ?q= param
- Modal closes immediately after auto-opening
- Saved preference collapses the provider list (shows only selected provider + "Change provider" link)
- Unchecking remember clears preference and expands list
- Copy prompt at bottom, styled as secondary action
- Modal question rendered as <blockquote> (was <p>)

**assets/css/components/questions.css:**
- .provider-grid changed from CSS grid (2-4 cols) to single-column flex list
- .provider-btn redesigned as full-width text row
- .modal-question blockquote styling with left accent border + subtle background
- .provider-selected collapsed view with accent border
- .change-provider-btn styled as inline link (44px touch target)
- .copy-btn demoted to secondary outline button
- Dark mode for all new elements

### Verification
- Cookie preference system preserved (365-day expiry, same key)
- Clipboard API + fallback preserved
- Prompt builder preserved unchanged
- Dark mode verified for all new styles
- Touch targets >= 44x44px

Closes R32