### PR TITLE
I2 Phase 4: Remove empty cases and partners collections from _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,10 +8,6 @@ collections:
   pages:
     output: true
     permalink: /:path/
-  cases:
-    output: true
-  partners:
-    output: true
   tags:
     output: true
     permalink: /emne/:path/


### PR DESCRIPTION
## What

I2 Phase 4 — Remove empty Jekyll collection registrations that are no longer used. The site uses the page-class query model (`site.pages | where: "class", "case"`) instead of separate collections.

### Changed
- `_config.yml` — removed `cases:` and `partners:` collection registrations (both had `output: true` but no corresponding collection directories)

### Not affected
- `_includes/partners.html` continues to work (queries `site.pages where: class: "partner"`)
- All other collections preserved: `pages`, `tags`

## Closes
- I2 Phase 4 (BACKLOG.md)

## How to test
- `_config.yml` no longer has `cases:` or `partners:` under `collections:`
- All pages render identically

## Pre-merge notes
- Single file change, 4 lines removed
