### PR TITLE
fix(sidebar): remove logo, burger, cross-links; restore TOC formatting; align sidepanels vertically

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -3,7 +3,6 @@
 
 <script src="{{ '/assets/scripts/animations.js' | relative_url }}"></script>
 <script src="{{ '/assets/scripts/navbar.js' | relative_url }}"></script>
-<script src="{{ '/assets/scripts/cross-links.js' | relative_url }}"></script>
 <script src="{{ '/assets/scripts/review-questions.js' | relative_url }}" defer></script>
 <script src="{{ '/assets/scripts/sidebar.js' | relative_url }}"></script>
 <script src="{{ '/assets/scripts/sticky-cta.js' | relative_url }}"></script>

--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -8,20 +8,9 @@ layout: default
 {% if page.hero %}
   {% include hero.html %}
   <div class="article-layout">
-    <div class="logo-top">
-      <a href="/" class="logo-link" aria-label="No Excuse — Hjem">{% include logo-svg.html %}</a>
-    </div>
-
-    <div class="burger-top">
-      <button class="burger-pill" aria-label="Meny" aria-expanded="false">
-        <span class="burger-icon" aria-hidden="true">☰</span> Meny
-      </button>
-    </div>
-
     {% if page.show_toc != false %}
     <aside class="article-pager" aria-label="Relaterte artikler" hidden>
       <div class="pager-scroll">
-        <div class="js-pager-list"></div>
         {% include sidebar-toc.html %}
       </div>
     </aside>

--- a/assets/css/components/sidebar.css
+++ b/assets/css/components/sidebar.css
@@ -4,15 +4,12 @@
 
 /* --- Layout Grid --- */
 
-/* Article pages: left pager + centered content + 320px right sidebar
-   Two rows: logo/burger on row 1, sidepanels + content on row 2 */
+/* Article pages: left pager + centered content + 320px right sidebar */
 .article-layout {
     display: grid;
     grid-template-columns: 1fr 240px minmax(auto, 800px) 320px 1fr;
-    grid-template-rows: auto 1fr;
-    grid-template-areas:
-        ". logo . burger ."
-        ". pager content questions .";
+    grid-template-rows: 1fr;
+    grid-template-areas: ". pager content questions .";
 }
 
 /* Place children into grid areas */
@@ -28,84 +25,39 @@
     grid-area: questions;
 }
 
