### PR TITLE
fix(sidebar,carousel): share card below TOC, SVG icons, product banner, carousel scroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Hero carousel scroll button affix visibility**: `.carousel-btn--scroll` back-to-top state was invisible because `.carousel-nav` used `transform: translateX(-50%)` for centering, which (per CSS spec) makes it the containing block for `position: fixed` descendants. Changed centering to flexbox `justify-content: center` — no transform, no containing-block side effect. Affixed button centering changed from `transform: translateX(-50%)` to `left: calc(50% - 24px)`.
+- **Hero scroll-down offset**: `scrollTo({ top: hero.offsetHeight })` was 85px short — hero starts at `hero.offsetTop` (header height). Changed to `hero.offsetTop + hero.offsetHeight` to scroll past hero entirely.
+- **Sidebar product banner height**: Reduced `min-height` from 80px to 52px to conserve vertical space. Title color changed from `#fff` (with gradient overlay) to `var(--primary-navy)` for contrast against the light illustration.
+- **Share button SVG icons**: Removed `<rect fill="currentColor">` from Teams and LinkedIn SVGs — it rendered as solid white squares on the white text color, hiding the logo paths. White logo paths now display directly on the button's colored background.
+- **Share button text wrapping**: Added `white-space: nowrap` to prevent "Del på Teams"/"Del på LinkedIn" from breaking across lines in the narrow 240px left panel.
+
+### Changed
+- **Left sidebar: share buttons as separate card**: Moved share section (`share-section.html`) out of `.pager-scroll` to sit below the TOC as a visually distinct card with its own background, border-radius, and shadow — mirrors the right panel's card-separation pattern (questions card above product card). Card styling moved from `.article-pager` wrapper to `.pager-scroll` and `.sidebar-section--share` independently.
+
 - **Ledelse 60:2 — article layout migration**: Switched the product page from `product` layout to `article` layout. Added 5 diagnostic frontmatter questions with collapsible sidebar rendering. Added Dagfinn profile include at page bottom. Removed obsolete `show_cta_buttons`/`show_metodikk_callout` flags.
 - **Article layout — stat-bridge support**: Added conditional `stat-bridge.html` include between hero and article-layout div, gated on `page.stat_bridge`. The Ledelse 60:2 page uses this for its "4 perspektiver · 60 spørsmål · 2 timer" stat line.
 - **Homepage CTA heading fix**: Changed the inline CTA heading in `products.html` from `product.name` to `product.stat_bridge` for consistency with the stat line content.

--- a/_includes/share-section.html
+++ b/_includes/share-section.html
@@ -7,7 +7,6 @@
        class="share-btn share-btn--teams"
        title="Del på Teams">
       <svg width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true" focusable="false">
-        <rect width="24" height="24" rx="4" fill="currentColor"/>
         <path fill="#fff" d="M11.479 8.105h-2.447v7.466H7.02v-7.466H4.52V6.428h6.959v1.677zm4.02 1.298c1.06 0 1.92-.86 1.92-1.92s-.86-1.92-1.92-1.92-1.92.86-1.92 1.92.86 1.92 1.92 1.92z"/>
       </svg>
       <span>Del på Teams</span>
@@ -18,7 +17,6 @@
        class="share-btn share-btn--linkedin"
        title="Del på LinkedIn">
       <svg width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true" focusable="false">
-        <rect width="24" height="24" rx="3" fill="currentColor"/>
         <path fill="#fff" d="M7.5 8.5a1.5 1.5 0 110-3 1.5 1.5 0 010 3zM6 10h3v8H6v-8zm5 0h3v1.2a3 3 0 012.5-1.3c2.2 0 3.5 1.5 3.5 4.2v3.9h-3v-3.5c0-1.3-.5-2-1.5-2s-1.5.7-1.5 2v3.5h-3v-8z"/>
       </svg>
       <span>Del på LinkedIn</span>

--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -15,8 +15,8 @@ layout: default
     <aside class="article-pager" aria-label="Relaterte artikler" hidden>
       <div class="pager-scroll">
         {% include sidebar-toc.html %}
-        {% include share-section.html %}
       </div>
+      {% include share-section.html %}
     </aside>
     {% endif %}
 

