### PR TITLE
fix(layout): restore header logo, fix gutter positions, wire gutter burger menu

### DIFF
--- a/_pages/identitet.md
+++ b/_pages/identitet.md
@@ -100,22 +100,22 @@ En moden ledelse forstår at risiko ikke er noe man setter på lista en gang i �
 
 ![Illustrasjon av vanlige identitetsrelaterte utfordringer](/assets/images/banners/illustrasjon-identitet-utfordringer.webp)
 
-*   ![Abstrakt illustrasjon av tomme verdier som ikke er forankret](/assets/images/banners/identitet-t4-empty-values.webp "")
+*   ![Abstrakt illustrasjon av tomme verdier som ikke er forankret](/assets/images/banners/identitet-t4-empty-values.webp)
 
     #### Tomme verdier
 
     Verdier som ikke reflekterer faktisk atferd. Konsulentlede verdiprogrammer som aldri ble forankret.
-*   ![Abstrakt illustrasjon av individuell dominans i organisasjonskultur](/assets/images/banners/identitet-t4-individual-dominance.webp "")
+*   ![Abstrakt illustrasjon av individuell dominans i organisasjonskultur](/assets/images/banners/identitet-t4-individual-dominance.webp)
 
     #### Individuell dominans
 
     En kultur preget av «stjerneledere» og individualisme. Belønning av «helt-innsats» heller enn samarbeid. Individualistisk tankegang som demper kollektiv vekst.
-*   ![Abstrakt illustrasjon av historieløs organisasjon uten fortellinger](/assets/images/banners/identitet-t4-storylessness.webp "")
+*   ![Abstrakt illustrasjon av historieløs organisasjon uten fortellinger](/assets/images/banners/identitet-t4-storylessness.webp)
 
     #### Historieløshet
 
     En organisasjon uten fortellinger — nye folk får ingen kontekst. Kulturen er usynlig fordi den aldri er blitt eksplisitt.
-*   ![Abstrakt illustrasjon av forandringstretthet i organisasjonen](/assets/images/banners/identitet-t4-change-fatigue.webp "")
+*   ![Abstrakt illustrasjon av forandringstretthet i organisasjonen](/assets/images/banners/identitet-t4-change-fatigue.webp)
 
     #### Forandringstretthet
 

--- a/_pages/ledelse_forankring.md
+++ b/_pages/ledelse_forankring.md
@@ -139,22 +139,22 @@ Daniel Kahneman og Amos Tversky dokumenterte hvordan menneskelig tenkning system
 
 ## Vanlige beslutningsfallgruber
 
-*   ![Abstrakt illustrasjon av bekreftelsesbias](/assets/images/banners/forankring-t4-confirmation.webp "")
+*   ![Abstrakt illustrasjon av bekreftelsesbias](/assets/images/banners/forankring-t4-confirmation.webp)
 
     #### Bekreftelsesbias
 
     Vi søker informasjon som støtter det vi allerede tror, og ignorerer det som utfordrer det. Beslutninger tas basert på ønsketenkning.
-*   ![Abstrakt illustrasjon av ankerfeste som beslutningsfelle](/assets/images/banners/forankring-t4-anchoring.webp "")
+*   ![Abstrakt illustrasjon av ankerfeste som beslutningsfelle](/assets/images/banners/forankring-t4-anchoring.webp)
 
     #### Ankerfeste
 
     Det første tallet eller forslaget som presenteres får uforholdsmessig stor innflytelse. «Vi har alltid gjort det sånn» blir argumentet.
-*   ![Abstrakt illustrasjon av sunk cost-fallacy](/assets/images/banners/forankring-t4-sunk-cost.webp "")
+*   ![Abstrakt illustrasjon av sunk cost-fallacy](/assets/images/banners/forankring-t4-sunk-cost.webp)
 
     #### Sunk cost-fallacy
 
     Vi fortsetter med feil investeringer fordi vi allerede har brukt så mye. Å kutte tap oppfattes som å innrømme feil.
