### PR TITLE
W3: Scroll affordances — scroll-down chevron + back-to-top fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Step pages content (R25)**: Substantive body text for `/samtale/`, `/intervju/`, `/rapport/` step pages — expanded leads, what-happens sections, why-it-matters, prerequisites, CTAs. Uses uniform frontmatter schema (hero, intro_text, steps, prerequisites, cta, meta).
+- **Social preview infrastructure (S1)**: Fallback chain (`hero.image → banner → page.image → site default`) for `og:image` and `twitter:image` in `_includes/metadata.html`. Added `url` to `_config.yml` for absolute URLs. Fixed broken `.png` → `.webp` reference. Added `og:image:width/height`.
+- **Alt text accessibility audit (A4)**: Added/improved alt text across all articles and graphics for WCAG AA compliance. Persistent `alt`-per-grid pattern with element-level identifiers for card backgrounds.
+- **Dynamic crosslinking JS (R26)**: Vanilla JS utility (`assets/scripts/cross-links.js`) that injects contextual "Relaterte artikler" callouts at end of article body. URL-based topic detection with 4 cross-link mappings. No `.md` content files modified.
+- **GRC perspective cards refactor (R30)**: Replaced `.info-box` divs with `.card.card--frame` components using existing 16:9 frame banner images. 2×2 responsive grid with `.card-grid--grc`.
+- **LLM ask modal refactor (R32)**: Removed provider SVG icons, single-column list layout, auto-open provider URL on selection, collapse/expand for saved preference (cookie), copy button demoted to secondary. DOM built entirely by JS (`buildModal()`).
+- **Scroll affordances (W3)**: Animated SVG scroll-down chevron at bottom of full heroes (auto-hides via IntersectionObserver). Back-to-top button wired with sentinel + `rootMargin: '100vh'` IntersectionObserver. Respects `prefers-reduced-motion`.
+
+### Changed
+- **Step pages + `/om-metode/` redirect (R25+R31)**: Moved step pages from `_pages/` root to `_steps/` collection with permalinks under `/samtale/`, `/intervju/`, `/rapport/`. Created `/metode/` as canonical hub with `_layouts/metode.html` redirecting `/om-metode/` → `/metode/`. Frame navigation across step pages. Removed orphaned `_includes/step-navigation.html`, `usikkerhet-broken-link.html`.
+- **Mobile header reposition (R28)**: Moved `.nav-toggle` out of `<nav>` into `.banner` so burger and logo share a flex row on mobile. Removed `flex-wrap: wrap` and `flex-direction: column` on mobile header. Single-line header.
+
+### Removed
+- **Orphaned includes cleanup (R31)**: `_includes/step-navigation.html`, `_includes/usikkerhet-broken-link.html` — no longer referenced after step page restructure.
+
 - **Provenance pipeline (Z2.1–Z2.5)**: End-to-end AI-generated content disclosure system:
   - **Z2.1 — Provenance JSON-LD**: `_includes/provenance-jsonld.html` injects `digitalSourceType` `TrainedAlgorithmicMediaDigitalSource` and `license` `CC0-1.0` as standalone JSON-LD `WebPage` block on every page. Respects `page.provenance` frontmatter override (`ai`/`editorial`/`human`). Wired into `_layouts/default.html` after `json-ld.html`.
   - **Z2.2 — CC0 declarations**: `<link rel="license">` in `metadata.html`, `license: CC0-1.0` in `_data/metadata.yml`, `package.json` changed from `UNLICENSED` to `CC0-1.0`, `license`/`license_url` in `_config.yml`, `LICENSE` file (CC0 1.0 Universal full text) at project root.

--- a/_includes/hero.html
+++ b/_includes/hero.html
@@ -66,5 +66,10 @@
     <a href="{{ '/identitet/' | relative_url }}" class="hero-frame-link">Identitet</a>
   </div>
   {% endif %}
+  <div class="scroll-indicator" aria-hidden="true">
+    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M6 9l6 6 6-6"/>
+    </svg>
+  </div>
 </section>
 {% endif %}

--- a/assets/css/components/hero.css
+++ b/assets/css/components/hero.css
@@ -79,6 +79,41 @@
     opacity: 0.85;
 }
 
