### PR TITLE
feat(layout): nav reorganization, page layout, pure MD conversion, terminology fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **Back-to-top fix (I2 Phase 2, via W3)**: Wired `.back-to-top` button with IntersectionObserver sentinel + rootMargin. Implemented in `animations.js` as part of the scroll affordances feature.
 
+### Added
+- **Page layout (no-id)**: New `_layouts/page.html` — minimal article-body wrapper for pure-markdown pages without sidebar, replacing `layout: default` + inline HTML pattern.
+
+### Changed
+- **Nav/layout reorganization**: Removed newsletter signup from `_layouts/article.html` and `_layouts/home.html`. Moved cross-link pager to dedicated left sidebar column in article grid. Repositioned questions include into right sidebar alongside TOC with compact styling. Removed hero include and hero frontmatter from `index.md`/home layout. Fixed `.nav-featured` selector in `navbar.css` to target direct child of `.navbar` (was only `.nav-links a.nav-featured`, never matched).
+- **Content → pure MD**: Converted `_pages/personvern.md` from `layout: default` + inline HTML to `layout: page` + pure markdown. Converted `_pages/ledelse_60-2.md` body to pure markdown — removed `{% include %}` and `{{ page.story }}` variable references, added `show_cta_buttons`/`show_metodikk_callout` frontmatter booleans for conditional gating in `_layouts/product.html`.
+- **Terminology: vitenskapelig → kunnskapsbasert**: Updated `_pages/om_metode.md` hero alt text, `_includes/metodikk-callout.html` heading, and `_pages/ledelse_60-2.md` body text. Historical entry in CHANGELOG.md left intact.
+
 ## [1.9.0] - 2026-06-08
 
 ### Added

--- a/_includes/metodikk-callout.html
+++ b/_includes/metodikk-callout.html
@@ -1,5 +1,5 @@
 <div class="info-box metodikk-callout">
-  <h3>Vitenskapelig fundament</h3>
+  <h3>Kunnskapsbasert fundament</h3>
   <p>Ledelse 60:2 bygger på etterprøvbare beskrivelser av ledelsesfunksjonen, med utgangspunkt i anerkjent organisasjonsteori.</p>
   <a href="/metode/" class="metodikk-link">Les mer om metoden →</a>
 </div>

--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -12,6 +12,9 @@ layout: default
     <div class="frame-content frame-{{ page.frame_id }}">
   {% else %}
     <div class="article-layout">
+      <aside class="article-pager" aria-label="Relaterte artikler" hidden>
+        <div class="js-pager-list"></div>
+      </aside>
       <div class="section container--wide article-body animate-on-scroll fade-in-up">
         <details class="toc-collapsible">
           <summary>Innholdsfortegnelse</summary>
@@ -29,6 +32,10 @@ layout: default
       </div>
       <aside class="article-sidebar" aria-label="Sidemeny">
         {% include sidebar-toc.html %}
+        {% if page.questions %}
+          {% capture question_list %}{{ page.questions | join: "||" }}{% endcapture %}
+          {% include questions.html title=page.questions_title questions=question_list %}
+        {% endif %}
       </aside>
     </div>
   {% endif %}
@@ -66,9 +73,4 @@ layout: default
 {% include cases-cards.html %}
 {% include references.html %}
 
-{% if page.questions %}
-  {% capture question_list %}{{ page.questions | join: "||" }}{% endcapture %}
-  {% include questions.html title=page.questions_title questions=question_list %}
-{% endif %}
 
-{% include newsletter-signup.html %}

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -1,7 +1,6 @@
 ---
 layout: default
 ---
-{% include hero.html %}
 {% include stat-bridge.html %}
 <div class="home-layout">
   <div class="home-content-area">
@@ -16,6 +15,5 @@ layout: default
     {% include sidebar-home.html %}
   </aside>
 </div>
-{% include newsletter-signup.html %}
 {% include cta-section.html %}
 {% include partners.html %}

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -1,0 +1,6 @@
+---
+layout: default
+---
+<div class="section container--wide article-body animate-on-scroll fade-in-up">
+{{ content }}
+</div>

--- a/_layouts/product.html
+++ b/_layouts/product.html
@@ -24,7 +24,15 @@ layout: default
 {% endif %}
 
 <div class="section container--wide article-body animate-on-scroll fade-in-up">
