### PR TITLE
feat(hero-carousel): replace cross-links with hero carousel navigation

### DIFF
--- a/_data/carousel.yml
+++ b/_data/carousel.yml
@@ -1,0 +1,46 @@
+# Carousel navigation cycles
+# Each cycle defines an ordered list of page URLs.
+# The carousel at the bottom of the hero links to prev/next in the cycle (wrapping around).
+
+- name: "Artikler"
+  pages:
+    - /tillit/
+    - /generativ-ki/
+    - /forankring/
+    - /usikkerhet/
+    - /triader/
+    - /makt/
+
+- name: "Perspektiver"
+  pages:
+    - /perspektiv/
+    - /identitet/
+    - /struktur/
+    - /mennesker/
+    - /pavirkning/
+
+- name: "GRC"
+  pages:
+    - /grc/
+    - /risikostyring/
+    - /compliance/
+    - /kvalitet/
+    - /informasjonssikkerhet/
+    - /baerekraft/
+    - /endringsledelse/
+
+- name: "Om"
+  pages:
+    - /metode/
+    - /om-oss/
+    - /kultur/
+
+- name: "Produkter"
+  pages:
+    - /ledelse-60-2/
+
+- name: "Steg"
+  pages:
+    - /samtale/
+    - /intervju/
+    - /rapport/

--- a/_includes/carousel.html
+++ b/_includes/carousel.html
@@ -1,0 +1,57 @@
+{% comment %}
+  Carousel navigation — three circular buttons at bottom of hero.
+  Finds the current page in _data/carousel.yml cycles and renders prev/scroll/next links.
+
+  Prev/Next are links to sibling pages in the cycle (wrapping).
+  The center button scrolls to article content; after hero passes, it becomes a
+  sticky scroll-to-top button handled by carousel.js.
+{% endcomment %}
+
+{% assign carousel_prev = false %}
+{% assign carousel_next = false %}
+
+{% for cycle in site.data.carousel %}
+  {% for url in cycle.pages %}
+    {% if url == page.url %}
+      {% assign carousel_size = cycle.pages.size %}
+      {% assign carousel_index = forloop.index0 %}
+      {% assign prev_i = carousel_index | minus: 1 %}
+      {% assign next_i = carousel_index | plus: 1 %}
+
+      {% if prev_i < 0 %}
+        {% assign prev_i = carousel_size | minus: 1 %}
+      {% endif %}
+      {% if next_i >= carousel_size %}
+        {% assign next_i = 0 %}
+      {% endif %}
+
+      {% assign carousel_prev = cycle.pages[prev_i] %}
+      {% assign carousel_next = cycle.pages[next_i] %}
+    {% endif %}
+  {% endfor %}
+{% endfor %}
+
+{% if carousel_prev or carousel_next %}
+<nav class="carousel-nav" aria-label="Artikkelnavigasjon">
+  <a href="{{ carousel_prev | relative_url }}" class="carousel-btn carousel-btn--prev" aria-label="Forrige artikkel">
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M15 18l-6-6 6-6"/>
+    </svg>
+  </a>
+
+  <button class="carousel-btn carousel-btn--scroll" aria-label="Rull til innhold">
+    <svg class="carousel-icon-down" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M6 9l6 6 6-6"/>
+    </svg>
+    <svg class="carousel-icon-up" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="display:none">
+      <path d="M18 15l-6-6-6 6"/>
+    </svg>
+  </button>
+
+  <a href="{{ carousel_next | relative_url }}" class="carousel-btn carousel-btn--next" aria-label="Neste artikkel">
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M9 18l6-6-6-6"/>
+    </svg>
+  </a>
+</nav>
+{% endif %}

--- a/_includes/hero.html
+++ b/_includes/hero.html
@@ -61,5 +61,6 @@
       <path d="M6 9l6 6 6-6"/>
     </svg>
   </div>
+  {% include carousel.html %}
 </section>
 {% endif %}

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -6,6 +6,7 @@
 <script src="{{ '/assets/scripts/cross-links.js' | relative_url }}"></script>
 <script src="{{ '/assets/scripts/review-questions.js' | relative_url }}" defer></script>
 <script src="{{ '/assets/scripts/sidebar.js' | relative_url }}"></script>
+<script src="{{ '/assets/scripts/carousel.js' | relative_url }}"></script>
 <script src="{{ '/assets/scripts/sticky-cta.js' | relative_url }}"></script>
 <script src="{{ '/assets/scripts/newsletter.js' | relative_url }}" defer></script>
 <script src="{{ '/assets/scripts/contact.js' | relative_url }}" defer></script>

--- a/_includes/styles.html
+++ b/_includes/styles.html
@@ -27,6 +27,7 @@
 <link rel="stylesheet" href="{{ '/assets/css/components/step-timeline.css' | relative_url }}">
 <link rel="stylesheet" href="{{ '/assets/css/components/stat-bridge.css' | relative_url }}">
 <link rel="stylesheet" href="{{ '/assets/css/components/sidebar.css' | relative_url }}">
+<link rel="stylesheet" href="{{ '/assets/css/components/carousel.css' | relative_url }}">
 <link rel="stylesheet" href="{{ '/assets/css/components/newsletter.css' | relative_url }}">
 <link rel="stylesheet" href="{{ '/assets/css/components/sticky-cta.css' | relative_url }}">
 <link rel="stylesheet" href="{{ '/assets/css/products.css' | relative_url }}">

