### PR TITLE
fix(sidebar): move logo above left panel, restore inline nav on desktop, make sidebar sections distinct cards

### DIFF
--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -8,11 +8,18 @@ layout: default
 {% if page.hero %}
   {% include hero.html %}
   <div class="article-layout">
+    <div class="logo-top">
+      <a href="/" class="logo-link" aria-label="No Excuse — Hjem">{% include logo-svg.html %}</a>
+    </div>
+
+    <div class="burger-top">
+      <button class="burger-pill" aria-label="Meny" aria-expanded="false">
+        <span class="burger-icon" aria-hidden="true">☰</span> Meny
+      </button>
+    </div>
+
     {% if page.show_toc != false %}
     <aside class="article-pager" aria-label="Relaterte artikler" hidden>
-      <div class="pager-header">
-        <a href="/" class="logo-link" aria-label="No Excuse — Hjem">{% include logo-svg.html %}</a>
-      </div>
       <div class="pager-scroll">
         <div class="js-pager-list"></div>
         {% include sidebar-toc.html %}
@@ -38,17 +45,25 @@ layout: default
       {% endif %}
     </div>
 
-    <aside class="article-questions" aria-label="Spørsmål">
-      <button class="burger-pill" aria-label="Meny" aria-expanded="false">Meny</button>
+    <aside class="article-questions" aria-label="Spørsmål og tilbud">
       {% if page.questions %}
+      <div class="sidebar-card sidebar-card--questions">
         {% capture question_list %}{{ page.questions | join: "||" }}{% endcapture %}
         {% include questions.html title=page.questions_title questions=question_list %}
+      </div>
       {% endif %}
+
       {% if page.cta %}
-      <div class="sidebar-cta">
+      <div class="sidebar-card sidebar-card--product">
         {% assign product = site.pages | where: "class", "product" | first %}
         {% if product and product.image %}
         <img src="{{ product.image | relative_url }}" alt="{{ product.name }}" class="sidebar-cta-banner">
+        {% endif %}
+        {% if product %}
+        <h4 class="sidebar-card-heading">{{ product.name }}</h4>
+          {% if product.short_description %}
+        <p class="sidebar-card-desc">{{ product.short_description }}</p>
+          {% endif %}
         {% endif %}
         {% assign cta_primary = page.cta[0] %}
         {% assign cta_secondary = page.cta[1] %}

--- a/assets/css/components/sidebar.css
+++ b/assets/css/components/sidebar.css
@@ -4,12 +4,14 @@
 
 /* --- Layout Grid --- */
 
-/* Article pages: left pager + centered content + 320px right sidebar */
+/* Article pages: left pager + centered content + 320px right sidebar
+   Two rows: logo/burger on row 1, sidepanels + content on row 2 */
 .article-layout {
     display: grid;
     grid-template-columns: 1fr 240px minmax(auto, 800px) 320px 1fr;
     grid-template-rows: auto 1fr;
     grid-template-areas:
+        ". logo . burger ."
         ". pager content questions .";
 }
 
@@ -26,15 +28,81 @@
     grid-area: questions;
 }
 