+{% if page.show_cta_buttons %}
+  {% include cta-buttons.html %}
+{% endif %}
+
 {{ content }}
+
+{% if page.show_metodikk_callout %}
+  {% include metodikk-callout.html %}
+{% endif %}
 </div>
 
 {% include cta-section.html %}

--- a/_pages/ledelse_60-2.md
+++ b/_pages/ledelse_60-2.md
@@ -3,6 +3,8 @@ class: product
 layout: product
 show_benefit_cards: true
 show_step_cards: true
+show_cta_buttons: true
+show_metodikk_callout: true
 title: "Ledelse 60:2 — Orientering for ledergruppen"
 description: "Tidseffektiv orientering for ledergruppen — 60 diagnostiske spørsmål, 2 timer, felles retningsvalg."
 permalink: /ledelse-60-2/
@@ -21,7 +23,6 @@ hero_effect: parallax-fade
 stat_bridge: "4 perspektiver · 60 spørsmål · 2 timer"
 benefit_heading: "Fordeler med Ledelse 60:2"
 step_heading: "Slik fungerer det"
-story: "«Ledelse 60:2» er vår tilnærming til å bruke en enkel vitenskapelig metode for å sammenlikne etterprøvbare beskrivelser av ledelsesfunksjonen på et gitt nivå i en virksomhet. Virksomhetens utbytte er å få et bedre beslutningsgrunnlag for å prioritere forbedringer av hvordan ledelsen fungerer, og forbedring av administrative støttefunksjoner for styring og kontroll. Vår motivasjon er å bidra til utviklingen ny kunnskap om nordisk ledelses- og styringspraksis, noe som vi tror vil være viktig for norske virksomheters konkurranseevne."
 image: "assets/images/hero-illustration.webp"
 tags: "#ledelse #orientering #analyse #ledelse60-2"
 json_ld:
@@ -62,12 +63,8 @@ cta:
   body: "Vi finner ut om Ledelse 60:2 er rett for dere. Ingen binding, ingen salgspitch — bare en ærlig vurdering."
 ---
 
-{% include cta-buttons.html %}
-
 ## Historien bak metoden
 
-{{ page.story }}
+«Ledelse 60:2» er vår tilnærming til å bruke en enkel kunnskapsbasert metode for å sammenlikne etterprøvbare beskrivelser av ledelsesfunksjonen på et gitt nivå i en virksomhet. Virksomhetens utbytte er å få et bedre beslutningsgrunnlag for å prioritere forbedringer av hvordan ledelsen fungerer, og forbedring av administrative støttefunksjoner for styring og kontroll. Vår motivasjon er å bidra til utviklingen ny kunnskap om nordisk ledelses- og styringspraksis, noe som vi tror vil være viktig for norske virksomheters konkurranseevne.
 
 ![Trinn 1: Uforpliktende samtale → Trinn 2: Strukturert intervju → Trinn 3: Rapport og anbefalinger](/assets/images/banners/ledelse-60-2-t2-prosessflyt.webp)
-
-{% include metodikk-callout.html %}

--- a/_pages/om_metode.md
+++ b/_pages/om_metode.md
@@ -7,7 +7,7 @@ permalink: /metode/
 og_image: /assets/images/banners/om-metode-og.webp
 hero:
   image: /assets/images/banners/science-foundation.webp
-  alt: "Vitenskapelig fundament"
+  alt: "Kunnskapsbasert fundament"
   title: "Om metodikk"
   intro: "Strukturerte intervjuer for kartlegging av ledergrupper."
 hero_effect: parallax-fade

--- a/_pages/personvern.md
+++ b/_pages/personvern.md
@@ -1,70 +1,56 @@
 ---
-layout: default
+layout: page
 title: "Personvernerklæring"
 description: "Hvordan No Excuse AS behandler dine personopplysninger — i tråd med GDPR (forordning 2016/679)."
 permalink: /personvern/
 ---
-<article class="section container--wide article-body animate-on-scroll fade-in-up">
-  <h1>Personvernerklæring</h1>
 
-  <p><strong>Sist oppdatert:</strong> {{ site.time | date: "%-d. %B %Y" }}</p>
+# Personvernerklæring
 
