### PR TITLE
feat(content): convert Ledelse 60:2 benefits and steps to pure markdown

### DIFF
--- a/_layouts/product.html
+++ b/_layouts/product.html
@@ -5,24 +5,6 @@ layout: default
 
 {% include stat-bridge.html %}
 
-{% if page.show_benefit_cards %}
-<section class="section section--benefit-grid animate-on-scroll fade-in-up">
-  {% if page.benefit_heading %}
-  <h2 class="section-heading">{{ page.benefit_heading }}</h2>
-  {% endif %}
-  {% include benefit-cards.html %}
-</section>
-{% endif %}
-
-{% if page.show_step_cards %}
-<section class="section section--step-grid animate-on-scroll fade-in-up">
-  {% if page.step_heading %}
-  <h2 class="section-heading">{{ page.step_heading }}</h2>
-  {% endif %}
-  {% include step-cards.html %}
-</section>
-{% endif %}
-
 <div class="section container--wide article-body animate-on-scroll fade-in-up">
 {% if page.show_cta_buttons %}
   {% include cta-buttons.html %}

--- a/_pages/ledelse_60-2.md
+++ b/_pages/ledelse_60-2.md
@@ -1,8 +1,6 @@
 ---
 class: product
 layout: product
-show_benefit_cards: true
-show_step_cards: true
 show_cta_buttons: true
 show_metodikk_callout: true
 title: "Ledelse 60:2 — Orientering for ledergruppen"
@@ -21,8 +19,6 @@ hero:
   cta_url: "https://outlook.office.com/book/ledelse@noexcuse.no/?ismsaljsauthenabled"
 hero_effect: parallax-fade
 stat_bridge: "4 perspektiver · 60 spørsmål · 2 timer"
-benefit_heading: "Fordeler med Ledelse 60:2"
-step_heading: "Slik fungerer det"
 image: "assets/images/hero-illustration.webp"
 tags: "#ledelse #orientering #analyse #ledelse60-2"
 json_ld:
@@ -63,8 +59,36 @@ cta:
   body: "Vi finner ut om Ledelse 60:2 er rett for dere. Ingen binding, ingen salgspitch — bare en ærlig vurdering."
 ---
 
-## Historien bak metoden
+## Fordeler med Ledelse 60:2
 
-«Ledelse 60:2» er vår tilnærming til å bruke en enkel kunnskapsbasert metode for å sammenlikne etterprøvbare beskrivelser av ledelsesfunksjonen på et gitt nivå i en virksomhet. Virksomhetens utbytte er å få et bedre beslutningsgrunnlag for å prioritere forbedringer av hvordan ledelsen fungerer, og forbedring av administrative støttefunksjoner for styring og kontroll. Vår motivasjon er å bidra til utviklingen ny kunnskap om nordisk ledelses- og styringspraksis, noe som vi tror vil være viktig for norske virksomheters konkurranseevne.
+Metoden gir deg et strukturert bilde av ledergruppens modenhet på tvers av fire rammer — struktur, mennesker, påvirkning og identitet. Her er områdene vi utforsker:
+
+- **[Tillitsbasert ledelse](/tillit/)** — Hvordan psykologisk trygghet og tillit fungerer i praksis, og hvorfor det er den viktigste faktoren for en velfungerende organisasjon.
+- **[Organisasjonskultur](/kultur/)** — Forstå kulturen som styrer atferden, fra Scheins tre nivåer til Logans kulturstadier.
+- **[Forankring og forpliktelse](/forankring/)** — Hvordan beslutninger faktisk tas i organisasjoner, og hvorfor rasjonelle ledere ofte tar irrasjonelle valg.
+- **[Ledelse under usikkerhet](/usikkerhet/)** — Naviger usikkerhet og endring med modne ledergrupper og forskningsbaserte verktøy.
+- **[Endringsledelse](/endringsledelse/)** — Hvorfor de fleste endringsinitiativ feiler, og hva forskningen sier om varig endring.
+- **[Generativ KI-ledelse](/generativ-ki/)** — Hvordan lede ansatte som styrer AI-modeller, og utvikle ledelseskompetanse for en ny æra.
+- **[Risikostyring](/risikostyring/)** — Gjør risikostyring til en integrert del av ledelsesdialogen, ikke bare en årlig øvelse.
+- **[Kvalitetsledelse](/kvalitetsledelse/)** — Fra kontrollbyråkrati til kontinuerlig forbedring, utover ISO 9001-sertifisering.
+- **[Compliance](/compliance/)** — Bygg en samsvarskultur som faktisk fungerer, ikke bare papir og prosedyrer.
+- **[Informasjonssikkerhet](/informasjonssikkerhet/)** — Informasjonssikkerhet er et ledelsesansvar, ikke et IT-problem.
+- **[Bærekraft og samfunnsansvar](/baerekraft/)** — Autentisk bærekraftsarbeid som er forankret i ledelsens identitet, ikke grønnvasking.
+
+## Slik fungerer det
+
+Ledelse 60:2 er bygget opp i tre trinn. Hele prosessen tar to timer fordelt på strukturerte samtaler.
+
+**Trinn 1: Uforpliktende samtale** — Vi tar en prat for å bli kjent med hverandre og raskt avklare om metoden passer for dere. Ingen kontrakter, ingen forpliktelser. Du beskriver situasjonen deres, og vi gir en umiddelbar vurdering. [Les mer om samtalen →](/samtale/)
+
+**Trinn 2: Strukturert intervju** — Kjerneøvelsen i Ledelse 60:2. Vi gjennomfører et strukturert intervju med inntil fem ledere der vi sammen reflekterer over 60 diagnostiske spørsmål fordelt på fire rammer. Selve samtalen er like verdifull som analysen. [Les mer om intervjuet →](/intervju/)
+
+**Trinn 3: Rapport og anbefalinger** — Du får en tydelig rapport som viser hvor dere står sammenliknet med typisk bestepraksis. Ikke generisk teoristoff, men konkrete funn fra intervjuet med ledergruppen deres. Rapporten leveres normalt innen en uke. [Les mer om rapporten →](/rapport/)
 
 ![Trinn 1: Uforpliktende samtale → Trinn 2: Strukturert intervju → Trinn 3: Rapport og anbefalinger](/assets/images/banners/ledelse-60-2-t2-prosessflyt.webp)