-*   ![Abstrakt illustrasjon av overdreven selvtillit som beslutningsfelle](/assets/images/banners/forankring-t4-overconfidence.webp "")
+*   ![Abstrakt illustrasjon av overdreven selvtillit som beslutningsfelle](/assets/images/banners/forankring-t4-overconfidence.webp)
 
     #### Overdreven selvtillit
 

--- a/_pages/ledelse_generativ-ki.md
+++ b/_pages/ledelse_generativ-ki.md
@@ -154,22 +154,22 @@ Den som kontrollerer KI, former retningen. Det er et spørsmål om [makt](/makt/
 
 ## Røde flagg
 
-*   ![Abstrakt illustrasjon av rødt flagg: KI uten menneskelig review](/assets/images/banners/genki-t4-no-human-review.webp "")
+*   ![Abstrakt illustrasjon av rødt flagg: KI uten menneskelig review](/assets/images/banners/genki-t4-no-human-review.webp)
 
     #### KI-implementert uten menneskelig review
 
     Output fra modellen går direkte til kunde eller beslutning uten at et menneske har sett på det.
-*   ![Abstrakt illustrasjon av rødt flagg: «KI sa det» som begrunnelse](/assets/images/banners/genki-t4-ki-said-it.webp "")
+*   ![Abstrakt illustrasjon av rødt flagg: «KI sa det» som begrunnelse](/assets/images/banners/genki-t4-ki-said-it.webp)
 
     #### «KI sa det»
 
     Brukt som begrunnelse for beslutninger. Modellen blir autoritet, ikke verktøy.
-*   ![Abstrakt illustrasjon av rødt flagg: kvantitet over kvalitet i KI-bruk](/assets/images/banners/genki-t4-quantity-over-quality.webp "")
+*   ![Abstrakt illustrasjon av rødt flagg: kvantitet over kvalitet i KI-bruk](/assets/images/banners/genki-t4-quantity-over-quality.webp)
 
     #### Kvantitet over kvalitet
 
     Organisasjonen måler hvor mye KI som brukes, ikke om det faktisk fungerer. Høyere volum maskerer lavere verdi.
-*   ![Abstrakt illustrasjon av rødt flagg: raskere men mindre nøyaktig med KI](/assets/images/banners/genki-t4-faster-less-accurate.webp "")
+*   ![Abstrakt illustrasjon av rødt flagg: raskere men mindre nøyaktig med KI](/assets/images/banners/genki-t4-faster-less-accurate.webp)
 
     #### Raskere, men mindre nøyaktig
 

--- a/_pages/ledelse_tillit.md
+++ b/_pages/ledelse_tillit.md
@@ -166,22 +166,22 @@ Tillit bygges ikke av gode intensjoner. Det bygges av konsekvent atferd over tid
 
 ## Vanlige tillitsutfordringer i norske organisasjoner
 
-*   ![Abstrakt illustrasjon av hierarkisk blindhet som tillitsutfordring](/assets/images/banners/tillit-t4-hierarchical-blindness.webp "")
+*   ![Abstrakt illustrasjon av hierarkisk blindhet som tillitsutfordring](/assets/images/banners/tillit-t4-hierarchical-blindness.webp)
 
     #### Hierarkisk blindhet
 
     Ledere som ikke ser at deres atferd oppfattes annerledes avhengig av posisjon. Det som føles som «direkte» oppfattes som «domsnutt» av underordnede.
-*   ![Abstrakt illustrasjon av informasjonsasymmetri som tillitsutfordring](/assets/images/banners/tillit-t4-info-asymmetry.webp "")
+*   ![Abstrakt illustrasjon av informasjonsasymmetri som tillitsutfordring](/assets/images/banners/tillit-t4-info-asymmetry.webp)
 
     #### Informerings asymmetri
 
     Ledere vet mer enn de deler. Medarbeidere tolker dette som mistillit. Kommunikasjonen blir formell og overfladisk.
-*   ![Abstrakt illustrasjon av historisk bagasje som tillitsutfordring](/assets/images/banners/tillit-t4-historical-baggage.webp "")
+*   ![Abstrakt illustrasjon av historisk bagasje som tillitsutfordring](/assets/images/banners/tillit-t4-historical-baggage.webp)
 
     #### Historisk baggage
 
     Tidligere svik sitter i kulturen. Nye ledere møtes med «vi har hørt dette før»-holdning. Initiativ blir møtt med skepsis.
-*   ![Abstrakt illustrasjon av inkonsekvent oppfølging som tillitsutfordring](/assets/images/banners/tillit-t4-inconsistent-followup.webp "")
+*   ![Abstrakt illustrasjon av inkonsekvent oppfølging som tillitsutfordring](/assets/images/banners/tillit-t4-inconsistent-followup.webp)
 
     #### Inkonsekvent oppfølging
 

--- a/_pages/ledelse_usikkerhet.md
+++ b/_pages/ledelse_usikkerhet.md
@@ -146,49 +146,49 @@ Når usikkerhet oppstår, oppstår også maktkamper. De som griper muligheten i 
 
 John Kotter har kartlagt hvorfor endringsinitiativer feiler — og hvordan de faktisk kan lykkes. Hans forskning viser at de fleste endringsforsøk mislykkes fordi de gjør én eller flere av åtte kritiske feil. Her er hans åtte steg, fra akutt til forankret.
 
-1.  ![Abstrakt illustrasjon av Kotters steg 1: Skap nødvendighet](/assets/images/banners/usikkerhet-t3-kotter-1.webp "")
+1.  ![Abstrakt illustrasjon av Kotters steg 1: Skap nødvendighet](/assets/images/banners/usikkerhet-t3-kotter-1.webp)
 
     ### Skap nødvendighet
 
     Hjelp folk å se hvorfor endring er nødvendig nå — ikke til slutt. Hva koster det å ikke endre? Konkurransetrykk, regulatoriske endringer, arbeidsmarkedsskifter. Nødvendighet er ikke panikk — det er klarhet.
 
-2.  ![Abstrakt illustrasjon av Kotters steg 2: Bygg en sterk koalisjon](/assets/images/banners/usikkerhet-t3-kotter-2.webp "")
+2.  ![Abstrakt illustrasjon av Kotters steg 2: Bygg en sterk koalisjon](/assets/images/banners/usikkerhet-t3-kotter-2.webp)
 
     ### Bygg en sterk koalisjon
 
     Samle en gruppe med nok makt til å lede endringen. Inkluder formelle ledere og uformelle opinionsledere. Ikke alle trenger å være overbevist — men nøkkelaktører må være med.
 
-3.  ![Abstrakt illustrasjon av Kotters steg 3: Formuler en visjon](/assets/images/banners/usikkerhet-t3-kotter-3.webp "")
+3.  ![Abstrakt illustrasjon av Kotters steg 3: Formuler en visjon](/assets/images/banners/usikkerhet-t3-kotter-3.webp)
 
     ### Formuler en visjon
 
     Beskriv hvordan fremtiden ser ut etter endringen. Enkel, klar, inspirerende — ikke en prosjektplan. Visjonen skal styre beslutninger, ikke bare kommunikasjon.
 
-4.  ![Abstrakt illustrasjon av Kotters steg 4: Kommuniser visjonen](/assets/images/banners/usikkerhet-t3-kotter-4.webp "")
+4.  ![Abstrakt illustrasjon av Kotters steg 4: Kommuniser visjonen](/assets/images/banners/usikkerhet-t3-kotter-4.webp)
 
     ### Kommuniser visjonen
 
     Gjør visjonen til en pågående tilstedeværelse, ikke en engangsannonsering. Led med eksempel — handlinger taler høyere enn presentasjoner. Addresser angst og motstand direkte, ikke ignorer dem.
 
-5.  ![Abstrakt illustrasjon av Kotters steg 5: Fjern hindringer](/assets/images/banners/usikkerhet-t3-kotter-5.webp "")
+5.  ![Abstrakt illustrasjon av Kotters steg 5: Fjern hindringer](/assets/images/banners/usikkerhet-t3-kotter-5.webp)
 
     ### Fjern hindringer
 
     Identifiser barrierer: strukturer, systemer, ferdigheter, vaner. Myndiggjør folk til å fjerne hindringer eller finne veier rundt dem. Feir tidlige seiere som fjerner en barriere.
 
-6.  ![Abstrakt illustrasjon av Kotters steg 6: Skap kortsiktige seiere](/assets/images/banners/usikkerhet-t3-kotter-6.webp "")
+6.  ![Abstrakt illustrasjon av Kotters steg 6: Skap kortsiktige seiere](/assets/images/banners/usikkerhet-t3-kotter-6.webp)
 
     ### Skap kortsiktige seiere
 
     Planlegg synlige forbedringer innen 3-6 måneder. Ikke vent på den store transformasjonen — tidlige seiere bygger momentum. Analyser resultater ærlig — juster hvis seieren ikke var så stor som forventet.
 
-7.  ![Abstrakt illustrasjon av Kotters steg 7: Bygg videre på endringen](/assets/images/banners/usikkerhet-t3-kotter-7.webp "")
+7.  ![Abstrakt illustrasjon av Kotters steg 7: Bygg videre på endringen](/assets/images/banners/usikkerhet-t3-kotter-7.webp)
 
     ### Bygg videre på endringen
 
     Bruk troverdigheten fra tidlige seiere til å angripe større endringer. Fremhev folk som gjennomførte tidlige endringer. Ikke erklær seier for tidlig — konsolidering tar tid.
 
-8.  ![Abstrakt illustrasjon av Kotters steg 8: Forankre i kulturen](/assets/images/banners/usikkerhet-t3-kotter-8.webp "")
+8.  ![Abstrakt illustrasjon av Kotters steg 8: Forankre i kulturen](/assets/images/banners/usikkerhet-t3-kotter-8.webp)
 
     ### Forankre i kulturen
 
@@ -211,27 +211,27 @@ Scheins tre kulturnivåer kobler seg til Kotters steg: artefakter påvirkes av k
 
 ## Vanlige kulturutfordringer
 
-*   ![Abstrakt illustrasjon av uoverensstemmelse mellom verdier og praksis](/assets/images/banners/usikkerhet-t4-values-practice.webp "")
+*   ![Abstrakt illustrasjon av uoverensstemmelse mellom verdier og praksis](/assets/images/banners/usikkerhet-t4-values-practice.webp)
 
     #### Uoverensstemmelse mellom verdier og praksis
 
     «Vi er innovative» står på veggen, men ideer drepes i møter. Kulturen sier noe annet enn det ledelsen tror.
-*   ![Abstrakt illustrasjon av taus kunnskap som ikke deles](/assets/images/banners/usikkerhet-t4-tacit-knowledge.webp "")
+*   ![Abstrakt illustrasjon av taus kunnskap som ikke deles](/assets/images/banners/usikkerhet-t4-tacit-knowledge.webp)
 
     #### Tacite kunnskap som ikke deles
 
     Kunnskapen sitter i hodene til enkelte, ikke i systemer. Når folk slutter, forsvinner kunnskapen.
-*   ![Abstrakt illustrasjon av silotenkning i organisasjoner](/assets/images/banners/usikkerhet-t4-silo-thinking.webp "")
+*   ![Abstrakt illustrasjon av silotenkning i organisasjoner](/assets/images/banners/usikkerhet-t4-silo-thinking.webp)
 
     #### Silo-tenkning
 
     Avdelinger som jobber for seg selv. «Det der er ikke mitt problem»-mentalitet. Koordinering på tvers av avdelinger er tilfeldig.
-*   ![Abstrakt illustrasjon av «alltid sånn her»-mentalitet](/assets/images/banners/usikkerhet-t4-always-done.webp "")
+*   ![Abstrakt illustrasjon av «alltid sånn her»-mentalitet](/assets/images/banners/usikkerhet-t4-always-done.webp)
 
     #### «Alltid sånn her»-mentalitet
 
     Historisk suksess blir institusjonlisert. «Vi har alltid gjort det sånn» blir argumentet mot fornyelse.
-*   ![Abstrakt illustrasjon av strukturell usikkerhet](/assets/images/banners/usikkerhet-t4-structural-uncertainty.webp "")
+*   ![Abstrakt illustrasjon av strukturell usikkerhet](/assets/images/banners/usikkerhet-t4-structural-uncertainty.webp)
 
     #### Strukturell usikkerhet
 

--- a/_pages/mennesker.md
+++ b/_pages/mennesker.md
@@ -114,22 +114,22 @@ Gode rutiner og klare roller er ikke det motsatte av tillitsbasert ledelse — d
 
 ![Illustrasjon av vanlige menneskerelaterte utfordringer](/assets/images/banners/illustrasjon-mennesker-utfordringer.webp)
 
-*   ![Abstrakt illustrasjon av manglende psykologisk trygghet](/assets/images/banners/mennesker-t4-psychological-safety.webp "")
+*   ![Abstrakt illustrasjon av manglende psykologisk trygghet](/assets/images/banners/mennesker-t4-psychological-safety.webp)
 
     #### Manglende psykologisk trygghet
 
     Folk tørr ikke si ifra om problemer. Feil skjules. Kritikk leveres bak lukkede dører. Innovasjon dør før den får luft.
-*   ![Abstrakt illustrasjon av tomme verdier som ikke etterleves](/assets/images/banners/mennesker-t4-empty-values.webp "")
+*   ![Abstrakt illustrasjon av tomme verdier som ikke etterleves](/assets/images/banners/mennesker-t4-empty-values.webp)
 
     #### Tomme verdier
 
     Organisasjonen har verdier på veggen, men de stemmer ikke med hvordan folk faktisk oppfører seg. Verdiene er blitt flosler, ikke veiledning.
-*   ![Abstrakt illustrasjon av siloer og manglende samarbeid](/assets/images/banners/mennesker-t4-silos.webp "")
+*   ![Abstrakt illustrasjon av siloer og manglende samarbeid](/assets/images/banners/mennesker-t4-silos.webp)
 
     #### Sil og silo
 
     Avdelinger og individer jobber i siloer. Folk kjenner ikke til hva naboen driver med. Kunden matcher med én person som blir en flaskehals.
-*   ![Abstrakt illustrasjon av for mye volum og for lite mening](/assets/images/banners/mennesker-t4-meaninglessness.webp "")
+*   ![Abstrakt illustrasjon av for mye volum og for lite mening](/assets/images/banners/mennesker-t4-meaninglessness.webp)
 
     #### For mye volum, for lite mening
 

--- a/_pages/påvirkning.md
+++ b/_pages/påvirkning.md
@@ -102,22 +102,22 @@ Pfeffers research viser at politisk dyktighet korrelerer sterkt med ledereffekti
 
 ![Illustrasjon av vanlige påvirkningsrelaterte utfordringer](/assets/images/banners/illustrasjon-påvirkning-utfordringer.webp)
 
-*   ![Abstrakt illustrasjon av usynlig beslutningsmakt](/assets/images/banners/pavirkning-t4-invisible-power.webp "")
+*   ![Abstrakt illustrasjon av usynlig beslutningsmakt](/assets/images/banners/pavirkning-t4-invisible-power.webp)
 
     #### Usynlig beslutningsmakt
 
     De som formelt har makt, har ikke reell makt. Eller omvendt. Beslutninger tas «der» men av dem som «ikke skal ha noe med det å gjøre». Senior ledere kan ofte bryte uformelle regler — de har bygget opp «idiosynkratiske kreditter» gjennom tidligere bidrag som gir dem retten til å avvike fra normene.
-*   ![Abstrakt illustrasjon av skjulte agendaer](/assets/images/banners/pavirkning-t4-hidden-agendas.webp "")
+*   ![Abstrakt illustrasjon av skjulte agendaer](/assets/images/banners/pavirkning-t4-hidden-agendas.webp)
 
     #### Skjulte agendaer
 
     Aktører som ikke er transparente om sine interesser. Medarbeidere som jobber forbi offisielle kanaler for å påvirke beslutninger.
-*   ![Abstrakt illustrasjon av ressurskamper som maskeres som rasjonelle](/assets/images/banners/pavirkning-t4-resource-struggles.webp "")
+*   ![Abstrakt illustrasjon av ressurskamper som maskeres som rasjonelle](/assets/images/banners/pavirkning-t4-resource-struggles.webp)
 
     #### Ressurskamper som maskeres
 
     Budsjettkonflikter, GIS-struktureringer og andre strukturelle endringer som egentlig handler om makt og innflytelse, men fremstilles som rasjonelle.
-*   ![Abstrakt illustrasjon av for mye enighet i ledergruppen](/assets/images/banners/pavirkning-t4-too-much-agreement.webp "")
+*   ![Abstrakt illustrasjon av for mye enighet i ledergruppen](/assets/images/banners/pavirkning-t4-too-much-agreement.webp)
 
     #### For mye enighet
 

--- a/_pages/struktur.md
+++ b/_pages/struktur.md
@@ -100,22 +100,22 @@ Douglas Hubbard, forfatteren av «How to Measure Anything», påpeker at mye som
 
 ![Illustrasjon av vanlige strukturspesifikke utfordringer](/assets/images/banners/illustrasjon-struktur-utfordringer.webp)
 
-*   ![Abstrakt illustrasjon av uklar rolleavklaring som strukturutfordring](/assets/images/banners/struktur-t4-role-clarification.webp "")
+*   ![Abstrakt illustrasjon av uklar rolleavklaring som strukturutfordring](/assets/images/banners/struktur-t4-role-clarification.webp)
 
     #### Uklar rolleavklaring
 
     To personer som tror de eier samme område. Eller ingen som eier det i det hele tatt. Ofte avslørt først når noe går galt.
-*   ![Abstrakt illustrasjon av målkonflikter som strukturutfordring](/assets/images/banners/struktur-t4-goal-conflict.webp "")
+*   ![Abstrakt illustrasjon av målkonflikter som strukturutfordring](/assets/images/banners/struktur-t4-goal-conflict.webp)
 
     #### Målkonflikter
 
     Avdeling A optimaliserer for sin målsetting som bremser avdeling B. Motivert av insentiver som ikke er koordinert.
-*   ![Abstrakt illustrasjon av koordineringsproblemer som strukturutfordring](/assets/images/banners/struktur-t4-coordination.webp "")
+*   ![Abstrakt illustrasjon av koordineringsproblemer som strukturutfordring](/assets/images/banners/struktur-t4-coordination.webp)
 
     #### Koordineringsproblemer
 
     Mye tid brukes på å samordne arbeid som burde vært koordinert fra start. Fokus på «å skape buy-in» i stedet for å bygge struktur som sikrer involvering.
-*   ![Abstrakt illustrasjon av byråkratisk byrde som strukturutfordring](/assets/images/banners/struktur-t4-bureaucracy.webp "")
+*   ![Abstrakt illustrasjon av byråkratisk byrde som strukturutfordring](/assets/images/banners/struktur-t4-bureaucracy.webp)
 
     #### Byråkratisk byrde
 

--- a/assets/css/components/sidebar.css
+++ b/assets/css/components/sidebar.css
@@ -10,7 +10,7 @@
     grid-template-columns: 1fr 240px minmax(auto, 800px) 320px 1fr;
     grid-template-rows: auto 1fr;
     grid-template-areas:
-        "g-left  .      .       .       g-right"
+        ".       g-left  .       g-right ."
         ".       pager  content questions .";
 }
 