-  <p>No Excuse AS (org. nr. 934 418 880) behandler personopplysninger i samsvar med gjeldende personvernlovgivning, herunder EUs personvernforordning (GDPR). Denne erklæringen forklarer hvilke opplysninger vi samler inn, hvorfor vi samler dem inn, og hvilke rettigheter du har.</p>
+**Sist oppdatert:** 11. juni 2026
 
-  <h2>Behandlingsansvarlig</h2>
-  <p>
-    No Excuse AS<br>
-    E-post: <a href="mailto:ledelse@noexcuse.no">ledelse@noexcuse.no</a><br>
-    Org. nr.: 934 418 880
-  </p>
+No Excuse AS (org. nr. 934 418 880) behandler personopplysninger i samsvar med gjeldende personvernlovgivning, herunder EUs personvernforordning (GDPR). Denne erklæringen forklarer hvilke opplysninger vi samler inn, hvorfor vi samler dem inn, og hvilke rettigheter du har.
 
-  <h2>Hvilke opplysninger samler vi inn?</h2>
-  <p>Vi samler kun inn opplysninger du selv gir oss:</p>
-  <ul>
-    <li><strong>E-postadresse:</strong> Når du melder deg på nyhetsbrev</li>
-    <li><strong>Navn, e-post og melding:</strong> Når du sender oss en henvendelse via kontaktskjemaet</li>
-  </ul>
+## Behandlingsansvarlig
 
-  <h2>Formål og rettslig grunnlag</h2>
-  <table>
-    <thead>
-      <tr>
-        <th>Formål</th>
-        <th>Opplysninger</th>
-        <th>Rettslig grunnlag</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>Nyhetsbrev</td>
-        <td>E-postadresse</td>
-        <td>Samtykke (GDPR art. 6(1)a)</td>
-      </tr>
-      <tr>
-        <td>Kontaktskjema</td>
-        <td>Navn, e-post, melding</td>
-        <td>Samtykke (GDPR art. 6(1)a)</td>
-      </tr>
-    </tbody>
-  </table>
+No Excuse AS\
+E-post: [ledelse@noexcuse.no](mailto:ledelse@noexcuse.no)\
+Org. nr.: 934 418 880
 
-  <h2>Lagring og behandling</h2>
-  <p>Opplysningene lagres sikkert og benyttes kun til det formålet de er samlet inn for. Nyhetsbrev-abonnenter beholdes inntil du melder deg av. Kontakthenvendelser slettes når saken er avsluttet, med mindre annet er avtalt.</p>
+## Hvilke opplysninger samler vi inn?
 
-  <h2>Dine rettigheter</h2>
-  <p>Du har rett til:</p>
-  <ul>
-    <li>Innsyn i hvilke opplysninger vi har lagret om deg</li>
-    <li>Be om retting eller sletting av dine opplysninger</li>
-    <li>Be om begrensning av behandling</li>
-    <li>Dataportabilitet</li>
-    <li>Når som helst trekke tilbake samtykke</li>
-  </ul>
-  <p>Ta kontakt på <a href="mailto:ledelse@noexcuse.no">ledelse@noexcuse.no</a> for å benytte deg av dine rettigheter. Vi svarer innen 30 dager.</p>
+Vi samler kun inn opplysninger du selv gir oss:
 
-  <h2>Klagemulighet</h2>
-  <p>Dersom du mener at vår behandling av personopplysninger ikke er i samsvar med gjeldende regelverk, kan du klage til <a href="https://www.datatilsynet.no/" rel="nofollow noopener">Datatilsynet</a>.</p>
+- **E-postadresse:** Når du melder deg på nyhetsbrev
+- **Navn, e-post og melding:** Når du sender oss en henvendelse via kontaktskjemaet
 
