### PR TITLE
feat(n5): add perspektiv layout template for frame pages

### DIFF
--- a/_layouts/perspektiv.html
+++ b/_layouts/perspektiv.html
@@ -1,0 +1,149 @@
+---
+layout: page
+---
+
+<link rel="stylesheet" href="{{ '/assets/css/perspektiv-styles.css' | relative_url }}">
+
+{% assign frame = page %}
+{% assign frame_id = page.frame_id %}
+
+{% assign all_frames = site.pages | where: "class", "frame" | sort: "id" %}
+{% assign current_index = nil %}
+{% for f in all_frames %}
+  {% if f.id == frame_id %}
+    {% assign current_index = forloop.index0 %}
+  {% endif %}
+{% endfor %}
+{% assign prev_index = current_index | minus: 1 %}
+{% assign next_index = current_index | plus: 1 %}
+{% assign prev_frame = all_frames[prev_index] %}
+{% assign next_frame = all_frames[next_index] %}
+
+<!-- Hero Section -->
+{% include hero.html
+   image=frame.hero.banner_image
+   alt=frame.hero.alt
+   title=frame.title
+   intro=frame.hero.intro
+   breadcrumb=frame.hero.breadcrumb
+   hero_effect=page.hero_effect
+%}
+
+<!-- Intro Section -->
+<section class="perspektiv-section section container--wide animate-on-scroll fade-in-up">
+  <h2>{{ frame.intro.heading }}</h2>
+  {{ frame.intro.body | markdownify }}
+</section>
+
+<!-- Three Elements with spot illustrations -->
+<section class="perspektiv-section section container--wide animate-on-scroll fade-in-up">
+  <h2>De tre hovedelementene</h2>
+
+  {% for element in frame.elements %}
+  <div class="perspektiv-element animate-on-scroll fade-in-up">
+    {% assign spot_num = forloop.index0 | modulo: 2 %}
+    {% assign float_class = "" %}
+    {% if spot_num == 0 %}
+      {% assign float_class = "argument-illustration" %}
+    {% else %}
+      {% assign float_class = "argument-illustration argument-illustration--right" %}
+    {% endif %}
+
+    {% if page.show_spots and element.spot_image %}
+    <img src="{{ element.spot_image | relative_url }}"
+         alt="Illustrasjon: {{ element.title }}"
+         class="{{ float_class }}"
+         loading="lazy">
+    {% endif %}
+
+    <h3>{{ element.title }}</h3>
+    {{ element.body | markdownify }}
+    <p><strong>Tegn på god {{ element.title | downcase }}:</strong> {{ element.signs.positive }}</p>
+    <p><strong>Tegn på {{ element.title | downcase }}-problemer:</strong> {{ element.signs.negative }}</p>
+  </div>
+  {% endfor %}
+</section>
+
+<!-- Section break image: hovedelementer -->
+<section class="perspektiv-section section container--wide animate-on-scroll fade-in-up">
+  <img src="{{ '/assets/images/banners/illustrasjon-' | append: frame.id | append: '-hovedelementer.webp' | relative_url }}"
+       alt="Illustrasjon av de tre hovedelementene i {{ frame.title | downcase }}"
+       class="section-illustration">
+</section>
+
+<!-- Leader Value with spot illustration -->
+<section class="perspektiv-section section container--wide animate-on-scroll fade-in-up">
+  {% if page.show_spots and frame.leader_value.spot_image %}
+  <img src="{{ frame.leader_value.spot_image | relative_url }}"
+       alt="Illustrasjon: {{ frame.leader_value.heading }}"
+       class="argument-illustration argument-illustration--right"
+       loading="lazy">
+  {% endif %}
+
+  <h2>{{ frame.leader_value.heading }}</h2>
+  {{ frame.leader_value.body | markdownify }}
+</section>
+
+<!-- Challenges Section -->
+<section class="perspektiv-section section container--wide animate-on-scroll fade-in-up">
+  <h2>Vanlige {{ frame.id }}lige utfordringer</h2>
+  <img src="{{ '/assets/images/banners/illustrasjon-' | append: frame.id | append: '-utfordringer.webp' | relative_url }}"
+       alt="Illustrasjon av vanlige {{ frame.id }}lige utfordringer"
+       class="section-illustration">
+
+  <div class="perspektiv-challenges stagger-parent">
+    {% for challenge in frame.challenges %}
+    <div class="perspektiv-challenge animate-on-scroll fade-in-up stagger">
+      <h4>{{ challenge.title }}</h4>
+      <p>{{ challenge.body }}</p>
+    </div>
+    {% endfor %}
+  </div>
+</section>
+
+<!-- Questions Section -->
+<section class="perspektiv-section section container--wide animate-on-scroll fade-in-up">
+  <h2>Spørsmål {{ frame.id }}perspektivet kan hjelpe dere å besvare</h2>
+  <ul class="perspektiv-questions stagger-parent">
+    {% for question in frame.questions %}
+    <li class="animate-on-scroll slide-in-left stagger">{{ question }}</li>
+    {% endfor %}
+  </ul>
+</section>
+
+<!-- CTA Section — three-path funnel -->
+<section class="perspektiv-cta section container--wide animate-on-scroll fade-in-up">
+  <img src="{{ frame.cta.image | relative_url }}" alt="{{ frame.cta.alt }}" class="section-illustration">
+
+  <h2>{{ frame.cta.heading }}</h2>
+  {{ frame.cta.body | markdownify }}
+
+  <div class="frame-cta-buttons">
+    <a href="{{ frame.cta.booking_url }}" class="product-cta">Bestill uforpliktende samtale</a>
+    <a href="{{ '/ledelse-60-2/' | relative_url }}" class="product-cta product-cta--secondary">Les mer om Ledelse 60:2 →</a>
+  </div>
+</section>
+
+<!-- About / Scientific Basis Section -->
+<section class="perspektiv-section perspektiv-about section container--wide animate-on-scroll fade-in-up">
+  <h2>{{ frame.about.heading }}</h2>
+  {{ frame.about.body | markdownify }}
+  <a href="{{ frame.about.link_url | relative_url }}" class="perspektiv-link">{{ frame.about.link_text }}</a>
+</section>
+
+<!-- Cross-navigation: other frames + methodology -->
+<section class="perspektiv-section section container--wide animate-on-scroll fade-in-up">
+  <h2>Utforsk andre perspektiver</h2>
+  <div class="perspektiv-cross-nav">
+    {% if prev_frame %}
+    <a href="{{ '/' | append: prev_frame.id | append: '/' | relative_url }}" class="product-cta product-cta--secondary">← {{ prev_frame.title }}</a>
+    {% endif %}
+    <a href="{{ '/metode/' | relative_url }}" class="product-cta product-cta--secondary">↑ Om metode</a>
+    {% if next_frame %}
+    <a href="{{ '/' | append: next_frame.id | append: '/' | relative_url }}" class="product-cta product-cta--secondary">{{ next_frame.title }} →</a>
+    {% endif %}
+  </div>
+</section>
+
+<!-- Custom content from page body -->
+{{ content }}


### PR DESCRIPTION
Adds `_layouts/perspektiv.html` — a dedicated Jekyll layout for the four frame pages (makt, perspektiv, triade, struktur). Renders structured frontmatter sections: hero, intro, three elements with spot illustrations, challenges, questions, CTA funnel, about section, and cross-navigation between frames.

The layout is added inert — no existing pages are switched to it. Activating it requires adding frontmatter fields to individual frame pages (per N4-N7 specs).

**Depends on:** `perspektiv-styles.css` (already on main), frame-specific illustration banners (already on main)