### PR TITLE
fix: carousel position context, TOC item styles, scroll-indicator stacking

### DIFF
--- a/assets/css/components/carousel.css
+++ b/assets/css/components/carousel.css
@@ -83,7 +83,7 @@
     to   { opacity: 1; transform: scale(1); }
 }
 
-/* Hide old scroll-indicator when carousel is present */
+/* Carousel-nav sits above the scroll-indicator */
 .hero .scroll-indicator {
-    display: none;
+    z-index: 1;
 }

--- a/assets/css/components/hero.css
+++ b/assets/css/components/hero.css
@@ -6,6 +6,7 @@
 .hero {
     display: grid;
     padding: 0;
+    position: relative;
 }
 
 .hero-image {

--- a/assets/css/components/sidebar.css
+++ b/assets/css/components/sidebar.css
@@ -52,6 +52,58 @@
     margin: 0 0 var(--space-sm);
 }
 
+/* --- TOC / Page Index --- */
+
+.toc-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.toc-item {
+    display: block;
+    padding: var(--space-xs) 0;
+    padding-left: var(--space-sm);
+    font-size: 0.9em;
+    line-height: 1.4;
+    color: var(--text-color-light);
+    text-decoration: none;
+    border-left: 2px solid transparent;
+    transition: color 0.2s ease, border-color 0.2s ease;
+    cursor: pointer;
+}
+
+.toc-item:hover {
+    color: var(--link-hover-light);
+    border-left-color: var(--border-color-light);
+}
+
+.toc-item--h3 {
+    padding-left: calc(var(--space-sm) + var(--space-md));
+    font-size: 0.82em;
+    opacity: 0.85;
+}
+
+/* Active heading — scroll-spy highlight */
+.toc-item--active {
+    color: var(--primary-navy);
+    border-left-color: var(--primary-accent);
+    font-weight: 600;
+}
+
+.dark-mode .toc-item {
+    color: var(--text-color-dark);
+}
+
+.dark-mode .toc-item:hover {
+    color: var(--link-hover-dark);
+}
+
+.dark-mode .toc-item--active {
+    color: var(--primary-azure);
+    border-left-color: var(--primary-azure);
+}
+
 /* --- Left Pager Panel --- */
 
 .article-pager,


### PR DESCRIPTION
## Fixes

1. **Carousel not visible on hero pages** — `.hero` had no `position: relative`, so the absolute-positioned `.carousel-nav` escaped the hero container. Added `position: relative`.

2. **TOC item styling missing** — `.toc-list`, `.toc-item`, `.toc-item--h3`, `.toc-item--active` CSS was dropped during the sidebar rewrite in PR #174. Restored the full set.

3. **Scroll-indicator hidden unconditionally** — Carousel.css had `.hero .scroll-indicator { display: none }` which hid the chevron even on pages without a carousel. Changed to `z-index: 1` so the carousel-nav stacks above it while both can coexist.

## Files changed
- `assets/css/components/hero.css` — added `position: relative`
- `assets/css/components/carousel.css` — `display: none` → `z-index: 1`
- `assets/css/components/sidebar.css` — restored TOC item styles