-  <h2>Endringer</h2>
-  <p>Denne erklæringen kan oppdateres ved behov. Dato for siste oppdatering står øverst på siden. Ved vesentlige endringer vil vi varsle tydelig på nettstedet.</p>
-</article>
+## Formål og rettslig grunnlag
+
+| Formål | Opplysninger | Rettslig grunnlag |
+|--------|-------------|-------------------|
+| Nyhetsbrev | E-postadresse | Samtykke (GDPR art. 6(1)a) |
+| Kontaktskjema | Navn, e-post, melding | Samtykke (GDPR art. 6(1)a) |
+
+## Lagring og behandling
+
+Opplysningene lagres sikkert og benyttes kun til det formålet de er samlet inn for. Nyhetsbrev-abonnenter beholdes inntil du melder deg av. Kontakthenvendelser slettes når saken er avsluttet, med mindre annet er avtalt.
+
+## Dine rettigheter
+
+Du har rett til:
+
+- Innsyn i hvilke opplysninger vi har lagret om deg
+- Be om retting eller sletting av dine opplysninger
+- Be om begrensning av behandling
+- Dataportabilitet
+- Når som helst trekke tilbake samtykke
+
+Ta kontakt på [ledelse@noexcuse.no](mailto:ledelse@noexcuse.no) for å benytte deg av dine rettigheter. Vi svarer innen 30 dager.
+
+## Klagemulighet
+
+Dersom du mener at vår behandling av personopplysninger ikke er i samsvar med gjeldende regelverk, kan du klage til [Datatilsynet](https://www.datatilsynet.no/).
+
+## Endringer
+
+Denne erklæringen kan oppdateres ved behov. Dato for siste oppdatering står øverst på siden. Ved vesentlige endringer vil vi varsle tydelig på nettstedet.

--- a/assets/css/components/sidebar.css
+++ b/assets/css/components/sidebar.css
@@ -4,11 +4,11 @@
 
 /* --- Layout Grids --- */
 
-/* Article pages: centered content + 320px right sidebar */
+/* Article pages: left pager + centered content + 320px right sidebar */
 .article-layout {
     display: grid;
-    grid-template-columns: 1fr minmax(auto, 800px) 320px 1fr;
-    grid-template-areas: ". content sidebar .";
+    grid-template-columns: 1fr 240px minmax(auto, 800px) 320px 1fr;
+    grid-template-areas: ". pager content sidebar .";
 }
 
 /* Homepage: wider content + 300px right sidebar */
@@ -28,9 +28,96 @@
     grid-area: content;
 }
 
+.article-layout > .article-pager {
+    grid-area: pager;
+}
+
 .article-layout > .article-sidebar,
 .home-layout > .home-sidebar {
     grid-area: sidebar;
+}
+
+/* --- Left Pager Panel (cross-links) --- */
+
+.article-pager {
+    position: sticky;
+    top: calc(var(--header-height, 85px) + var(--space-md, 16px));
+    align-self: start;
+    max-height: calc(100vh - var(--header-height, 85px) - var(--space-2xl, 40px));
+    overflow-y: auto;
+    overscroll-behavior: contain;
+
+    background: var(--box-background-light);
+    border-radius: var(--radius-xl);
+    box-shadow: var(--shadow-sm);
+    padding: var(--space-lg);
+    font-size: 0.9em;
+}
+
+.article-pager[hidden] {
+    display: none;
+}
+
+.dark-mode .article-pager {
+    background: var(--box-background-dark);
+    box-shadow: var(--shadow-sm-dark);
+}
+
+/* Cross-link list inside pager */
+.article-pager .cross-link-section {
+    margin: 0;
+    padding: 0;
+}
+
+.article-pager .cross-link-label {
+    font-size: 0.85em;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    opacity: 0.6;
+    margin: 0 0 var(--space-sm);
+}
+
+.article-pager .cross-link-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.article-pager .cross-link-list li {
+    margin-bottom: var(--space-sm);
+    line-height: 1.4;
+}
+
+.article-pager .cross-link-list li:last-child {
+    margin-bottom: 0;
+}
+
+.article-pager .cross-link {
+    color: var(--link-color-light);
+    text-decoration: none;
+    font-weight: 500;
+    font-size: 0.9em;
+}
+
+.article-pager .cross-link:hover {
+    text-decoration: underline;
+    color: var(--link-hover-light);
+}
+
+.dark-mode .article-pager .cross-link {
+    color: var(--link-color-dark);
+}
+
+.dark-mode .article-pager .cross-link:hover {
+    color: var(--link-hover-dark);
+}
+
+.article-pager .cross-link-desc {
+    display: block;
+    font-size: 0.82em;
+    opacity: 0.7;
+    margin-top: 1px;
 }
 
 /* --- Sidebar Panel --- */