-.article-layout > .logo-top {
-    grid-area: logo;
+/* --- Sidebar Sections (shared by left pager TOC & homepage sidebar) --- */
+
+.sidebar-section {
+    margin-bottom: var(--space-lg);
+    padding-bottom: var(--space-lg);
+    border-bottom: 1px solid var(--border-color-light);
 }
 
-.article-layout > .burger-top {
-    grid-area: burger;
+.sidebar-section:last-child {
+    margin-bottom: 0;
+    padding-bottom: 0;
+    border-bottom: none;
 }
 
-/* --- Logo Above Left Panel (on page background) --- */
-
-.logo-top {
-    padding: var(--space-md) 0;
-    display: flex;
-    align-items: center;
+.dark-mode .sidebar-section {
+    border-bottom-color: var(--border-color-dark);
 }
 
-.logo-top .logo-link {
-    display: block;
-    text-decoration: none;
-}
-
-.logo-top .logo-link svg {
-    display: block;
-    height: 32px;
-    width: auto;
-}
-
-/* --- Burger Pill Above Right Panel (on page background) --- */
-
-.burger-top {
-    padding: var(--space-md) 0;
-    display: flex;
-    align-items: center;
-}
-
-.burger-pill {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 8px;
-    width: 100%;
-    padding: 10px 20px;
-    min-height: 44px;
-    background: var(--box-background-light);
-    border: 2px solid var(--border-color-light);
-    border-radius: 999px;
-    cursor: pointer;
+.sidebar-section h3 {
+    font-size: 0.85em;
     font-weight: 600;
-    font-size: 0.95em;
-    color: var(--text-color-light);
-    transition: background-color 0.2s ease, color 0.2s ease;
-    box-shadow: var(--shadow-sm);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    opacity: 0.6;
+    margin: 0 0 var(--space-sm);
 }
 
-.burger-pill:hover {
-    background: var(--surface-hover-light);
-    color: var(--link-hover-light);
-}
+/* --- Left Pager Panel --- */
 
-.dark-mode .burger-pill {
-    background: var(--box-background-dark);
-    border-color: var(--border-color-dark);
-    color: var(--text-color-dark);
-    box-shadow: var(--shadow-sm-dark);
+.article-pager,
+.article-questions {
+    margin-top: var(--space-2xl);
 }
-
-.dark-mode .burger-pill:hover {
-    background: var(--surface-hover-dark);
-    color: var(--link-hover-dark);
-}
-
-/* Burger icon */
-.burger-icon {
-    font-size: 1.15em;
-    line-height: 1;
-}
-
-/* --- Left Pager Panel (cross-links) --- */
 
 .article-pager {
     display: flex;
@@ -136,63 +88,6 @@
     overscroll-behavior: contain;
     padding: var(--space-lg);
     font-size: 0.9em;
-}
-
-/* Cross-link list inside pager */
-.article-pager .cross-link-section {
-    margin: 0;
-    padding: 0;
-}
-
-.article-pager .cross-link-label {
-    font-size: 0.85em;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    opacity: 0.6;
-    margin: 0 0 var(--space-sm);
-}
-
-.article-pager .cross-link-list {
-    list-style: none;
-    padding: 0;
-    margin: 0;
-}
-
-.article-pager .cross-link-list li {
-    margin-bottom: var(--space-sm);
-    line-height: 1.4;
-}
-
-.article-pager .cross-link-list li:last-child {
-    margin-bottom: 0;
-}
-
-.article-pager .cross-link {
-    color: var(--link-color-light);
-    text-decoration: none;
-    font-weight: 500;
-    font-size: 0.9em;
-}
-
-.article-pager .cross-link:hover {
-    text-decoration: underline;
-    color: var(--link-hover-light);
-}
-
-.dark-mode .article-pager .cross-link {
-    color: var(--link-color-dark);
-}
-
-.dark-mode .article-pager .cross-link:hover {
-    color: var(--link-hover-dark);
-}
-
-.article-pager .cross-link-desc {
-    display: block;
-    font-size: 0.82em;
-    opacity: 0.7;
-    margin-top: 1px;
 }
 
 /* --- Questions Sidebar (Right Panel) --- */
@@ -366,9 +261,7 @@
     }
 
     .article-pager,
-    .article-questions,
-    .logo-top,
-    .burger-top {
+    .article-questions {
         display: none;
     }
 }

--- a/assets/scripts/navbar.js
+++ b/assets/scripts/navbar.js
@@ -1,7 +1,7 @@
 (function () {
   "use strict";
 
-  var toggles = document.querySelectorAll(".nav-toggle, .burger-pill");
+  var toggles = document.querySelectorAll(".nav-toggle");
   var overlay = document.querySelector(".nav-overlay");
   var closeBtn = document.querySelector(".nav-overlay-close");
 


### PR DESCRIPTION
## Changes

Removes the left-panel logo and right-panel burger pill (user will reimplement those later). Removes cross-link UI (container `div`, script include, and all CSS). Fixes the broken sidepanel index formatting (restored `.sidebar-section` class). Adds `margin-top: var(--space-2xl)` to both sidepanels so they align vertically with the article body's `.section` padding.

## Files changed

- `_layouts/article.html` — removed `.logo-top`, `.burger-top`, `.js-pager-list` divs
- `_includes/scripts.html` — removed cross-links.js include
- `assets/css/components/sidebar.css` — simplified grid to single row; removed `.logo-top`, `.burger-top`, `.burger-pill`, `.cross-link-*` CSS; restored `.sidebar-section`; added `margin-top` to sidepanels
- `assets/scripts/navbar.js` — removed stale `.burger-pill` selector

## Related

Fixes formatting regressions from PR #172 sidebar restructure.