-/* CTA card inside the questions sidebar — separated by a border */
-.article-questions .sidebar-cta {
-    margin-top: var(--space-lg);
-    padding-top: var(--space-lg);
-    border-top: 1px solid var(--border-color-light);
+.article-layout > .logo-top {
+    grid-area: logo;
 }
 
-.dark-mode .article-questions .sidebar-cta {
-    border-top-color: var(--border-color-dark);
+.article-layout > .burger-top {
+    grid-area: burger;
+}
+
+/* --- Logo Above Left Panel (on page background) --- */
+
+.logo-top {
+    padding: var(--space-md) 0;
+    display: flex;
+    align-items: center;
+}
+
+.logo-top .logo-link {
+    display: block;
+    text-decoration: none;
+}
+
+.logo-top .logo-link svg {
+    display: block;
+    height: 32px;
+    width: auto;
+}
+
+/* --- Burger Pill Above Right Panel (on page background) --- */
+
+.burger-top {
+    padding: var(--space-md) 0;
+    display: flex;
+    align-items: center;
+}
+
+.burger-pill {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    width: 100%;
+    padding: 10px 20px;
+    min-height: 44px;
+    background: var(--box-background-light);
+    border: 2px solid var(--border-color-light);
+    border-radius: 999px;
+    cursor: pointer;
+    font-weight: 600;
+    font-size: 0.95em;
+    color: var(--text-color-light);
+    transition: background-color 0.2s ease, color 0.2s ease;
+    box-shadow: var(--shadow-sm);
+}
+
+.burger-pill:hover {
+    background: var(--surface-hover-light);
+    color: var(--link-hover-light);
+}
+
+.dark-mode .burger-pill {
+    background: var(--box-background-dark);
+    border-color: var(--border-color-dark);
+    color: var(--text-color-dark);
+    box-shadow: var(--shadow-sm-dark);
+}
+
+.dark-mode .burger-pill:hover {
+    background: var(--surface-hover-dark);
+    color: var(--link-hover-dark);
+}
+
+/* Burger icon */
+.burger-icon {
+    font-size: 1.15em;
+    line-height: 1;
 }
 
 /* --- Left Pager Panel (cross-links) --- */
@@ -59,23 +127,6 @@
 .dark-mode .article-pager {
     background: var(--box-background-dark);
     box-shadow: var(--shadow-sm-dark);
-}
-
-/* Pager header — logo stays visible at top while pager scrolls */
-.pager-header {
-    flex-shrink: 0;
-    padding: var(--space-lg) var(--space-lg) 0;
-}
-
-.pager-header .logo-link {
-    display: block;
-    text-decoration: none;
-}
-
-.pager-header .logo-link svg {
-    display: block;
-    height: 40px;
-    width: auto;
 }
 
 /* Pager scrollable content */
@@ -154,10 +205,9 @@
     overflow-y: auto;
     overscroll-behavior: contain;
 
-    background: var(--box-background-light);
-    border-radius: var(--radius-xl);
-    box-shadow: var(--shadow-sm);
-    padding: var(--space-lg);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-lg);
 
     /* Hidden until hero scrolls past */
     opacity: 0;
@@ -169,12 +219,6 @@
 .article-questions.sidebar-visible {
     opacity: 1;
     pointer-events: auto;
-}
-
-/* Dark mode */
-.dark-mode .article-questions {
-    background: var(--box-background-dark);
-    box-shadow: var(--shadow-sm-dark);
 }
 
 /* Hide scrollbar but keep functionality */
@@ -191,193 +235,78 @@
     background: var(--border-color-dark);
 }
 
-/* --- Sidebar Sections --- */
+/* --- Sidebar Cards (distinct sections inside right panel) --- */
 