@@ -266,6 +353,65 @@
     display: none;
 }
 
+/* Questions rendered directly inside sidebar (from questions.html include) */
+.article-sidebar .review-questions {
+    padding: 0;
+    margin: 0;
+    max-width: none;
+}
+
+.article-sidebar .review-questions.section {
+    padding-block: 0;
+}
+
+.article-sidebar .review-questions h2 {
+    font-size: 0.85em;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    opacity: 0.6;
+    margin: 0 0 var(--space-sm);
+    padding: 0;
+}
+
+.article-sidebar .review-questions ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.article-sidebar .review-questions li {
+    font-size: 0.85em;
+    padding: var(--space-xs) 0;
+    cursor: pointer;
+    line-height: 1.4;
+    opacity: 0.85;
+    transition: opacity 0.2s ease;
+    border: none;
+    border-radius: 0;
+    min-height: auto;
+    gap: var(--space-sm);
+}
+
+.article-sidebar .review-questions li:hover {
+    opacity: 1;
+    background: transparent;
+    box-shadow: none;
+}
+
+.article-sidebar .review-questions .click-hint {
+    width: 14px;
+    height: 14px;
+    flex-shrink: 0;
+    margin-top: 2px;
+    color: var(--primary-accent);
+    opacity: 0.5;
+}
+
+.article-sidebar .review-questions li span {
+    font-size: 1em;
+}
+
 /* --- Homepage Sidebar Content --- */
 
 .sidebar-featured-articles {
@@ -333,6 +479,7 @@
         display: block;
     }
 
+    .article-pager,
     .article-sidebar,
     .home-sidebar {
         display: none;

--- a/assets/css/navbar.css
+++ b/assets/css/navbar.css
@@ -31,13 +31,16 @@
     background-color: var(--nav-hover-bg-light);
 }
 
-/* Featured nav item — subtle CTA pill for Ledelse 60:2 */
+/* Featured nav item — subtle CTA pill for Ledelse 60:2
+   Link is a direct child of .navbar (not inside .nav-links) */
+a.nav-featured,
 .nav-links a.nav-featured {
     border: 2px solid var(--primary-accent);
     color: var(--primary-accent);
     padding: 8px 18px;
 }
 