--- a/assets/css/components/carousel.css
+++ b/assets/css/components/carousel.css
@@ -8,9 +8,10 @@
 .carousel-nav {
     position: absolute;
     bottom: var(--space-lg);
-    left: 50%;
-    transform: translateX(-50%);
+    left: 0;
+    right: 0;
     display: flex;
+    justify-content: center;
     align-items: center;
     gap: 12px;
     z-index: 3;
@@ -72,8 +73,7 @@
 .carousel-btn--scroll.is-affixed {
     position: fixed;
     bottom: var(--space-lg);
-    left: 50%;
-    transform: translateX(-50%);
+    left: calc(50% - 24px);
     z-index: 9999;
     animation: carousel-fade-in 0.3s ease;
 }

--- a/assets/css/components/sidebar.css
+++ b/assets/css/components/sidebar.css
@@ -114,32 +114,33 @@
 .article-pager {
     display: flex;
     flex-direction: column;
+    gap: var(--space-lg);
     position: sticky;
     top: var(--space-md);
     align-self: start;
     max-height: calc(100vh - var(--space-xl, 40px));
-
-    background: var(--box-background-light);
-    border-radius: var(--radius-xl);
-    box-shadow: var(--shadow-sm);
 }
 
 .article-pager[hidden] {
     display: none;
 }
 
-.dark-mode .article-pager {
-    background: var(--box-background-dark);
-    box-shadow: var(--shadow-sm-dark);
-}
-
-/* Pager scrollable content */
 .pager-scroll {
     flex: 1;
+    min-height: 0;
     overflow-y: auto;
     overscroll-behavior: contain;
     padding: var(--space-lg);
     font-size: 0.9em;
+
+    background: var(--box-background-light);
+    border-radius: var(--radius-xl);
+    box-shadow: var(--shadow-sm);
+}
+
+.dark-mode .pager-scroll {
+    background: var(--box-background-dark);
+    box-shadow: var(--shadow-sm-dark);
 }
 
 /* --- Questions Sidebar (Right Panel) --- */
@@ -220,7 +221,7 @@
 
 .sidebar-product-banner {
     display: grid;
-    min-height: 80px;
+    min-height: 52px;
     border-radius: var(--radius-xl) var(--radius-xl) 0 0;
     overflow: hidden;
     margin: calc(-1 * var(--space-lg)) calc(-1 * var(--space-lg)) var(--space-md);
@@ -238,29 +239,16 @@
     z-index: 0;
 }
 
-.sidebar-product-banner::after {
-    content: '';
-    background: linear-gradient(to top, rgba(0,0,0,0.65) 0%, transparent 50%);
-    z-index: 1;
-}
-
 .sidebar-product-banner .sidebar-card-heading {
-    align-self: end;
+    align-self: center;
     padding: var(--space-sm) var(--space-md);
     margin: 0;
-    z-index: 2;
-    color: #fff;
-    text-shadow: 0 1px 3px rgba(0,0,0,0.35);
+    z-index: 1;
+    color: var(--primary-navy);
 }
 
-/* When no image is available, fall back to normal heading color */
-.sidebar-product-banner:not(:has(.sidebar-product-banner-bg)) .sidebar-card-heading {
-    color: var(--heading-color-light);
-    text-shadow: none;
-}
-
-.dark-mode .sidebar-product-banner:not(:has(.sidebar-product-banner-bg)) .sidebar-card-heading {
-    color: var(--heading-color-dark);
+.dark-mode .sidebar-product-banner .sidebar-card-heading {
+    color: var(--primary-navy);
 }
 
 /* --- CTA Buttons in Sidebar --- */
@@ -344,7 +332,6 @@
 /* --- Share Section (visually distinct card) --- */
 
 .sidebar-section--share {
-    margin-top: var(--space-lg);
     padding: var(--space-lg);
     background: var(--box-background-light);
     border-radius: var(--radius-xl);
@@ -381,6 +368,7 @@
     cursor: pointer;
     transition: background 0.2s ease, transform 0.1s ease;
     min-height: 44px;
+    white-space: nowrap;
 }
 
 .share-btn:active {

--- a/assets/scripts/carousel.js
+++ b/assets/scripts/carousel.js
@@ -37,9 +37,7 @@
             // Scroll back to top
             window.scrollTo({ top: 0, behavior: 'smooth' });
         } else {
-            // Scroll down past hero entirely
-            var heroHeight = hero.offsetHeight;
-            window.scrollTo({ top: heroHeight, behavior: 'smooth' });
+            window.scrollTo({ top: hero.offsetTop + hero.offsetHeight, behavior: 'smooth' });
         }
     });
 


### PR DESCRIPTION
## Changes

### Left sidebar: share buttons as separate card
Moved the share section out of `.pager-scroll` to sit below the TOC as a visually distinct card with its own background, border-radius, and shadow — mirrors the right panel's card-separation pattern (questions card above product card).

### Share button SVG icon fix
Removed `<rect fill="currentColor">` from Teams and LinkedIn SVGs — it rendered as solid white squares on the button's white text color, completely hiding the logo paths.

### Share button text wrapping fix
`white-space: nowrap` prevents "Del på Teams"/"Del på LinkedIn" from breaking in the 240px left panel.

### Product banner height + color
Reduced `min-height` from 80px to 52px to conserve vertical space. Title color changed to `--primary-navy` for contrast against the light illustration.

### Carousel scroll button fixes
- **Affix invisibility**: `.carousel-btn--scroll.is-affixed` was invisible because `.carousel-nav` used `transform: translateX(-50%)`, creating a containing block for `position: fixed` descendants. Replaced with flexbox — no transform, no side effect.
- **Scroll-down offset**: Fixed from `hero.offsetHeight` to `hero.offsetTop + hero.offsetHeight` — header height was causing scroll to stop 85px short.

## How to test
- Open any article with hero + sidebar (e.g. /makt/) on wide screen
- Verify share section appears as separate card below TOC in left panel
- Verify Teams and LinkedIn icons show logo (not white squares)
- Verify "Del på Teams" and "Del på LinkedIn" text doesn't wrap
- Verify product banner in right sidebar is shorter (52px) with dark blue title
- Scroll past hero, verify affixed back-to-top button is visible and clickable
- Click scroll-down chevron — should scroll past hero entirely

## Pre-merge notes
Stylelint and eslint not locally available — CSS/JS changes are syntactically straightforward and match existing patterns.