@@ -77,15 +77,6 @@
 
 .dark-mode .article-questions .sidebar-cta {
     border-top-color: var(--border-color-dark);
-}
-
-/* On wide article pages, hide the header's native logo & burger
-   (the gutter versions take over) */
-@media (min-width: 1200px) {
-    body:has(.article-layout) .header .logo-link,
-    body:has(.article-layout) .header .nav-toggle {
-        display: none;
-    }
 }
 
 /* --- Left Pager Panel (cross-links) --- */

--- a/assets/scripts/navbar.js
+++ b/assets/scripts/navbar.js
@@ -1,13 +1,16 @@
 (function () {
   "use strict";
 
-  var toggle = document.querySelector(".nav-toggle");
+  var toggles = document.querySelectorAll(".nav-toggle");
   var overlay = document.querySelector(".nav-overlay");
   var closeBtn = document.querySelector(".nav-overlay-close");
 
-  if (!toggle || !overlay) return;
+  if (!toggles.length || !overlay) return;
 
-  function open() {
+  var activeToggle = null;
+
+  function open(toggle) {
+    activeToggle = toggle;
     toggle.setAttribute("aria-expanded", "true");
     overlay.setAttribute("aria-hidden", "false");
     overlay.classList.add("active");
@@ -15,20 +18,24 @@
   }
 
   function close() {
-    toggle.setAttribute("aria-expanded", "false");
+    if (activeToggle) {
+      activeToggle.setAttribute("aria-expanded", "false");
+      activeToggle.focus();
+    }
     overlay.setAttribute("aria-hidden", "true");
     overlay.classList.remove("active");
     document.body.classList.remove("no-scroll");
-    toggle.focus();
   }
 
-  toggle.addEventListener("click", function () {
-    var expanded = toggle.getAttribute("aria-expanded") === "true";
-    if (expanded) {
-      close();
-    } else {
-      open();
-    }
+  Array.prototype.forEach.call(toggles, function (toggle) {
+    toggle.addEventListener("click", function () {
+      var expanded = toggle.getAttribute("aria-expanded") === "true";
+      if (expanded) {
+        close();
+      } else {
+        open(toggle);
+      }
+    });
   });
 
   if (closeBtn) {


### PR DESCRIPTION
## Summary

Three issues fixed:

### 1. Header logo/burger was hidden on article pages
The  CSS was suppressing the header's native logo and hamburger button on wide screens. Removed — the header always keeps its own logo and burger.

### 2. Gutter grid positions wrong
 and  were in buffer columns (1 and 5) instead of above their respective side panel columns (2 and 4). The logo now sits directly above the left pager column; the burger sits directly above the right questions column.

### 3. Gutter burger did nothing
 used  which only found the first toggle in the DOM. Changed to  and wired all matching buttons to the nav overlay — both the header burger and the gutter burger now open the same mobile menu.

### Also included
- Empty kramdown title hotfix from PR #170 follow-up: 41 images across 8 pages had  causing raw markdown output in list contexts (cherry-picked).

### How to test
1. Open any article page on wide screen (≥1200px) — header logo and burger should be visible
2. Scroll down — logo should reappear in the left gutter above the TOC panel (sticky)
3. Click the burger in the right gutter — mobile nav overlay should open
4. Close it, then click the header burger — same overlay, same behavior
5. Narrow screen (<1200px) — gutters hidden, header nav works as before