+a.nav-featured:hover,
 .nav-links a.nav-featured:hover {
     background-color: var(--primary-accent);
     color: var(--primary-accent-contrast);
@@ -124,11 +127,13 @@ body.no-scroll {
     background-color: var(--nav-hover-bg-dark);
 }
 
+.dark-mode a.nav-featured,
 .dark-mode .nav-links a.nav-featured {
     border-color: var(--primary-accent);
     color: var(--primary-accent);
 }
 
+.dark-mode a.nav-featured:hover,
 .dark-mode .nav-links a.nav-featured:hover {
     background-color: var(--primary-accent);
     color: var(--primary-accent-contrast);

--- a/assets/scripts/cross-links.js
+++ b/assets/scripts/cross-links.js
@@ -86,32 +86,49 @@
     }
 
     /**
-     * Inject cross-link callouts after <h2> headings in the article body.
-     * Each heading gets one callout containing all relevant links.
+     * Inject cross-link callouts into the left pager sidebar.
      */
     function injectCallouts(config) {
-        var articleBody = document.querySelector('.article-body');
-        if (!articleBody) return;
+        var pager = document.querySelector('.article-pager');
+        var pagerTarget = pager && pager.querySelector('.js-pager-list');
 
-        var headings = articleBody.querySelectorAll('h2');
-        if (headings.length === 0) return;
+        if (pagerTarget) {
+            // Inject into left pager sidebar
+            var list = buildLinkList(config);
+            pagerTarget.appendChild(list);
+            pager.removeAttribute('hidden');
+        } else {
+            // Fallback: inject after last h2 in article body (no pager layout)
+            var articleBody = document.querySelector('.article-body');
+            if (!articleBody) return;
 
-        // Build a single callout with all links
-        var callout = document.createElement('div');
-        callout.className = 'cross-link-section';
+            var headings = articleBody.querySelectorAll('h2');
+            if (headings.length === 0) return;
 
-        var label = document.createElement('p');
-        label.className = 'cross-link-label';
-        label.textContent = 'Relaterte artikler:';
-        callout.appendChild(label);
+            var callout = document.createElement('div');
+            callout.className = 'cross-link-section';
 
+            var label = document.createElement('p');
+            label.className = 'cross-link-label';
+            label.textContent = 'Relaterte artikler:';
+            callout.appendChild(label);
+
+            var list = buildLinkList(config);
+            callout.appendChild(list);
+
+            var lastHeading = headings[headings.length - 1];
+            lastHeading.parentNode.insertBefore(callout, lastHeading.nextSibling);
+        }
+    }
+
+    /** Build a <ul class="cross-link-list"> from config links */
+    function buildLinkList(config) {
         var list = document.createElement('ul');
         list.className = 'cross-link-list';
 
         for (var i = 0; i < config.links.length; i++) {
             var item = document.createElement('li');
             var link = createCallout(config.links[i]);
-            // Replace <aside> wrapper with direct link (already inside <li>)
             var anchor = link.querySelector('a');
             var descSpan = link.querySelector('.cross-link-desc');
 
@@ -134,11 +151,7 @@
             list.appendChild(item);
         }
 
-        callout.appendChild(list);
-
-        // Insert after the last h2
-        var lastHeading = headings[headings.length - 1];
-        lastHeading.parentNode.insertBefore(callout, lastHeading.nextSibling);
+        return list;
     }
 
     function init() {

--- a/index.md
+++ b/index.md
@@ -2,13 +2,6 @@
 layout: home
 title: "No Excuse AS"
 description: "No Excuse AS hjelper ledergrupper med å bli bedre — uten byråkrati. 60 diagnostiske spørsmål på 2 timer."
-hero:
-  image: /assets/images/hero-illustration.webp
-  alt: "No Excuse AS — Ledergrupper fortjener bedre diagnoseverktøy"
-  title: "Ledergrupper fortjener bedre diagnoseverktøy"
-  intro: "De fleste ledelsesverktøy reduserer kompleksitet til en poengsum. Vi gjør det motsatte: 60 spørsmål på 2 timer som avdekker mønstre, ikke tall."
-  cta_text: "Bestill uforpliktende samtale"
-  cta_url: "https://outlook.office.com/book/ledelse@noexcuse.no/?ismsaljsauthenabled"
 stat_bridge: "4 perspektiver · 60 spørsmål · 2 timer"
 json_ld:
   - type: "Organization"


### PR DESCRIPTION
## Summary

Four groups of changes on the nav/layout/infrastructure front:

### Nav/layout reorganization
- Removed newsletter signup from article and home layouts (was premature without backend)
- Moved cross-link pager to a dedicated left sidebar column (.article-pager) in the article grid
- Repositioned questions include into the right sidebar alongside TOC with compact styling
- Removed hero include from home layout and hero frontmatter from index.md
- Fixed .nav-featured selector to target direct child of .navbar (was only .nav-links a.nav-featured, never matched)

### New page layout
- Created _layouts/page.html — minimal article-body wrapper for pure-markdown pages without sidebar
- Replaces the layout: default + inline HTML pattern used by pages like personvern

### Content → pure MD
- Converted personvern.md from inline HTML to pure markdown
- Converted ledelse_60-2.md body to pure markdown — removed Liquid {% include %} and {{ page.story }} references
- Added show_cta_buttons / show_metodikk_callout frontmatter booleans for conditional gating in _layouts/product.html

### Terminology
- vitenskapelig → kunnskapsbasert in 3 files: om_metode.md, ledelse_60-2.md, metodikk-callout.html

## How to test
1. bundle exec jekyll build — should exit 0
2. Visit /personvern/ — should render as clean markdown (no inline HTML)
3. Visit any article page — cross-links in left sidebar, questions in right sidebar
4. Visit / (home) — no newsletter form, no hero section
5. Visit /ledelse-60-2/ — content reads kunnskapsbasert, not vitenskapelig
6. Nav pill Ledelse 60:2 styled correctly (a.nav-featured matching)

## Pre-merge notes
- No pre-existing lint/test failures outside these changes
- bundle exec jekyll build confirmed passing