+
+## Historien bak metoden
+
+«Ledelse 60:2» er vår tilnærming til å bruke en enkel kunnskapsbasert metode for å sammenlikne etterprøvbare beskrivelser av ledelsesfunksjonen på et gitt nivå i en virksomhet. Virksomhetens utbytte er å få et bedre beslutningsgrunnlag for å prioritere forbedringer av hvordan ledelsen fungerer, og forbedring av administrative støttefunksjoner for styring og kontroll. Vår motivasjon er å bidra til utviklingen av ny kunnskap om nordisk ledelses- og styringspraksis, noe som vi tror vil være viktig for norske virksomheters konkurranseevne.
+
+Metoden bygger på Bolman & Deals fire rammeverk for ledelse, kombinert med praktisk erfaring fra norsk arbeidsliv. Vi har utviklet 60 spørsmål som dekker de viktigste dimensjonene av ledelsesfunksjonen, og testet dem i en rekke ledergrupper på tvers av bransjer og organisasjonsstørrelser. Spørsmålene er designet for å skape refleksjon og innsikt, ikke for å gi enkle poengsummer eller rangeringer.


### PR DESCRIPTION
## Summary

The Ledelse 60:2 page relied on dynamic Liquid includes (`benefit-cards.html`, `step-cards.html`) and frontmatter flags to render its main content sections. These are now written directly as markdown in `_pages/ledelse_60-2.md`.

### Changes

**ledelse_60-2.md:**
- Replaced the old 4-line body (only "Historien bak metoden") with three full markdown sections:
  - **Fordeler med Ledelse 60:2** — structured list of all 11 benefit topics with descriptions and inline links
  - **Slik fungerer det** — three-step walkthrough with bold headings, descriptions, and links to /samtale/, /intervju/, /rapport/
  - **Historien bak metoden** — original paragraph preserved + new paragraph about Bolman & Deals rammeverk and question development
- Removed `show_benefit_cards`, `show_step_cards`, `benefit_heading`, `step_heading` from frontmatter

**product.html layout:**
- Removed the `section--benefit-grid` and `section--step-grid` template blocks (content now rendered inline via `{{ content }}`)

### How to test
1. Pages using `layout: product` still build (only ledelse_60-2.md used the removed frontmatter flags)
2. Visit /ledelse-60-2/ — all three sections visible as body text, no empty card grids

### Pre-merge notes
- The `benefit-cards.html` and `step-cards.html` includes still exist in `_includes/` but are no longer referenced from any layout. Candidates for cleanup in a follow-up.