### PR TITLE
fix: remove header-height from sidepanel sticky top offset

### DIFF
--- a/assets/css/components/sidebar.css
+++ b/assets/css/components/sidebar.css
@@ -63,9 +63,9 @@
     display: flex;
     flex-direction: column;
     position: sticky;
-    top: calc(var(--header-height, 85px) + var(--space-md, 16px));
+    top: var(--space-md);
     align-self: start;
-    max-height: calc(100vh - var(--header-height, 85px) - var(--space-2xl, 40px));
+    max-height: calc(100vh - var(--space-xl, 40px));
 
     background: var(--box-background-light);
     border-radius: var(--radius-xl);
@@ -94,9 +94,9 @@
 
 .article-questions {
     position: sticky;
-    top: calc(var(--header-height, 85px) + var(--space-md, 16px));
+    top: var(--space-md);
     align-self: start;
-    max-height: calc(100vh - var(--header-height, 85px) - var(--space-2xl, 40px));
+    max-height: calc(100vh - var(--space-xl, 40px));
     overflow-y: auto;
     overscroll-behavior: contain;
 


### PR DESCRIPTION
Header is a static element that scrolls away with the page — it has no `position: sticky` or `fixed`. The previous `top: calc(var(--header-height, 85px) + var(--space-md, 16px))` left ~101px of empty space at the viewport top when the sidepanels stuck.

Both `.article-pager` and `.article-questions`:
- `top: calc(var(--header-height) + var(--space-md)) → var(--space-md)`
- `max-height: calc(100vh - var(--header-height) - var(--space-2xl)) → calc(100vh - var(--space-xl))`

PR #177 already has the previous commits — this updates the branch.