-.sidebar-section {
-    margin-bottom: var(--space-lg);
-    padding-bottom: var(--space-lg);
-    border-bottom: 1px solid var(--border-color-light);
-}
-
-.sidebar-section:last-child {
-    margin-bottom: 0;
-    padding-bottom: 0;
-    border-bottom: none;
-}
-
-.dark-mode .sidebar-section {
-    border-bottom-color: var(--border-color-dark);
-}
-
-.sidebar-section h3 {
-    font-size: 0.85em;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    opacity: 0.6;
-    margin: 0 0 var(--space-sm);
-}
-
-/* --- TOC / Page Index --- */
-
-.toc-list {
-    list-style: none;
-    padding: 0;
-    margin: 0;
-}
-
-.toc-item {
-    display: block;
-    padding: var(--space-xs) 0;
-    padding-left: var(--space-sm);
-    font-size: 0.9em;
-    line-height: 1.4;
-    color: var(--text-color-light);
-    text-decoration: none;
-    border-left: 2px solid transparent;
-    transition: color 0.2s ease, border-color 0.2s ease;
-    cursor: pointer;
-}
-
-.toc-item:hover {
-    color: var(--link-hover-light);
-    border-left-color: var(--border-color-light);
-}
-
-.toc-item--h3 {
-    padding-left: calc(var(--space-sm) + var(--space-md));
-    font-size: 0.82em;
-    opacity: 0.85;
-}
-
-/* Active heading — scroll-spy highlight */
-.toc-item--active {
-    color: var(--primary-navy);
-    border-left-color: var(--primary-accent);
-    font-weight: 600;
-}
-
-.dark-mode .toc-item {
-    color: var(--text-color-dark);
-}
-
-.dark-mode .toc-item:hover {
-    color: var(--link-hover-dark);
-}
-
-.dark-mode .toc-item--active {
-    color: var(--primary-azure);
-    border-left-color: var(--primary-azure);
-}
-
-/* --- Burger Pill (wide screens, inside right sidebar) --- */
-
-.burger-pill {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 100%;
-    padding: 10px 20px;
-    min-height: 44px;
+.sidebar-card {
     background: var(--box-background-light);
-    border: 2px solid var(--border-color-light);
-    border-radius: 999px;
-    cursor: pointer;
-    font-weight: 600;
-    font-size: 0.95em;
-    color: var(--text-color-light);
-    transition: background-color 0.2s ease, color 0.2s ease;
-    margin-bottom: var(--space-md);
+    border-radius: var(--radius-xl);
     box-shadow: var(--shadow-sm);
+    padding: var(--space-lg);
 }
 
-.burger-pill:hover {
-    background: var(--surface-hover-light);
-    color: var(--link-hover-light);
+.sidebar-card:last-child {
+    margin-bottom: 0;
 }
 
-.dark-mode .burger-pill {
+.dark-mode .sidebar-card {
     background: var(--box-background-dark);
-    border-color: var(--border-color-dark);
-    color: var(--text-color-dark);
     box-shadow: var(--shadow-sm-dark);
 }
 
-.dark-mode .burger-pill:hover {
-    background: var(--surface-hover-dark);
-    color: var(--link-hover-dark);
-}
-
-/* --- Sidebar CTA (Compact) --- */
-
-.sidebar-cta h4 {
+/* Card heading */
+.sidebar-card-heading {
     font-size: 1em;
+    font-weight: 600;
     margin: 0 0 var(--space-sm);
     line-height: 1.3;
 }
 
-.sidebar-cta p {
+/* Card description text */
+.sidebar-card-desc {
     font-size: 0.85em;
-    margin: 0 0 var(--space-sm);
+    margin: 0 0 var(--space-md);
     opacity: 0.8;
     line-height: 1.4;
 }
 
-.sidebar-cta .cta-buttons {
+/* --- CTA Banner Image --- */
+
+.sidebar-cta-banner {
+    display: block;
+    width: 100%;
+    aspect-ratio: 16/9;
+    object-fit: cover;
+    border-radius: var(--radius-md);
+    margin-bottom: var(--space-md);
+}
+
+/* --- CTA Buttons in Sidebar --- */
+
+.sidebar-card .cta-buttons {
     display: flex;
     flex-direction: column;
     gap: var(--space-sm);
 }
 
-.sidebar-cta .cta-buttons .cta {
+.sidebar-card .cta-buttons .cta {
     padding: var(--space-sm) var(--space-md);
     font-size: 0.85em;
     text-align: center;
 }
 
-/* --- Sidebar Questions (Compact) --- */
+/* --- Questions inside sidebar card --- */
 
-.sidebar-questions {
-    margin: 0;
-}
-
-.sidebar-questions .review-questions {
-    padding: 0;
-    margin: 0;
-}
-
-.sidebar-questions .review-questions ul {
-    list-style: none;
-    padding: 0;
-    margin: 0;
-}
-
-.sidebar-questions .review-questions li {
-    font-size: 0.85em;
-    padding: var(--space-xs) 0;
-    cursor: pointer;
-    line-height: 1.4;
-    opacity: 0.85;
-    transition: opacity 0.2s ease;
-}
-
-.sidebar-questions .review-questions li:hover {
-    opacity: 1;
-}
-
-
-/* Questions rendered directly inside .article-questions sidebar (from questions.html include) */
-.article-questions .review-questions {
+.sidebar-card--questions .review-questions {
     padding: 0;
     margin: 0;
     max-width: none;
 }
 
-.article-questions .review-questions.section {
+.sidebar-card--questions .review-questions.section {
     padding-block: 0;
 }
 
-.article-questions .review-questions h2 {
+.sidebar-card--questions .review-questions h2 {
     font-size: 0.85em;
     font-weight: 600;
     text-transform: uppercase;
@@ -387,13 +316,13 @@
     padding: 0;
 }
 
-.article-questions .review-questions ul {
+.sidebar-card--questions .review-questions ul {
     list-style: none;
     padding: 0;
     margin: 0;
 }
 
-.article-questions .review-questions li {
+.sidebar-card--questions .review-questions li {
     font-size: 0.85em;
     padding: var(--space-xs) 0;
     cursor: pointer;
@@ -406,25 +335,14 @@
     gap: var(--space-sm);
 }
 
-.article-questions .review-questions li:hover {
+.sidebar-card--questions .review-questions li:hover {
     opacity: 1;
     background: transparent;
     box-shadow: none;
 }
 
-.article-questions .review-questions li span {
+.sidebar-card--questions .review-questions li span {
     font-size: 1em;
-}
-
-/* --- Sidebar CTA banner image --- */
-
-.sidebar-cta-banner {
-    display: block;
-    width: 100%;
-    aspect-ratio: 16/9;
-    object-fit: cover;
-    border-radius: var(--radius-md);
-    margin-bottom: var(--space-md);
 }
 
 /* --- Sparkle: visible only on hover/focus/click --- */
@@ -448,7 +366,9 @@
     }
 
     .article-pager,
-    .article-questions {
+    .article-questions,
+    .logo-top,
+    .burger-top {
         display: none;
     }
 }

--- a/assets/css/navbar.css
+++ b/assets/css/navbar.css
@@ -140,97 +140,96 @@ body.no-scroll {
     background: var(--nav-link-color-dark);
 }
 
-/* All screens: nav overlay visibility controlled by .active class */
-.nav-overlay {
-    display: none;
-}
+/* Mobile — ≤768px: full-screen burger menu overlay */
+@media (max-width: 768px) {
+    .nav-overlay {
+        display: none;
+    }
 
-.nav-overlay.active {
-    display: flex;
-    position: fixed;
-    inset: 0;
-    z-index: 200;
-    background: var(--box-background-light);
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-}
+    .nav-overlay.active {
+        display: flex;
+        position: fixed;
+        inset: 0;
+        z-index: 200;
+        background: var(--box-background-light);
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+    }
 
-.nav-overlay-close {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    position: absolute;
-    top: 12px;
-    right: 12px;
-    width: 48px;
-    height: 48px;
-    background: none;
-    border: none;
-    font-size: 2em;
-    color: var(--text-color-light);
-    cursor: pointer;
-    border-radius: var(--radius-md);
-    min-height: 44px;
-    min-width: 44px;
-}
+    .nav-overlay-close {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        position: absolute;
+        top: 12px;
+        right: 12px;
+        width: 48px;
+        height: 48px;
+        background: none;
+        border: none;
+        font-size: 2em;
+        color: var(--text-color-light);
+        cursor: pointer;
+        border-radius: var(--radius-md);
+        min-height: 44px;
+        min-width: 44px;
+    }
 
-.nav-overlay-close:hover {
-    background: var(--surface-hover-light);
-}
+    .nav-overlay-close:hover {
+        background: var(--surface-hover-light);
+    }
 
-.nav-overlay .nav-links {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 4px;
-}
+    .nav-overlay .nav-links {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 4px;
+    }
 
-.nav-overlay .nav-links a {
-    font-size: 1.3em;
-    padding: 16px 32px;
-    width: auto;
-    text-align: center;
-    color: var(--text-color-light);
-}
+    .nav-overlay .nav-links a {
+        font-size: 1.3em;
+        padding: 16px 32px;
+        width: auto;
+        text-align: center;
+        color: var(--text-color-light);
+    }
 
-.nav-overlay .nav-links a:hover {
-    color: var(--text-color-light);
-    background: var(--surface-hover-light);
-}
+    .nav-overlay .nav-links a:hover {
+        color: var(--text-color-light);
+        background: var(--surface-hover-light);
+    }
 
-.dark-mode .nav-overlay {
-    background: var(--box-background-dark);
-}
+    .nav-toggle {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
 
-.dark-mode .nav-overlay a {
-    color: var(--text-color-dark);
-}
+    .dark-mode .nav-overlay {
+        background: var(--box-background-dark);
+    }
 
-.dark-mode .nav-overlay a:hover {
-    background: var(--surface-hover-dark);
-}
+    .dark-mode .nav-overlay a {
+        color: var(--text-color-dark);
+    }
 
-.dark-mode .nav-overlay-close {
-    color: var(--text-color-dark);
-}
+    .dark-mode .nav-overlay a:hover {
+        background: var(--surface-hover-dark);
+    }
 
-.dark-mode .nav-overlay-close:hover {
-    background: var(--surface-hover-dark);
+    .dark-mode .nav-overlay-close {
+        color: var(--text-color-dark);
+    }
+
+    .dark-mode .nav-overlay-close:hover {
+        background: var(--surface-hover-dark);
+    }
 }
 
 /* Hamburger toggle — hidden on desktop */
 @media (min-width: 769px) {
     .nav-toggle {
         display: none;
-    }
-}
-
-/* Mobile — ≤768px: full-screen burger menu overlay */
-@media (max-width: 768px) {
-    .nav-toggle {
-        display: flex;
-        align-items: center;
-        justify-content: center;
     }
 }


### PR DESCRIPTION
## Fixes

Fixes four regressions from the sidebar restructure in PR #172:

### a) Main menu removed from header
The nav overlay was set to `display: none` globally and only shown as a full-screen modal on `.active` — this broke the inline horizontal nav bar entirely.  
**Fix:** Moved all overlay modal styles inside `@media (max-width: 768px)`. On desktop (≥769px), `.nav-overlay` now displays as `flex` inline, showing nav links as a horizontal bar in the header.

### b) Logo inside left sidepanel card
Logo was inside `.article-pager` with card background/shadow, causing poor contrast on the page background and overflowing into the body area.  
**Fix:** Moved logo to `.logo-top` grid area (row 1, column 2) — above the left panel, directly on the page background. Resized SVG to 32px height. Removed `.pager-header` entirely.

### c) Burger pill inside right sidepanel
The "Meny" button was inside `.article-questions` with card styling.  
**Fix:** Moved it to `.burger-top` grid area (row 1, column 4) — above the right panel, directly on the page background. Added `☰` burger icon before the "Meny" text.

### d) Right sidebar sections not distinct cards
Questions and product sections shared the sidebar background without visual separation.  
**Fix:** Each section is now a `.sidebar-card` with its own `background`, `border-radius`, and `box-shadow`. The product card shows product name as `.sidebar-card-heading`, `short_description` as `.sidebar-card-desc`, banner image, and CTA buttons.

## Files changed
- `_layouts/article.html` — restructured grid placement, added `.logo-top`, `.burger-top` with ☰ icon, `.sidebar-card--questions`, `.sidebar-card--product`
- `assets/css/navbar.css` — removed global overlay override, moved modal styles into mobile media query
- `assets/css/components/sidebar.css` — added grid areas for logo/burger, removed `.pager-header`, added `.sidebar-card` styles, simplified structure

## How to test
1. Visit any article page on desktop (≥1200px) — verify nav links are visible as a horizontal bar in the header
2. Verify logo is above the left sidebar, directly on page background (no card/shadow behind it)
3. Verify "☰ Meny" pill is above the right sidebar, directly on page background
4. Verify right sidebar sections are separate cards with visible borders/shadows
5. Verify product card shows product name, description, banner image, and CTA buttons
6. Resize to mobile (≤768px) — verify burger overlay still works as a full-screen modal
7. Resize to tablet (769–1199px) — verify sidebars hide, content is full-width

## Pre-merge notes
- Same pre-existing stylelint/eslint caveats as before (requires `npm install`)
- Nav overlay `aria-hidden="true"` on desktop while `display: flex` makes it visible is a pre-existing a11y concern (not introduced here)