+/* Scroll-down indicator — animated chevron at bottom of hero */
+.scroll-indicator {
+    position: absolute;
+    bottom: var(--space-lg);
+    left: 50%;
+    transform: translateX(-50%);
+    width: 44px;
+    height: 44px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--primary-azure);
+    z-index: 2;
+    opacity: 1;
+    transition: opacity 0.4s ease;
+    pointer-events: none;
+}
+
+.scroll-indicator svg {
+    animation: scroll-bounce 2s ease-in-out infinite;
+}
+
+@keyframes scroll-bounce {
+    0%, 100% { transform: translateY(0); }
+    50% { transform: translateY(6px); }
+}
+
+.scroll-indicator.is-hidden {
+    opacity: 0;
+}
+
+.dark-mode .scroll-indicator {
+    color: var(--primary-azure);
+}
+
 /* Mobile */
 @media (max-width: 768px) {
     .hero-image {

--- a/assets/scripts/animations.js
+++ b/assets/scripts/animations.js
@@ -97,3 +97,54 @@
         init();
     }
 })();
+
+/* ===== Scroll Affordances ===== */
+(function() {
+    'use strict';
+
+    function init() {
+        var hero = document.querySelector('.hero');
+        var scrollCue = document.querySelector('.scroll-indicator');
+        var backToTop = document.querySelector('.back-to-top');
+
+        // Scroll cue: hide when hero scrolls out of view
+        if (hero && scrollCue) {
+            new IntersectionObserver(function(entries) {
+                if (!entries[0].isIntersecting) {
+                    scrollCue.classList.add('is-hidden');
+                }
+            }).observe(hero);
+        }
+
+        // Back-to-top: show after scrolling past one viewport height
+        if (backToTop) {
+            var sentinel = document.createElement('div');
+            sentinel.style.position = 'absolute';
+            sentinel.style.top = '0';
+            sentinel.style.left = '0';
+            sentinel.style.width = '1px';
+            sentinel.style.height = '1px';
+            document.body.appendChild(sentinel);
+
+            var reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
+
+            // rootMargin extends viewport 100vh upward so the sentinel at
+            // document top stays "intersecting" for the first viewport of scroll
+            new IntersectionObserver(function(entries) {
+                var isPastViewport = !entries[0].isIntersecting;
+                backToTop.classList.toggle('is-visible', isPastViewport);
+                if (isPastViewport && reduceMotion.matches) {
+                    document.documentElement.style.scrollBehavior = 'auto';
+                } else if (isPastViewport) {
+                    document.documentElement.style.scrollBehavior = 'smooth';
+                }
+            }, { rootMargin: '100vh 0px 0px 0px' }).observe(sentinel);
+        }
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();


### PR DESCRIPTION
## What

Two scroll affordances for the hero-to-content transition:

### Scroll-down chevron
- Animated SVG chevron at bottom-center of full hero sections (not frame-hero)
- Gentle 6px bounce animation on 2s ease-in-out loop
- Auto-hides via IntersectionObserver when hero scrolls out of view
- 44×44px touch target, `aria-hidden=\true\`, `var(--primary-azure)` color
- Dark mode supported (same azure, visible on dark overlay)

### Back-to-top button (fix)
- Existing HTML/CSS never activated — JS wiring was missing
- IntersectionObserver with sentinel at document top + `rootMargin: '100vh'`
- Appears after scrolling past ~1 viewport height, disappears near top
- Respects `prefers-reduced-motion` by disabling smooth scroll

### Technical approach
Both affordances use IntersectionObserver (no scroll event listeners) — matches the existing pattern in `animations.js` for the parallax-fade hero effect.

## Files changed
- `_includes/hero.html` — scroll-indicator div with SVG chevron inside full hero section
- `assets/css/components/hero.css` — scroll-indicator positioning, bounce keyframes, hidden state transition
- `assets/scripts/animations.js` — new IIFE for scroll affordances IntersectionObserver logic

## Closes
- W3 (BACKLOG.md)
- Partially addresses I2 phase 2 (wire back-to-top JS)

## How to test
1. Load any page with a full hero (e.g., homepage, perspektiv pages)
2. Scroll down — chevron should fade out as hero leaves viewport
3. Continue scrolling — back-to-top button appears after ~1 viewport height
4. Press back-to-top — smooth scroll to top
5. Near top — back-to-top disappears
6. Check with `prefers-reduced-motion: reduce` — button still appears but scroll behavior is instant

## Pre-merge notes
- No local lint/test/CI available (no Ruby/Jekyll, no Biome). Visual inspection only.
- PR #144 (/om-metode/ → /metode/) may affect which pages have full heroes