--- a/assets/css/components/carousel.css
+++ b/assets/css/components/carousel.css
@@ -1,0 +1,89 @@
+/* ========================================
+   Hero Carousel Navigation
+   Three circle buttons at bottom of hero:
+   ◀ (prev)  ▼ (scroll)  ▶ (next)
+   ======================================== */
+
+/* --- Container --- */
+.carousel-nav {
+    position: absolute;
+    bottom: var(--space-lg);
+    left: 50%;
+    transform: translateX(-50%);
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    z-index: 3;
+    pointer-events: none; /* let clicks pass through container */
+}
+
+.carousel-nav > * {
+    pointer-events: auto; /* restore clicks on buttons */
+}
+
+/* --- Circle Buttons --- */
+.carousel-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 44px;
+    height: 44px;
+    border: none;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.9);
+    color: var(--primary-navy);
+    cursor: pointer;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+    transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+    text-decoration: none;
+}
+
+.carousel-btn:hover {
+    background: #fff;
+    color: var(--primary-azure);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+}
+
+.carousel-btn:active {
+    transform: scale(0.95);
+}
+
+/* Dark mode */
+.dark-mode .carousel-btn {
+    background: rgba(30, 30, 40, 0.85);
+    color: var(--text-color-dark);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
+}
+
+.dark-mode .carousel-btn:hover {
+    background: rgba(50, 50, 65, 0.95);
+    color: var(--link-hover-dark);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
+}
+
+/* --- Scroll-up button: transitions to fixed/sticky --- */
+.carousel-btn--scroll {
+    /* Slightly larger center button */
+    width: 48px;
+    height: 48px;
+}
+
+/* Affixed state — fixed to bottom-right when hero is scrolled past */
+.carousel-btn--scroll.is-affixed {
+    position: fixed;
+    bottom: var(--space-lg);
+    right: var(--space-lg);
+    transform: none;
+    z-index: 100;
+    animation: carousel-fade-in 0.3s ease;
+}
+
+@keyframes carousel-fade-in {
+    from { opacity: 0; transform: scale(0.8); }
+    to   { opacity: 1; transform: scale(1); }
+}
+
+/* Hide old scroll-indicator when carousel is present */
+.hero .scroll-indicator {
+    display: none;
+}

--- a/assets/scripts/carousel.js
+++ b/assets/scripts/carousel.js
@@ -1,0 +1,53 @@
+(function () {
+    'use strict';
+
+    var scrollBtn = document.querySelector('.carousel-btn--scroll');
+    var hero = document.querySelector('.hero');
+    var articleBody = document.querySelector('.article-body');
+    var iconDown = scrollBtn && scrollBtn.querySelector('.carousel-icon-down');
+    var iconUp = scrollBtn && scrollBtn.querySelector('.carousel-icon-up');
+
+    if (!scrollBtn || !hero) return;
+
+    var isAffixed = false;
+    var headerHeight = 85; // matches --header-height
+
+    function toggleAffix() {
+        var heroBottom = hero.getBoundingClientRect().bottom;
+
+        if (heroBottom <= 0 && !isAffixed) {
+            // Hero scrolled past — affix the button
+            scrollBtn.classList.add('is-affixed');
+            iconDown.style.display = 'none';
+            iconUp.style.display = '';
+            scrollBtn.setAttribute('aria-label', 'Rull til toppen');
+            isAffixed = true;
+        } else if (heroBottom > 0 && isAffixed) {
+            // Hero back in view — return to hero position
+            scrollBtn.classList.remove('is-affixed');
+            iconDown.style.display = '';
+            iconUp.style.display = 'none';
+            scrollBtn.setAttribute('aria-label', 'Rull til innhold');
+            isAffixed = false;
+        }
+    }
+
+    scrollBtn.addEventListener('click', function () {
+        if (isAffixed) {
+            // Scroll back to top
+            window.scrollTo({ top: 0, behavior: 'smooth' });
+        } else {
+            // Scroll down past hero to article content
+            var target = articleBody || document.querySelector('.article-layout');
+            if (target) {
+                var rect = target.getBoundingClientRect();
+                var targetPos = rect.top + window.pageYOffset - headerHeight;
+                window.scrollTo({ top: targetPos, behavior: 'smooth' });
+            }
+        }
+    });
+
+    // Listen on scroll with passive flag for performance
+    window.addEventListener('scroll', toggleAffix, { passive: true });
+    toggleAffix(); // set initial state
+})();


### PR DESCRIPTION
## Changes

Replaces the removed cross-links UI with a hero carousel navigation system. Three circular buttons appear at the bottom of the hero on all pages that have page.hero:

- Prev - links to previous page in cycle (wraps)
- Scroll - scrolls past hero to article start; after hero scrolls past, affixes to bottom-right as scroll-to-top
- Next - links to next page in cycle (wraps)

### Carousel cycles

| Cycle | Pages |
|-------|-------|
| Artikler | Tillit - Generativ KI - Forankring - Usikkerhet - Triader - Makt |
| Perspektiver | Perspektiv - Identitet - Struktur - Mennesker - Pavirkning |
| GRC | GRC - Risikostyring - Compliance - Kvalitet - Informasjonssikkerhet - Baerekraft - Endringsledelse |
| Om | Metode - Om oss - Kultur |
| Produkter | Ledelse 60:2 (single product, links to self) |
| Steg | Samtale - Intervju - Rapport |

### Files
- _data/carousel.yml - cycle definitions
- _includes/carousel.html - Liquid include for prev/scroll/next buttons
- assets/css/components/carousel.css - circle button styles, dark mode, affixed state
- assets/scripts/carousel.js - scroll-to-content / scroll-to-top toggle
- _includes/hero.html - includes carousel.html
- _includes/styles.html - links carousel.css
- _includes/scripts.html - loads carousel.js