### PR TITLE
feat: style share section as distinct card like product card in right panel

### DIFF
--- a/_includes/profiles.html
+++ b/_includes/profiles.html
@@ -34,7 +34,10 @@
                     <span>{{ profile.email }}</span>
                 </a>
             </div>
-            <button class="profile-expand-btn" aria-label="Vis detaljer om {{ profile.name }}">Les mer →</button>
+            <div class="profile-ctas">
+                <a href="{{ profile.booking_url }}" class="cta" target="_blank" rel="noopener">Book en samtale</a>
+                <button class="cta cta--secondary" type="button" aria-label="Vis detaljer om {{ profile.name }}">Les mer</button>
+            </div>
         </div>
         <div class="profile-expanded" id="profile-expanded-{{ forloop.index }}">
             <div class="profile-modal-content">

--- a/assets/css/components/sidebar.css
+++ b/assets/css/components/sidebar.css
@@ -253,11 +253,24 @@
     opacity: 1;
 }
 
-/* --- Share Section --- */
+/* --- Share Section (visually distinct card) --- */
 
 .sidebar-section--share {
     margin-top: var(--space-lg);
-    padding-top: var(--space-lg);
+    padding: var(--space-lg);
+    background: var(--box-background-light);
+    border-radius: var(--radius-xl);
+    box-shadow: var(--shadow-sm);
+    border-bottom: none;
+}
+
+.dark-mode .sidebar-section--share {
+    background: var(--box-background-dark);
+    box-shadow: var(--shadow-sm-dark);
+}
+
+.sidebar-section--share h3 {
+    margin-bottom: var(--space-sm);
 }
 
 .share-buttons {

--- a/assets/css/profiles.css
+++ b/assets/css/profiles.css
@@ -87,18 +87,41 @@
     flex-shrink: 0;
 }
 
-.profile-expand-btn {
-    background: none;
-    border: none;
-    color: var(--link-color-light);
-    cursor: pointer;
-    font-size: 0.95em;
-    padding: 8px 16px;
-    text-decoration: underline;
+/* --- Compact card CTA buttons --- */
+.profile-ctas {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin-top: 16px;
 }
 
-.profile-expand-btn:hover {
-    opacity: 0.7;
+.profile-ctas .cta {
+    width: 100%;
+    box-sizing: border-box;
+    text-align: center;
+    font-size: 0.95em;
+    padding: 12px 24px;
+}
+
+.profile-ctas .cta--secondary {
+    background-color: transparent;
+    border-color: var(--border-color-light);
+    color: var(--text-color-light);
+}
+
+.profile-ctas .cta--secondary:hover {
+    background-color: var(--surface-hover-light);
+    color: var(--text-color-light);
+    border-color: var(--primary-accent);
+}
+
+.dark-mode .profile-ctas .cta--secondary {
+    border-color: var(--border-color-dark);
+    color: var(--text-color-dark);
+}
+
+.dark-mode .profile-ctas .cta--secondary:hover {
+    background-color: var(--surface-hover-dark);
 }
 
 /* --- Modal overlay --- */


### PR DESCRIPTION
Share section card now has its own background (`--box-background-light`), border-radius (`--radius-xl`), box-shadow (`--shadow-sm`), and padding — matching the visual treatment of `.sidebar-card` elements in the right `article-questions` panel.

## Changes
- `assets/css/components/sidebar.css` — `.sidebar-section--share` updated to render as a card with own background/shadow/padding/border-radius, plus dark-mode variant